### PR TITLE
`output.annotations.*` -> `output.annotations[].*` and `output.images.*` -> `output.images[].*`

### DIFF
--- a/index.json
+++ b/index.json
@@ -1638,35 +1638,35 @@
           "location": "body"
         },
         {
-          "name": "output.annotations.filename",
+          "name": "output.annotations[].filename",
           "type": "string",
           "description": "The name of the file to add an annotation to.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.blob_href",
+          "name": "output.annotations[].blob_href",
           "type": "string",
           "description": "The file's full blob URL.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.start_line",
+          "name": "output.annotations[].start_line",
           "type": "integer",
           "description": "The start line of the annotation.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.end_line",
+          "name": "output.annotations[].end_line",
           "type": "integer",
           "description": "The end line of the annotation.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.warning_level",
+          "name": "output.annotations[].warning_level",
           "type": "string",
           "description": "The warning level of the annotation. Can be one of `notice`, `warning`, or `failure`.",
           "required": true,
@@ -1678,21 +1678,21 @@
           "location": "body"
         },
         {
-          "name": "output.annotations.message",
+          "name": "output.annotations[].message",
           "type": "string",
           "description": "A short description of the feedback for these lines of code. The maximum size is 64 KB.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.title",
+          "name": "output.annotations[].title",
           "type": "string",
           "description": "The title that represents the annotation. The maximum size is 255 characters.",
           "required": false,
           "location": "body"
         },
         {
-          "name": "output.annotations.raw_details",
+          "name": "output.annotations[].raw_details",
           "type": "string",
           "description": "Details about this annotation. The maximum size is 64 KB.",
           "required": false,
@@ -1706,21 +1706,21 @@
           "location": "body"
         },
         {
-          "name": "output.images.alt",
+          "name": "output.images[].alt",
           "type": "string",
           "description": "The alternative text for the image.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.images.image_url",
+          "name": "output.images[].image_url",
           "type": "string",
           "description": "The full URL of the image.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.images.caption",
+          "name": "output.images[].caption",
           "type": "string",
           "description": "A short image description.",
           "required": false,
@@ -1858,35 +1858,35 @@
           "location": "body"
         },
         {
-          "name": "output.annotations.filename",
+          "name": "output.annotations[].filename",
           "type": "string",
           "description": "The name of the file to add an annotation to.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.blob_href",
+          "name": "output.annotations[].blob_href",
           "type": "string",
           "description": "The file's full blob URL.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.start_line",
+          "name": "output.annotations[].start_line",
           "type": "integer",
           "description": "The start line of the annotation.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.end_line",
+          "name": "output.annotations[].end_line",
           "type": "integer",
           "description": "The end line of the annotation.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.warning_level",
+          "name": "output.annotations[].warning_level",
           "type": "string",
           "description": "The warning level of the annotation. Can be one of `notice`, `warning`, or `failure`.",
           "required": true,
@@ -1898,21 +1898,21 @@
           "location": "body"
         },
         {
-          "name": "output.annotations.message",
+          "name": "output.annotations[].message",
           "type": "string",
           "description": "A short description of the feedback for these lines of code. The maximum size is 64 KB.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.annotations.title",
+          "name": "output.annotations[].title",
           "type": "string",
           "description": "The title that represents the annotation. The maximum size is 255 characters.",
           "required": false,
           "location": "body"
         },
         {
-          "name": "output.annotations.raw_details",
+          "name": "output.annotations[].raw_details",
           "type": "string",
           "description": "Details about this annotation. The maximum size is 64 KB.",
           "required": false,
@@ -1926,21 +1926,21 @@
           "location": "body"
         },
         {
-          "name": "output.images.alt",
+          "name": "output.images[].alt",
           "type": "string",
           "description": "The alternative text for the image.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.images.image_url",
+          "name": "output.images[].image_url",
           "type": "string",
           "description": "The full URL of the image.",
           "required": true,
           "location": "body"
         },
         {
-          "name": "output.images.caption",
+          "name": "output.images[].caption",
           "type": "string",
           "description": "A short image description.",
           "required": false,

--- a/lib/endpoint/find-parameters.js
+++ b/lib/endpoint/find-parameters.js
@@ -189,6 +189,11 @@ function findInBlocks (state) {
       parameterName = `output.${parameterName}`
     }
 
+    // workaround for https://github.com/octokit/routes/issues/97
+    if (state.results[0].path === '/repos/:owner/:repo/branches/:branch/protection' && parameterName === 'dismissal_restrictions') {
+      parameterName = `required_pull_request_reviews.dismissal_restrictions`
+    }
+
     const parameterIndex = _.findIndex(params, (param) => param.name === parameterName)
     const parameterType = parameterIndex >= 0 ? params[parameterIndex].type : null
 
@@ -197,11 +202,6 @@ function findInBlocks (state) {
         ? parameterName + '[]'
         : parameterName
       param.name = [parentParameterName, param.name].join('.')
-
-      // workaround for https://github.com/octokit/routes/issues/97
-      if (state.results[0].path === '/repos/:owner/:repo/branches/:branch/protection' && /^dismissal_restrictions\./.test(param.name)) {
-        param.name = `required_pull_request_reviews.${param.name}`
-      }
 
       return param
     })

