### PR TITLE
Replace "Time.now" with better default value

### DIFF
--- a/index.json
+++ b/index.json
@@ -602,7 +602,7 @@
           "name": "since",
           "type": "string",
           "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-          "default": "Time.now",
+          "default": "<current date/time>",
           "required": false
         },
         {
@@ -665,7 +665,7 @@
           "name": "since",
           "type": "string",
           "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-          "default": "Time.now",
+          "default": "<current date/time>",
           "required": false
         },
         {
@@ -702,7 +702,7 @@
           "name": "last_read_at",
           "type": "string",
           "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-          "default": "Time.now",
+          "default": "<current date/time>",
           "required": false
         }
       ],
@@ -731,7 +731,7 @@
           "name": "last_read_at",
           "type": "string",
           "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-          "default": "Time.now",
+          "default": "<current date/time>",
           "required": false
         }
       ],

--- a/routes/activity.json
+++ b/routes/activity.json
@@ -209,7 +209,7 @@
         "name": "since",
         "type": "string",
         "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-        "default": "Time.now",
+        "default": "<current date/time>",
         "required": false
       },
       {
@@ -272,7 +272,7 @@
         "name": "since",
         "type": "string",
         "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-        "default": "Time.now",
+        "default": "<current date/time>",
         "required": false
       },
       {
@@ -309,7 +309,7 @@
         "name": "last_read_at",
         "type": "string",
         "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-        "default": "Time.now",
+        "default": "<current date/time>",
         "required": false
       }
     ],
@@ -338,7 +338,7 @@
         "name": "last_read_at",
         "type": "string",
         "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-        "default": "Time.now",
+        "default": "<current date/time>",
         "required": false
       }
     ],

--- a/routes/activity/notifications/list-your-notifications-in-a-repository.json
+++ b/routes/activity/notifications/list-your-notifications-in-a-repository.json
@@ -34,7 +34,7 @@
       "name": "since",
       "type": "string",
       "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-      "default": "Time.now",
+      "default": "<current date/time>",
       "required": false
     },
     {

--- a/routes/activity/notifications/list-your-notifications.json
+++ b/routes/activity/notifications/list-your-notifications.json
@@ -22,7 +22,7 @@
       "name": "since",
       "type": "string",
       "description": "Only show notifications updated after the given time. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-      "default": "Time.now",
+      "default": "<current date/time>",
       "required": false
     },
     {

--- a/routes/activity/notifications/mark-as-read.json
+++ b/routes/activity/notifications/mark-as-read.json
@@ -8,7 +8,7 @@
       "name": "last_read_at",
       "type": "string",
       "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-      "default": "Time.now",
+      "default": "<current date/time>",
       "required": false
     }
   ],

--- a/routes/activity/notifications/mark-notifications-as-read-in-a-repository.json
+++ b/routes/activity/notifications/mark-notifications-as-read-in-a-repository.json
@@ -20,7 +20,7 @@
       "name": "last_read_at",
       "type": "string",
       "description": "Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
-      "default": "Time.now",
+      "default": "<current date/time>",
       "required": false
     }
   ],


### PR DESCRIPTION
closes #30

This PR only has the failing tests and is up for taking for anyone who’d like to get it fixed :)

Run test with

```
TEST_URL=https://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository ./node_modules/.bin/tap test/integration/single-endpoint-test.js
```

That way you don’t need to run all the tests all the time. Once that test passes, you can make double sure with `npm test`