### PR TITLE
Create a Tree: parameter type "array of objects " should be "object[]"

### DIFF
--- a/routes/git/trees/create-a-tree.json
+++ b/routes/git/trees/create-a-tree.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "tree",
-      "type": "array of objects",
+      "type": "objects[]",
       "description": "Objects (of `path`, `mode`, `type`, and `sha`) specifying a tree structure",
       "required": true
     },


### PR DESCRIPTION
has failing test, needs fix

```
TEST_URL=https://developer.github.com/v3/git/trees/#create-a-tree ltap test/integration/single-endpoint-test.js
```

closes #60