--- a/lib/endpoint/find-parameters.js
+++ b/lib/endpoint/find-parameters.js
@@ -182,7 +182,13 @@ function findInBlocks (state) {
     // "The xyz parameter takes the following keys"
     // extend params with "<param>.<key>" | "<type>" | "<description>"
     const prevBlock = state.blocks[parametersBlockIndex - 1]
-    const parameterName = prevBlock.text.match(/`([^`]+)`/).pop()
+    let parameterName = prevBlock.text.match(/`([^`]+)`/).pop()
+
+    // workaround for https://github.com/octokit/routes/issues/140
+    if (/^\/repos\/:owner\/:repo\/check-runs/.test(state.results[0].path) && ['annotations', 'images'].includes(parameterName)) {
+      parameterName = `output.${parameterName}`
+    }
+
     const parameterIndex = _.findIndex(params, (param) => param.name === parameterName)
     const parameterType = parameterIndex >= 0 ? params[parameterIndex].type : null
 
@@ -195,11 +201,6 @@ function findInBlocks (state) {
       // workaround for https://github.com/octokit/routes/issues/97
       if (state.results[0].path === '/repos/:owner/:repo/branches/:branch/protection' && /^dismissal_restrictions\./.test(param.name)) {
         param.name = `required_pull_request_reviews.${param.name}`
-      }
-
-      // workaround for https://github.com/octokit/routes/issues/140
-      if (/^\/repos\/:owner\/:repo\/check-runs/.test(state.results[0].path) && /^(annotations|images)\./.test(param.name)) {
-        param.name = `output.${param.name}`
       }
 
       return param

--- a/routes/checks.json
+++ b/routes/checks.json
@@ -135,35 +135,35 @@
         "location": "body"
       },
       {
-        "name": "output.annotations.filename",
+        "name": "output.annotations[].filename",
         "type": "string",
         "description": "The name of the file to add an annotation to.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.blob_href",
+        "name": "output.annotations[].blob_href",
         "type": "string",
         "description": "The file's full blob URL.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.start_line",
+        "name": "output.annotations[].start_line",
         "type": "integer",
         "description": "The start line of the annotation.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.end_line",
+        "name": "output.annotations[].end_line",
         "type": "integer",
         "description": "The end line of the annotation.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.warning_level",
+        "name": "output.annotations[].warning_level",
         "type": "string",
         "description": "The warning level of the annotation. Can be one of `notice`, `warning`, or `failure`.",
         "required": true,
@@ -175,21 +175,21 @@
         "location": "body"
       },
       {
-        "name": "output.annotations.message",
+        "name": "output.annotations[].message",
         "type": "string",
         "description": "A short description of the feedback for these lines of code. The maximum size is 64 KB.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.title",
+        "name": "output.annotations[].title",
         "type": "string",
         "description": "The title that represents the annotation. The maximum size is 255 characters.",
         "required": false,
         "location": "body"
       },
       {
-        "name": "output.annotations.raw_details",
+        "name": "output.annotations[].raw_details",
         "type": "string",
         "description": "Details about this annotation. The maximum size is 64 KB.",
         "required": false,
@@ -203,21 +203,21 @@
         "location": "body"
       },
       {
-        "name": "output.images.alt",
+        "name": "output.images[].alt",
         "type": "string",
         "description": "The alternative text for the image.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.images.image_url",
+        "name": "output.images[].image_url",
         "type": "string",
         "description": "The full URL of the image.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.images.caption",
+        "name": "output.images[].caption",
         "type": "string",
         "description": "A short image description.",
         "required": false,
@@ -355,35 +355,35 @@
         "location": "body"
       },
       {
-        "name": "output.annotations.filename",
+        "name": "output.annotations[].filename",
         "type": "string",
         "description": "The name of the file to add an annotation to.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.blob_href",
+        "name": "output.annotations[].blob_href",
         "type": "string",
         "description": "The file's full blob URL.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.start_line",
+        "name": "output.annotations[].start_line",
         "type": "integer",
         "description": "The start line of the annotation.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.end_line",
+        "name": "output.annotations[].end_line",
         "type": "integer",
         "description": "The end line of the annotation.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.warning_level",
+        "name": "output.annotations[].warning_level",
         "type": "string",
         "description": "The warning level of the annotation. Can be one of `notice`, `warning`, or `failure`.",
         "required": true,
@@ -395,21 +395,21 @@
         "location": "body"
       },
       {
-        "name": "output.annotations.message",
+        "name": "output.annotations[].message",
         "type": "string",
         "description": "A short description of the feedback for these lines of code. The maximum size is 64 KB.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.annotations.title",
+        "name": "output.annotations[].title",
         "type": "string",
         "description": "The title that represents the annotation. The maximum size is 255 characters.",
         "required": false,
         "location": "body"
       },
       {
-        "name": "output.annotations.raw_details",
+        "name": "output.annotations[].raw_details",
         "type": "string",
         "description": "Details about this annotation. The maximum size is 64 KB.",
         "required": false,
@@ -423,21 +423,21 @@
         "location": "body"
       },
       {
-        "name": "output.images.alt",
+        "name": "output.images[].alt",
         "type": "string",
         "description": "The alternative text for the image.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.images.image_url",
+        "name": "output.images[].image_url",
         "type": "string",
         "description": "The full URL of the image.",
         "required": true,
         "location": "body"
       },
       {
-        "name": "output.images.caption",
+        "name": "output.images[].caption",
         "type": "string",
         "description": "A short image description.",
         "required": false,

--- a/routes/checks/runs/create-a-check-run.json
+++ b/routes/checks/runs/create-a-check-run.json
@@ -134,35 +134,35 @@
       "location": "body"
     },
     {
-      "name": "output.annotations.filename",
+      "name": "output.annotations[].filename",
       "type": "string",
       "description": "The name of the file to add an annotation to.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.blob_href",
+      "name": "output.annotations[].blob_href",
       "type": "string",
       "description": "The file's full blob URL.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.start_line",
+      "name": "output.annotations[].start_line",
       "type": "integer",
       "description": "The start line of the annotation.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.end_line",
+      "name": "output.annotations[].end_line",
       "type": "integer",
       "description": "The end line of the annotation.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.warning_level",
+      "name": "output.annotations[].warning_level",
       "type": "string",
       "description": "The warning level of the annotation. Can be one of `notice`, `warning`, or `failure`.",
       "required": true,
@@ -174,21 +174,21 @@
       "location": "body"
     },
     {
-      "name": "output.annotations.message",
+      "name": "output.annotations[].message",
       "type": "string",
       "description": "A short description of the feedback for these lines of code. The maximum size is 64 KB.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.title",
+      "name": "output.annotations[].title",
       "type": "string",
       "description": "The title that represents the annotation. The maximum size is 255 characters.",
       "required": false,
       "location": "body"
     },
     {
-      "name": "output.annotations.raw_details",
+      "name": "output.annotations[].raw_details",
       "type": "string",
       "description": "Details about this annotation. The maximum size is 64 KB.",
       "required": false,
@@ -202,21 +202,21 @@
       "location": "body"
     },
     {
-      "name": "output.images.alt",
+      "name": "output.images[].alt",
       "type": "string",
       "description": "The alternative text for the image.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.images.image_url",
+      "name": "output.images[].image_url",
       "type": "string",
       "description": "The full URL of the image.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.images.caption",
+      "name": "output.images[].caption",
       "type": "string",
       "description": "A short image description.",
       "required": false,

--- a/routes/checks/runs/update-a-check-run.json
+++ b/routes/checks/runs/update-a-check-run.json
@@ -126,35 +126,35 @@
       "location": "body"
     },
     {
-      "name": "output.annotations.filename",
+      "name": "output.annotations[].filename",
       "type": "string",
       "description": "The name of the file to add an annotation to.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.blob_href",
+      "name": "output.annotations[].blob_href",
       "type": "string",
       "description": "The file's full blob URL.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.start_line",
+      "name": "output.annotations[].start_line",
       "type": "integer",
       "description": "The start line of the annotation.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.end_line",
+      "name": "output.annotations[].end_line",
       "type": "integer",
       "description": "The end line of the annotation.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.warning_level",
+      "name": "output.annotations[].warning_level",
       "type": "string",
       "description": "The warning level of the annotation. Can be one of `notice`, `warning`, or `failure`.",
       "required": true,
@@ -166,21 +166,21 @@
       "location": "body"
     },
     {
-      "name": "output.annotations.message",
+      "name": "output.annotations[].message",
       "type": "string",
       "description": "A short description of the feedback for these lines of code. The maximum size is 64 KB.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.annotations.title",
+      "name": "output.annotations[].title",
       "type": "string",
       "description": "The title that represents the annotation. The maximum size is 255 characters.",
       "required": false,
       "location": "body"
     },
     {
-      "name": "output.annotations.raw_details",
+      "name": "output.annotations[].raw_details",
       "type": "string",
       "description": "Details about this annotation. The maximum size is 64 KB.",
       "required": false,
@@ -194,21 +194,21 @@
       "location": "body"
     },
     {
-      "name": "output.images.alt",
+      "name": "output.images[].alt",
       "type": "string",
       "description": "The alternative text for the image.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.images.image_url",
+      "name": "output.images[].image_url",
       "type": "string",
       "description": "The full URL of the image.",
       "required": true,
       "location": "body"
     },
     {
-      "name": "output.images.caption",
+      "name": "output.images[].caption",
       "type": "string",
       "description": "A short image description.",
       "required": false,


### PR DESCRIPTION
will fix https://github.com/octokit/rest.js/issues/860 /cc @monder