### PR TITLE
Get contents: "path" parameter should be required

### DIFF
--- a/routes/repos/contents/get-contents.json
+++ b/routes/repos/contents/get-contents.json
@@ -20,7 +20,7 @@
       "name": "path",
       "type": "string",
       "description": "The content path.",
-      "required": false
+      "required": true
     },
     {
       "name": "ref",


### PR DESCRIPTION
has failing tests, needs fix. Test with

```
TEST_URL=https://developer.github.com/v3/repos/contents/#get-contents ./node_modules/.bin/tap test/integration/single-endpoint-test.js
```

closes #68