### PR TITLE
Migration - Start an import: parameter type "url" should be "string"

### DIFF
--- a/routes/migration/source-imports/start-an-import.json
+++ b/routes/migration/source-imports/start-an-import.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "vcs_url",
-      "type": "url",
+      "type": "string",
       "description": "**Required** The URL of the originating repository.",
       "required": false
     },


### PR DESCRIPTION
has failing test, needs fix

```
TEST_URL=https://developer.github.com/v3/migration/source_imports/#start-an-import ./node_modules/.bin/tap test/integration/single-endpoint-test.js
```

closes #65