### PR TITLE
update URL overrides

### DIFF
--- a/index.json
+++ b/index.json
@@ -16762,7 +16762,7 @@
       "name": "Get a list of provisioned identities",
       "enabledForApps": false,
       "method": "GET",
-      "path": "https://api.github.com/scim/v2/organizations/:organization/Users",
+      "path": "/scim/v2/organizations/:organization/Users",
       "params": [
         {
           "name": "organization",

--- a/lib/endpoint/overrides/routes.js
+++ b/lib/endpoint/overrides/routes.js
@@ -1,5 +1,8 @@
 module.exports = {
+  // https://developer.github.com/v3/issues/labels/#update-a-label
   'PATCH /repos/:owner/:repo/labels/:name': 'PATCH /repos/:owner/:repo/labels/:oldname',
-  'GET /gitignore/templates/C': 'GET /gitignore/templates/:name',
-  'GET /user/installations?access_token=...': 'GET /user/installations'
+  // https://developer.github.com/v3/apps/#list-installations-for-user
+  'GET /user/installations?access_token=...': 'GET /user/installations',
+  // https://developer.github.com/v3/scim/#get-a-list-of-provisioned-identities
+  'GET https://api.github.com/scim/v2/organizations/:organization/Users': 'GET /scim/v2/organizations/:organization/Users'
 }

--- a/routes/scim.json
+++ b/routes/scim.json
@@ -3,7 +3,7 @@
     "name": "Get a list of provisioned identities",
     "enabledForApps": false,
     "method": "GET",
-    "path": "https://api.github.com/scim/v2/organizations/:organization/Users",
+    "path": "/scim/v2/organizations/:organization/Users",
     "params": [
       {
         "name": "organization",

--- a/routes/scim/get-a-list-of-provisioned-identities.json
+++ b/routes/scim/get-a-list-of-provisioned-identities.json
@@ -2,7 +2,7 @@
   "name": "Get a list of provisioned identities",
   "enabledForApps": false,
   "method": "GET",
-  "path": "https://api.github.com/scim/v2/organizations/:organization/Users",
+  "path": "/scim/v2/organizations/:organization/Users",
   "params": [
     {
       "name": "organization",


### PR DESCRIPTION
https://developer.github.com/v3/scim/#get-a-list-of-provisioned-identities => `https://api.github.com/scim/v2/organizations/:organization/Users` should be `scim/v2/organizations/:organization/Users`