### PR TITLE
Add "organization" to section titles on "Organization migrations" page

### DIFF
--- a/index.json
+++ b/index.json
@@ -6185,7 +6185,7 @@
         }
       ],
       "description": "Initiates the generation of a migration archive.",
-      "idName": "start",
+      "idName": "start-for-org",
       "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#start-a-migration"
     },
     {
@@ -6219,7 +6219,7 @@
         }
       ],
       "description": "Lists the most recent migrations.",
-      "idName": "list",
+      "idName": "list-for-org",
       "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#get-a-list-of-migrations"
     },
     {
@@ -6244,7 +6244,7 @@
         }
       ],
       "description": "Fetches the status of a migration.\n\nThe `state` of a migration can be one of the following values:\n\n*   `pending`, which means the migration hasn't started yet.\n*   `exporting`, which means the migration is in progress.\n*   `exported`, which means the migration finished successfully.\n*   `failed`, which means the migration failed.",
-      "idName": "get-status",
+      "idName": "get-status-for-org",
       "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#get-the-status-of-a-migration"
     },
     {
@@ -6269,7 +6269,7 @@
         }
       ],
       "description": "Fetches the URL to a migration archive.\n\n",
-      "idName": "download-archive",
+      "idName": "download-archive-for-org",
       "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#download-a-migration-archive"
     },
     {
@@ -6294,7 +6294,7 @@
         }
       ],
       "description": "Deletes a previous migration archive. Migration archives are automatically deleted after seven days.",
-      "idName": "delete-archive",
+      "idName": "delete-archive-for-org",
       "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#delete-a-migration-archive"
     },
     {
@@ -6326,7 +6326,7 @@
         }
       ],
       "description": "Unlocks a repository that was locked for migration. You should unlock each migrated repository and [delete them](https://developer.github.com/v3/repos/#delete-a-repository) when the migration is complete and you no longer need the source data.",
-      "idName": "unlock-repo",
+      "idName": "unlock-org-repo",
       "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#unlock-a-repository"
     },
     {

--- a/index.json
+++ b/index.json
@@ -553,7 +553,7 @@
         }
       ],
       "description": "",
-      "idName": "list-repos-public-events-for-network",
+      "idName": "list-public-events-for-repo-network",
       "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories"
     },
     {
@@ -621,7 +621,7 @@
         }
       ],
       "description": "These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.",
-      "idName": "list-events-that-user-has-received",
+      "idName": "list-received-events-for-user",
       "documentationUrl": "https://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received"
     },
     {
@@ -655,7 +655,7 @@
         }
       ],
       "description": "",
-      "idName": "list-public-events-that-user-has-received",
+      "idName": "list-received-public-events-for-user",
       "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received"
     },
     {
@@ -1095,7 +1095,7 @@
         }
       ],
       "description": "You can also find out _when_ stars were created by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:",
-      "idName": "list-stargazers",
+      "idName": "list-stargazers-for-repo",
       "documentationUrl": "https://developer.github.com/v3/activity/starring/#list-stargazers"
     },
     {
@@ -1320,7 +1320,7 @@
         }
       ],
       "description": "",
-      "idName": "list-watchers",
+      "idName": "list-watchers-for-repo",
       "documentationUrl": "https://developer.github.com/v3/activity/watching/#list-watchers"
     },
     {
@@ -1381,7 +1381,7 @@
         }
       ],
       "description": "",
-      "idName": "list-repos-watched-by-user",
+      "idName": "list-watched-repos",
       "documentationUrl": "https://developer.github.com/v3/activity/watching/#list-repositories-being-watched"
     },
     {
@@ -2428,7 +2428,7 @@
         }
       ],
       "description": "Changes the default automatic flow when creating check suites. By default, the CheckSuiteEvent is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually [Create a check suite](https://developer.github.com/v3/checks/suites/#create-a-check-suite). You must have admin permissions in the repository to set preferences for check suites.",
-      "idName": "set-prefs-for-suites-on-repo",
+      "idName": "set-suites-preferences",
       "documentationUrl": "https://developer.github.com/v3/checks/suites/#set-preferences-for-check-suites-on-a-repository"
     },
     {
@@ -2576,7 +2576,7 @@
         }
       ],
       "description": "",
-      "idName": "list-user-or-if-called-anonymously-will-return-public",
+      "idName": "list",
       "documentationUrl": "https://developer.github.com/v3/gists/#list-a-users-gists"
     },
     {
@@ -3295,7 +3295,7 @@
         }
       ],
       "isOverride": true,
-      "idName": "get-refs",
+      "idName": "list-references",
       "documentationUrl": "https://developer.github.com/v3/git/refs/#get-all-references"
     },
     {
@@ -3679,7 +3679,7 @@
         }
       ],
       "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).",
-      "idName": "get",
+      "idName": "get-by-slug",
       "documentationUrl": "https://developer.github.com/v3/apps/#get-a-single-github-app"
     },
     {
@@ -3840,7 +3840,7 @@
         }
       ],
       "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
-      "idName": "list-repos-accessible-to-user-for-installation",
+      "idName": "list-installation-repos",
       "documentationUrl": "https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
     },
     {
@@ -4153,7 +4153,7 @@
         }
       ],
       "description": "Returns only active subscriptions. You need to authenticate this call with the user's OAuth token.",
-      "idName": "get-user-marketplace-purchases",
+      "idName": "list-marketplace-purchases",
       "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
     },
     {
@@ -4180,7 +4180,7 @@
         }
       ],
       "description": "Returns only active subscriptions. You need to authenticate this call with the user's OAuth token.",
-      "idName": "get-user-marketplace-purchases-stubbed",
+      "idName": "list-marketplace-purchases-stubbed",
       "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
     }
   ],
@@ -4276,7 +4276,7 @@
         }
       ],
       "description": "**Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.\n\nBe aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)\" endpoint.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
-      "idName": "list-assigned-to-user-across-visible-repos-including-owned-repositories-member-repositories-org-repositories",
+      "idName": "list",
       "documentationUrl": "https://developer.github.com/v3/issues/#list-issues"
     },
     {
@@ -4370,7 +4370,7 @@
         }
       ],
       "description": "**Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.\n\nBe aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)\" endpoint.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
-      "idName": "list-across-owned-member-repos-assigned-to-user",
+      "idName": "list-for-user",
       "documentationUrl": "https://developer.github.com/v3/issues/#list-issues"
     },
     {
@@ -4471,7 +4471,7 @@
         }
       ],
       "description": "**Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.\n\nBe aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)\" endpoint.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
-      "idName": "list-for-given-org-assigned-to-user",
+      "idName": "list-for-org",
       "documentationUrl": "https://developer.github.com/v3/issues/#list-issues"
     },
     {
@@ -5646,7 +5646,7 @@
         }
       ],
       "description": "",
-      "idName": "list-labels",
+      "idName": "list-labels-on-issue",
       "documentationUrl": "https://developer.github.com/v3/issues/labels/#list-labels-on-an-issue"
     },
     {
@@ -5829,7 +5829,7 @@
         }
       ],
       "description": "",
-      "idName": "get-labels-for-every-for-milestone",
+      "idName": "list-labels-for-milestone",
       "documentationUrl": "https://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone"
     },
     {
@@ -6142,7 +6142,7 @@
         }
       ],
       "description": "",
-      "idName": "list-events",
+      "idName": "list-events-for-timeline",
       "documentationUrl": "https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue"
     }
   ],
@@ -6219,7 +6219,7 @@
         }
       ],
       "description": "Lists the most recent migrations.",
-      "idName": "get-list",
+      "idName": "list",
       "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#get-a-list-of-migrations"
     },
     {
@@ -6570,7 +6570,7 @@
         }
       ],
       "description": "You can import repositories from Subversion, Mercurial, and TFS that include files larger than 100MB. This ability is powered by [Git LFS](https://git-lfs.github.com). You can learn more about our LFS feature and working with large files [on our help site](https://help.github.com/articles/versioning-large-files/).",
-      "idName": "set-git-lfs-pref",
+      "idName": "set-lfs-preference",
       "documentationUrl": "https://developer.github.com/v3/migrations/source_imports/#set-git-lfs-preference"
     },
     {
@@ -6815,7 +6815,7 @@
         }
       ],
       "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
-      "idName": "get-repo-code-contents",
+      "idName": "get-for-repo",
       "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
     }
   ],
@@ -6900,7 +6900,7 @@
         }
       ],
       "description": "This method returns the contents of the repository's license file, if one is detected.\n\nSimilar to [the repository contents API](https://developer.github.com/v3/repos/contents/#get-contents), this method also supports [custom media types](https://developer.github.com/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.",
-      "idName": "get-repo-contents",
+      "idName": "get-for-repo",
       "documentationUrl": "https://developer.github.com/v3/licenses/#get-the-contents-of-a-repositorys-license"
     }
   ],
@@ -6939,7 +6939,7 @@
         }
       ],
       "description": "",
-      "idName": "render-arbitrary-document",
+      "idName": "render",
       "documentationUrl": "https://developer.github.com/v3/markdown/#render-an-arbitrary-markdown-document"
     },
     {
@@ -6949,7 +6949,7 @@
       "path": "/markdown/raw",
       "params": [],
       "description": "You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.\n\n",
-      "idName": "render-document-in-raw-mode",
+      "idName": "render-raw",
       "documentationUrl": "https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode"
     }
   ],
@@ -6961,7 +6961,7 @@
       "path": "/rate_limit",
       "params": [],
       "description": "Note: Accessing this endpoint does not count against your rate limit.\n\n\n\n**Understanding Your Rate Limit Status**\n\nThe Search API has a [custom rate limit](https://developer.github.com/v3/search/#rate-limit), separate from the rate limit governing the rest of the API. For that reason, the response (shown above) categorizes your rate limit by resource. Within the `\"resources\"` object, the `\"search\"` object provides your rate limit status for the [Search API](https://developer.github.com/v3/search). The `\"core\"` object provides your rate limit status for all the _rest_ of the API.\n\nThe `\"rate\"` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code (or updating your existing code), you should use the `\"core\"` object instead of the `\"rate\"` object. The `\"core\"` object contains the same information that is present in the `\"rate\"` object.",
-      "idName": "get-current-rate-limit-status",
+      "idName": "get",
       "documentationUrl": "https://developer.github.com/v3/rate_limit/#get-your-current-rate-limit-status"
     }
   ],
@@ -7058,7 +7058,7 @@
         }
       ],
       "description": "List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.\n\nThis method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List your organizations](#list-your-organizations) API instead.",
-      "idName": "list-user",
+      "idName": "list-for-user",
       "documentationUrl": "https://developer.github.com/v3/orgs/#list-user-organizations"
     },
     {
@@ -7215,7 +7215,7 @@
         }
       ],
       "description": "If the user is blocked:\n\nIf the user is not blocked:",
-      "idName": "check-whether-user-is-blocked",
+      "idName": "check-blocked-user",
       "documentationUrl": "https://developer.github.com/v3/orgs/blocking/#check-whether-a-user-is-blocked-from-an-organization"
     },
     {
@@ -7324,7 +7324,7 @@
         }
       ],
       "description": "List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.\n\n",
-      "idName": "members-list",
+      "idName": "list-members",
       "documentationUrl": "https://developer.github.com/v3/orgs/members/#members-list"
     },
     {
@@ -7408,7 +7408,7 @@
         }
       ],
       "description": "Members of an organization can choose to have their membership publicized or not.",
-      "idName": "public-members-list",
+      "idName": "list-public-members",
       "documentationUrl": "https://developer.github.com/v3/orgs/members/#public-members-list"
     },
     {
@@ -8194,7 +8194,7 @@
         }
       ],
       "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-      "idName": "list-repo",
+      "idName": "list-for-repo",
       "documentationUrl": "https://developer.github.com/v3/projects/#list-repository-projects"
     },
     {
@@ -8241,7 +8241,7 @@
         }
       ],
       "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-      "idName": "list-org",
+      "idName": "list-for-org",
       "documentationUrl": "https://developer.github.com/v3/projects/#list-organization-projects"
     },
     {
@@ -8330,7 +8330,7 @@
         }
       ],
       "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-      "idName": "create-repo",
+      "idName": "create-for-repo",
       "documentationUrl": "https://developer.github.com/v3/projects/#create-a-repository-project"
     },
     {
@@ -8378,7 +8378,7 @@
         }
       ],
       "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-      "idName": "create-org",
+      "idName": "create-for-org",
       "documentationUrl": "https://developer.github.com/v3/projects/#create-an-organization-project"
     },
     {
@@ -9365,7 +9365,7 @@
         }
       ],
       "description": "",
-      "idName": "get-if-merged",
+      "idName": "check-if-merged",
       "documentationUrl": "https://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged"
     },
     {
@@ -9430,7 +9430,7 @@
         }
       ],
       "description": "",
-      "idName": "merge-merge-button",
+      "idName": "merge",
       "documentationUrl": "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button"
     },
     {
@@ -11134,7 +11134,7 @@
         }
       ],
       "description": "List public repositories for the specified user.",
-      "idName": "list-user",
+      "idName": "list-for-user",
       "documentationUrl": "https://developer.github.com/v3/repos/#list-user-repositories"
     },
     {
@@ -11184,7 +11184,7 @@
         }
       ],
       "description": "List repositories for the specified org.",
-      "idName": "list-org",
+      "idName": "list-for-org",
       "documentationUrl": "https://developer.github.com/v3/repos/#list-organization-repositories"
     },
     {
@@ -13161,7 +13161,7 @@
         }
       ],
       "description": "Possible values for the `permission` key: `admin`, `write`, `read`, `none`.",
-      "idName": "review-user-permission-level",
+      "idName": "get-collaborator-permission-level",
       "documentationUrl": "https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level"
     },
     {
@@ -13670,7 +13670,7 @@
         }
       ],
       "description": "Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`. For example:\n\n```\nGET /repos/:owner/:repo/compare/hubot:branchname...octocat:branchname\n```\n\nThe response from the API is equivalent to running the `git log base..head` command; however, commits are returned in reverse chronological order.\n\nPass the appropriate [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.\n\n**Working with large comparisons**\n\nThe response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [Commit List API](https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository) to enumerate all commits in the range.\n\nFor comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long to generate. You can typically resolve this error by using a smaller commit range.",
-      "idName": "compare-two-commits",
+      "idName": "compare-commits",
       "documentationUrl": "https://developer.github.com/v3/repos/commits/#compare-two-commits"
     },
     {
@@ -14891,7 +14891,7 @@
         }
       ],
       "description": "When authenticating as a user, this endpoint will list all currently open repository invitations for that user.\n\n",
-      "idName": "list-user-invitations",
+      "idName": "list-invitations",
       "documentationUrl": "https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations"
     },
     {
@@ -14973,7 +14973,7 @@
         }
       ],
       "description": "",
-      "idName": "perform-merge",
+      "idName": "merge",
       "documentationUrl": "https://developer.github.com/v3/repos/merging/#perform-a-merge"
     },
     {
@@ -14998,7 +14998,7 @@
         }
       ],
       "description": "Responses during the preview period contain two additional fields:\n\n*   `html_url`: The absolute URL (with scheme) to the rendered site. For example, `https://username.github.io`.\n*   `source`: Information about the source branch and directory for the rendered site. The source field includes:\n    *   `branch`: The repo branch for [site source files](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/) For example, _master_ or _gh-pages_.\n    *   `path`: The repo directory from which the site publishes. Can be either `/` or `/docs`.",
-      "idName": "get-information-about-pages-site",
+      "idName": "get-pages",
       "documentationUrl": "https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site"
     },
     {
@@ -15930,7 +15930,7 @@
         }
       ],
       "description": "Get the top 10 referrers over the last 14 days.",
-      "idName": "list-referrers",
+      "idName": "get-top-referrers",
       "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-referrers"
     },
     {
@@ -15955,7 +15955,7 @@
         }
       ],
       "description": "Get the top 10 popular contents over the last 14 days.",
-      "idName": "list-paths",
+      "idName": "get-top-paths",
       "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-paths"
     },
     {
@@ -15992,7 +15992,7 @@
         }
       ],
       "description": "Get the total number of views and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
-      "idName": "views",
+      "idName": "get-views",
       "documentationUrl": "https://developer.github.com/v3/repos/traffic/#views"
     },
     {
@@ -16029,7 +16029,7 @@
         }
       ],
       "description": "Get the total number of clones and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
-      "idName": "clones",
+      "idName": "get-clones",
       "documentationUrl": "https://developer.github.com/v3/repos/traffic/#clones"
     },
     {
@@ -17317,7 +17317,7 @@
         }
       ],
       "description": "List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) when authenticating via [OAuth](https://developer.github.com/apps/building-oauth-apps/).",
-      "idName": "list-user",
+      "idName": "list",
       "documentationUrl": "https://developer.github.com/v3/teams/#list-user-teams"
     },
     {
@@ -17666,7 +17666,7 @@
         }
       ],
       "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "idName": "list-comments",
+      "idName": "list-discussion-comments",
       "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#list-comments"
     },
     {
@@ -17698,7 +17698,7 @@
         }
       ],
       "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "idName": "get-comment",
+      "idName": "get-discussion-comment",
       "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment"
     },
     {
@@ -17730,7 +17730,7 @@
         }
       ],
       "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "idName": "create-comment",
+      "idName": "create-discussion-comment",
       "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#create-a-comment"
     },
     {
@@ -17769,7 +17769,7 @@
         }
       ],
       "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "idName": "edit-comment",
+      "idName": "edit-discussion-comment",
       "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment"
     },
     {
@@ -17801,7 +17801,7 @@
         }
       ],
       "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "idName": "delete-comment",
+      "idName": "delete-discussion-comment",
       "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment"
     },
     {
@@ -18085,7 +18085,7 @@
         }
       ],
       "description": "**Filter parameter**\n\nYou can filter results with the `id`, `userName`, `emails` and `external_id` query parameters.\n\n```\nGET /scim/v2/organizations/:organization/Users?filter=userName\n```\n\nRetrieves a paginated list of all provisioned organization members, including pending invitations.",
-      "idName": "get-provisioned-identities-list",
+      "idName": "get-provisioned-identities",
       "documentationUrl": "https://developer.github.com/v3/scim/#get-a-list-of-provisioned-identities"
     },
     {
@@ -18128,7 +18128,7 @@
         }
       ],
       "description": "Provision organization membership for and send activation emails to a list of email addresses.",
-      "idName": "provision-invite-users",
+      "idName": "provision-and-invite-users",
       "documentationUrl": "https://developer.github.com/v3/scim/#provision-and-invite-users"
     },
     {
@@ -18223,7 +18223,7 @@
         }
       ],
       "description": "Provides publicly available information about someone with a GitHub account.\n\nThe `email` key in the following response is the publicly visible email address from your GitHub [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub. For more information, see [Authentication](https://developer.github.com/v3/#authentication).\n\nThe Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see \"[Emails API](https://developer.github.com/v3/users/emails/)\".",
-      "idName": "get",
+      "idName": "get-by-username",
       "documentationUrl": "https://developer.github.com/v3/users/#get-a-single-user"
     },
     {
@@ -18365,7 +18365,7 @@
         }
       ],
       "description": "Lists all users, in the order that they signed up on GitHub. This list includes personal user accounts and organization accounts.\n\nNote: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://developer.github.com/v3/#link-header) to get the URL for the next page of users.",
-      "idName": "get",
+      "idName": "list",
       "documentationUrl": "https://developer.github.com/v3/users/#get-all-users"
     },
     {
@@ -18393,7 +18393,7 @@
         }
       ],
       "description": "If the user is blocked:\n\nIf the user is not blocked:",
-      "idName": "check-whether-youve-blocked",
+      "idName": "check-blocked",
       "documentationUrl": "https://developer.github.com/v3/users/blocking/#check-whether-youve-blocked-a-user"
     },
     {
@@ -18623,7 +18623,7 @@
         }
       ],
       "description": "",
-      "idName": "list-who-is-following-for-user",
+      "idName": "list-following-for-user",
       "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user"
     },
     {
@@ -18650,7 +18650,7 @@
         }
       ],
       "description": "",
-      "idName": "list-who-is-following",
+      "idName": "list-following",
       "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user"
     },
     {
@@ -18693,7 +18693,7 @@
         }
       ],
       "description": "",
-      "idName": "check-one-follows-another-for-user",
+      "idName": "check-following-for-user",
       "documentationUrl": "https://developer.github.com/v3/users/followers/#check-if-one-user-follows-another"
     },
     {

--- a/lib/endpoint/to-id-name.js
+++ b/lib/endpoint/to-id-name.js
@@ -35,7 +35,7 @@ const ignoreWordsAtEnd = [
 
 function endpointToIdName (endpoint) {
   // endpoint-specific exceptions
-  const route = `${endpoint.verb} ${endpoint.path}`
+  const route = `${endpoint.method} ${endpoint.path}`
 
   switch (route) {
     // suggested to change in docs

--- a/lib/endpoint/to-id-name.js
+++ b/lib/endpoint/to-id-name.js
@@ -47,8 +47,6 @@ function endpointToIdName (endpoint) {
     case 'GET /marketplace_listing/stubbed/plans/:id/accounts': return 'list-accounts-for-plan-stubbed'
     case 'GET /orgs/:org/issues': return 'list-for-org'
     case 'GET /orgs/:org/members': return 'list-members'
-    case 'GET /orgs/:org/migrations': return 'list'
-    case 'GET /orgs/:org/migrations/:id': return 'get'
     case 'GET /orgs/:org/public_members': return 'list-public-members'
     case 'GET /repos/:owner/:name/community/profile': return 'get-community-profile-metrics'
     case 'GET /repos/:owner/:repo/collaborators/:username/permission': return 'get-collaborator-permission-level'
@@ -76,6 +74,14 @@ function endpointToIdName (endpoint) {
     case 'GET /repos/:owner/:repo/issues/:number/timeline': return 'list-events-for-timeline'
     case 'GET /projects/:id/collaborators/:username/permission': return 'get-user-permission-level'
     case 'GET /teams/:id/projects/:project_id': return 'get-project'
+
+    // https://github.com/octokit/routes/issues/173
+    case 'POST /orgs/:org/migrations': return 'start-for-org'
+    case 'GET /orgs/:org/migrations': return 'list-for-org'
+    case 'GET /orgs/:org/migrations/:migration_id': return 'get-status-for-org'
+    case 'GET /orgs/:org/migrations/:migration_id/archive': return 'download-archive-for-org'
+    case 'DELETE /orgs/:org/migrations/:migration_id/archive': return 'delete-archive-for-org'
+    case 'DELETE /orgs/:org/migrations/:migration_id/repos/:repo_name/lock': return 'unlock-org-repo'
 
     // permament workarounds
     case 'GET /orgs/:org/projects': return 'list-for-org'
@@ -125,13 +131,16 @@ function endpointToIdName (endpoint) {
   }
 
   // add scope singular/plural variations to fillWords
-  const ignoreWords = fillWords.concat(getVariations(endpoint.scope))
+  const scopeNameVariations = getVariations(endpoint.scope)
+  const ignoreWords = fillWords.concat(scopeNameVariations)
 
+  // const forContextReplaceRegex = new RegExp(`(user|organization) (${scopeNameVariations.join('|')})`, 'ig')
   const fillWordsRegex = new RegExp(`\\b(${ignoreWords.join('|')})\\b`, 'ig')
   const ignoreWordsAtEndRegex = new RegExp(`\\b(${ignoreWordsAtEnd.join('|')})\\s*$`, 'i')
 
   let idName = endpoint.name
     .replace(/\bin an?\b/, 'for')
+    // .replace(forContextReplaceRegex, '$2 for $1')
     .replace(fillWordsRegex, '')
     .replace(ignoreWordsAtEndRegex, '')
 

--- a/routes/activity.json
+++ b/routes/activity.json
@@ -105,7 +105,7 @@
       }
     ],
     "description": "",
-    "idName": "list-repos-public-events-for-network",
+    "idName": "list-public-events-for-repo-network",
     "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories"
   },
   {
@@ -173,7 +173,7 @@
       }
     ],
     "description": "These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.",
-    "idName": "list-events-that-user-has-received",
+    "idName": "list-received-events-for-user",
     "documentationUrl": "https://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received"
   },
   {
@@ -207,7 +207,7 @@
       }
     ],
     "description": "",
-    "idName": "list-public-events-that-user-has-received",
+    "idName": "list-received-public-events-for-user",
     "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received"
   },
   {
@@ -647,7 +647,7 @@
       }
     ],
     "description": "You can also find out _when_ stars were created by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:",
-    "idName": "list-stargazers",
+    "idName": "list-stargazers-for-repo",
     "documentationUrl": "https://developer.github.com/v3/activity/starring/#list-stargazers"
   },
   {
@@ -872,7 +872,7 @@
       }
     ],
     "description": "",
-    "idName": "list-watchers",
+    "idName": "list-watchers-for-repo",
     "documentationUrl": "https://developer.github.com/v3/activity/watching/#list-watchers"
   },
   {
@@ -933,7 +933,7 @@
       }
     ],
     "description": "",
-    "idName": "list-repos-watched-by-user",
+    "idName": "list-watched-repos",
     "documentationUrl": "https://developer.github.com/v3/activity/watching/#list-repositories-being-watched"
   },
   {

--- a/routes/activity/events/list-events-that-a-user-has-received.json
+++ b/routes/activity/events/list-events-that-a-user-has-received.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.",
-  "idName": "list-events-that-user-has-received",
+  "idName": "list-received-events-for-user",
   "documentationUrl": "https://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received"
 }

--- a/routes/activity/events/list-public-events-for-a-network-of-repositories.json
+++ b/routes/activity/events/list-public-events-for-a-network-of-repositories.json
@@ -36,6 +36,6 @@
     }
   ],
   "description": "",
-  "idName": "list-repos-public-events-for-network",
+  "idName": "list-public-events-for-repo-network",
   "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories"
 }

--- a/routes/activity/events/list-public-events-that-a-user-has-received.json
+++ b/routes/activity/events/list-public-events-that-a-user-has-received.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "",
-  "idName": "list-public-events-that-user-has-received",
+  "idName": "list-received-public-events-for-user",
   "documentationUrl": "https://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received"
 }

--- a/routes/activity/starring/list-stargazers.json
+++ b/routes/activity/starring/list-stargazers.json
@@ -36,6 +36,6 @@
     }
   ],
   "description": "You can also find out _when_ stars were created by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:",
-  "idName": "list-stargazers",
+  "idName": "list-stargazers-for-repo",
   "documentationUrl": "https://developer.github.com/v3/activity/starring/#list-stargazers"
 }

--- a/routes/activity/watching/list-repositories-being-watched-by-the-authenticated-user.json
+++ b/routes/activity/watching/list-repositories-being-watched-by-the-authenticated-user.json
@@ -22,6 +22,6 @@
     }
   ],
   "description": "",
-  "idName": "list-repos-watched-by-user",
+  "idName": "list-watched-repos",
   "documentationUrl": "https://developer.github.com/v3/activity/watching/#list-repositories-being-watched"
 }

--- a/routes/activity/watching/list-watchers.json
+++ b/routes/activity/watching/list-watchers.json
@@ -36,6 +36,6 @@
     }
   ],
   "description": "",
-  "idName": "list-watchers",
+  "idName": "list-watchers-for-repo",
   "documentationUrl": "https://developer.github.com/v3/activity/watching/#list-watchers"
 }

--- a/routes/apps.json
+++ b/routes/apps.json
@@ -14,7 +14,7 @@
       }
     ],
     "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).",
-    "idName": "get",
+    "idName": "get-by-slug",
     "documentationUrl": "https://developer.github.com/v3/apps/#get-a-single-github-app"
   },
   {
@@ -175,7 +175,7 @@
       }
     ],
     "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
-    "idName": "list-repos-accessible-to-user-for-installation",
+    "idName": "list-installation-repos",
     "documentationUrl": "https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
   },
   {
@@ -488,7 +488,7 @@
       }
     ],
     "description": "Returns only active subscriptions. You need to authenticate this call with the user's OAuth token.",
-    "idName": "get-user-marketplace-purchases",
+    "idName": "list-marketplace-purchases",
     "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
   },
   {
@@ -515,7 +515,7 @@
       }
     ],
     "description": "Returns only active subscriptions. You need to authenticate this call with the user's OAuth token.",
-    "idName": "get-user-marketplace-purchases-stubbed",
+    "idName": "list-marketplace-purchases-stubbed",
     "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
   }
 ]

--- a/routes/apps/get-a-single-github-app.json
+++ b/routes/apps/get-a-single-github-app.json
@@ -13,6 +13,6 @@
     }
   ],
   "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).",
-  "idName": "get",
+  "idName": "get-by-slug",
   "documentationUrl": "https://developer.github.com/v3/apps/#get-a-single-github-app"
 }

--- a/routes/apps/installations/list-repositories-accessible-to-the-user-for-an-installation.json
+++ b/routes/apps/installations/list-repositories-accessible-to-the-user-for-an-installation.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
-  "idName": "list-repos-accessible-to-user-for-installation",
+  "idName": "list-installation-repos",
   "documentationUrl": "https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
 }

--- a/routes/apps/marketplace/get-a-users-marketplace-purchases-stubbed.json
+++ b/routes/apps/marketplace/get-a-users-marketplace-purchases-stubbed.json
@@ -22,6 +22,6 @@
     }
   ],
   "description": "Returns only active subscriptions. You need to authenticate this call with the user's OAuth token.",
-  "idName": "get-user-marketplace-purchases-stubbed",
+  "idName": "list-marketplace-purchases-stubbed",
   "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
 }

--- a/routes/apps/marketplace/get-a-users-marketplace-purchases.json
+++ b/routes/apps/marketplace/get-a-users-marketplace-purchases.json
@@ -22,6 +22,6 @@
     }
   ],
   "description": "Returns only active subscriptions. You need to authenticate this call with the user's OAuth token.",
-  "idName": "get-user-marketplace-purchases",
+  "idName": "list-marketplace-purchases",
   "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
 }

--- a/routes/checks.json
+++ b/routes/checks.json
@@ -877,7 +877,7 @@
       }
     ],
     "description": "Changes the default automatic flow when creating check suites. By default, the CheckSuiteEvent is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually [Create a check suite](https://developer.github.com/v3/checks/suites/#create-a-check-suite). You must have admin permissions in the repository to set preferences for check suites.",
-    "idName": "set-prefs-for-suites-on-repo",
+    "idName": "set-suites-preferences",
     "documentationUrl": "https://developer.github.com/v3/checks/suites/#set-preferences-for-check-suites-on-a-repository"
   },
   {

--- a/routes/checks/suites/set-preferences-for-check-suites-on-a-repository.json
+++ b/routes/checks/suites/set-preferences-for-check-suites-on-a-repository.json
@@ -42,6 +42,6 @@
     }
   ],
   "description": "Changes the default automatic flow when creating check suites. By default, the CheckSuiteEvent is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually [Create a check suite](https://developer.github.com/v3/checks/suites/#create-a-check-suite). You must have admin permissions in the repository to set preferences for check suites.",
-  "idName": "set-prefs-for-suites-on-repo",
+  "idName": "set-suites-preferences",
   "documentationUrl": "https://developer.github.com/v3/checks/suites/#set-preferences-for-check-suites-on-a-repository"
 }

--- a/routes/codes-of-conduct.json
+++ b/routes/codes-of-conduct.json
@@ -49,7 +49,7 @@
       }
     ],
     "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
-    "idName": "get-repo-code-contents",
+    "idName": "get-for-repo",
     "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
   }
 ]

--- a/routes/codes-of-conduct/get-the-contents-of-a-repositorys-code-of-conduct.json
+++ b/routes/codes-of-conduct/get-the-contents-of-a-repositorys-code-of-conduct.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
-  "idName": "get-repo-code-contents",
+  "idName": "get-for-repo",
   "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
 }

--- a/routes/gists.json
+++ b/routes/gists.json
@@ -71,7 +71,7 @@
       }
     ],
     "description": "",
-    "idName": "list-user-or-if-called-anonymously-will-return-public",
+    "idName": "list",
     "documentationUrl": "https://developer.github.com/v3/gists/#list-a-users-gists"
   },
   {

--- a/routes/gists/list-the-authenticated-users-gists-or-if-called-anonymously-this-will-return-all-public-gists.json
+++ b/routes/gists/list-the-authenticated-users-gists-or-if-called-anonymously-this-will-return-all-public-gists.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "",
-  "idName": "list-user-or-if-called-anonymously-will-return-public",
+  "idName": "list",
   "documentationUrl": "https://developer.github.com/v3/gists/#list-a-users-gists"
 }

--- a/routes/git.json
+++ b/routes/git.json
@@ -224,7 +224,7 @@
       }
     ],
     "isOverride": true,
-    "idName": "get-refs",
+    "idName": "list-references",
     "documentationUrl": "https://developer.github.com/v3/git/refs/#get-all-references"
   },
   {

--- a/routes/git/refs/get-all-references.json
+++ b/routes/git/refs/get-all-references.json
@@ -28,6 +28,6 @@
     }
   ],
   "isOverride": true,
-  "idName": "get-refs",
+  "idName": "list-references",
   "documentationUrl": "https://developer.github.com/v3/git/refs/#get-all-references"
 }

--- a/routes/issues.json
+++ b/routes/issues.json
@@ -90,7 +90,7 @@
       }
     ],
     "description": "**Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.\n\nBe aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)\" endpoint.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
-    "idName": "list-assigned-to-user-across-visible-repos-including-owned-repositories-member-repositories-org-repositories",
+    "idName": "list",
     "documentationUrl": "https://developer.github.com/v3/issues/#list-issues"
   },
   {
@@ -184,7 +184,7 @@
       }
     ],
     "description": "**Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.\n\nBe aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)\" endpoint.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
-    "idName": "list-across-owned-member-repos-assigned-to-user",
+    "idName": "list-for-user",
     "documentationUrl": "https://developer.github.com/v3/issues/#list-issues"
   },
   {
@@ -285,7 +285,7 @@
       }
     ],
     "description": "**Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.\n\nBe aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)\" endpoint.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
-    "idName": "list-for-given-org-assigned-to-user",
+    "idName": "list-for-org",
     "documentationUrl": "https://developer.github.com/v3/issues/#list-issues"
   },
   {
@@ -1460,7 +1460,7 @@
       }
     ],
     "description": "",
-    "idName": "list-labels",
+    "idName": "list-labels-on-issue",
     "documentationUrl": "https://developer.github.com/v3/issues/labels/#list-labels-on-an-issue"
   },
   {
@@ -1643,7 +1643,7 @@
       }
     ],
     "description": "",
-    "idName": "get-labels-for-every-for-milestone",
+    "idName": "list-labels-for-milestone",
     "documentationUrl": "https://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone"
   },
   {
@@ -1956,7 +1956,7 @@
       }
     ],
     "description": "",
-    "idName": "list-events",
+    "idName": "list-events-for-timeline",
     "documentationUrl": "https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue"
   }
 ]

--- a/routes/issues/labels/get-labels-for-every-issue-in-a-milestone.json
+++ b/routes/issues/labels/get-labels-for-every-issue-in-a-milestone.json
@@ -43,6 +43,6 @@
     }
   ],
   "description": "",
-  "idName": "get-labels-for-every-for-milestone",
+  "idName": "list-labels-for-milestone",
   "documentationUrl": "https://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone"
 }

--- a/routes/issues/labels/list-labels-on-an-issue.json
+++ b/routes/issues/labels/list-labels-on-an-issue.json
@@ -43,6 +43,6 @@
     }
   ],
   "description": "",
-  "idName": "list-labels",
+  "idName": "list-labels-on-issue",
   "documentationUrl": "https://developer.github.com/v3/issues/labels/#list-labels-on-an-issue"
 }

--- a/routes/issues/list-all-issues-across-owned-and-member-repositories-assigned-to-the-authenticated-user.json
+++ b/routes/issues/list-all-issues-across-owned-and-member-repositories-assigned-to-the-authenticated-user.json
@@ -89,6 +89,6 @@
     }
   ],
   "description": "**Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.\n\nBe aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)\" endpoint.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
-  "idName": "list-across-owned-member-repos-assigned-to-user",
+  "idName": "list-for-user",
   "documentationUrl": "https://developer.github.com/v3/issues/#list-issues"
 }

--- a/routes/issues/list-all-issues-assigned-to-the-authenticated-user-across-all-visible-repositories-including-owned-repositories-member-repositories-and-organization-repositories.json
+++ b/routes/issues/list-all-issues-assigned-to-the-authenticated-user-across-all-visible-repositories-including-owned-repositories-member-repositories-and-organization-repositories.json
@@ -89,6 +89,6 @@
     }
   ],
   "description": "**Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.\n\nBe aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)\" endpoint.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
-  "idName": "list-assigned-to-user-across-visible-repos-including-owned-repositories-member-repositories-org-repositories",
+  "idName": "list",
   "documentationUrl": "https://developer.github.com/v3/issues/#list-issues"
 }

--- a/routes/issues/list-all-issues-for-a-given-organization-assigned-to-the-authenticated-user.json
+++ b/routes/issues/list-all-issues-for-a-given-organization-assigned-to-the-authenticated-user.json
@@ -96,6 +96,6 @@
     }
   ],
   "description": "**Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, \"Issues\" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.\n\nBe aware that the `id` of a pull request returned from \"Issues\" endpoints will be an _issue id_. To find out the pull request id, use the \"[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)\" endpoint.\n\n\n\n**Note:** If a user opened an issue via a GitHub App, the `performed_via_github_app` key contains information on that GitHub App.",
-  "idName": "list-for-given-org-assigned-to-user",
+  "idName": "list-for-org",
   "documentationUrl": "https://developer.github.com/v3/issues/#list-issues"
 }

--- a/routes/issues/timeline/list-events-for-an-issue.json
+++ b/routes/issues/timeline/list-events-for-an-issue.json
@@ -43,6 +43,6 @@
     }
   ],
   "description": "",
-  "idName": "list-events",
+  "idName": "list-events-for-timeline",
   "documentationUrl": "https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue"
 }

--- a/routes/licenses.json
+++ b/routes/licenses.json
@@ -49,7 +49,7 @@
       }
     ],
     "description": "This method returns the contents of the repository's license file, if one is detected.\n\nSimilar to [the repository contents API](https://developer.github.com/v3/repos/contents/#get-contents), this method also supports [custom media types](https://developer.github.com/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.",
-    "idName": "get-repo-contents",
+    "idName": "get-for-repo",
     "documentationUrl": "https://developer.github.com/v3/licenses/#get-the-contents-of-a-repositorys-license"
   }
 ]

--- a/routes/licenses/get-the-contents-of-a-repositorys-license.json
+++ b/routes/licenses/get-the-contents-of-a-repositorys-license.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "This method returns the contents of the repository's license file, if one is detected.\n\nSimilar to [the repository contents API](https://developer.github.com/v3/repos/contents/#get-contents), this method also supports [custom media types](https://developer.github.com/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.",
-  "idName": "get-repo-contents",
+  "idName": "get-for-repo",
   "documentationUrl": "https://developer.github.com/v3/licenses/#get-the-contents-of-a-repositorys-license"
 }

--- a/routes/markdown.json
+++ b/routes/markdown.json
@@ -33,7 +33,7 @@
       }
     ],
     "description": "",
-    "idName": "render-arbitrary-document",
+    "idName": "render",
     "documentationUrl": "https://developer.github.com/v3/markdown/#render-an-arbitrary-markdown-document"
   },
   {
@@ -43,7 +43,7 @@
     "path": "/markdown/raw",
     "params": [],
     "description": "You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.\n\n",
-    "idName": "render-document-in-raw-mode",
+    "idName": "render-raw",
     "documentationUrl": "https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode"
   }
 ]

--- a/routes/markdown/render-a-markdown-document-in-raw-mode.json
+++ b/routes/markdown/render-a-markdown-document-in-raw-mode.json
@@ -5,6 +5,6 @@
   "path": "/markdown/raw",
   "params": [],
   "description": "You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.\n\n",
-  "idName": "render-document-in-raw-mode",
+  "idName": "render-raw",
   "documentationUrl": "https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode"
 }

--- a/routes/markdown/render-an-arbitrary-markdown-document.json
+++ b/routes/markdown/render-an-arbitrary-markdown-document.json
@@ -32,6 +32,6 @@
     }
   ],
   "description": "",
-  "idName": "render-arbitrary-document",
+  "idName": "render",
   "documentationUrl": "https://developer.github.com/v3/markdown/#render-an-arbitrary-markdown-document"
 }

--- a/routes/migrations.json
+++ b/routes/migrations.json
@@ -71,7 +71,7 @@
       }
     ],
     "description": "Lists the most recent migrations.",
-    "idName": "get-list",
+    "idName": "list",
     "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#get-a-list-of-migrations"
   },
   {
@@ -422,7 +422,7 @@
       }
     ],
     "description": "You can import repositories from Subversion, Mercurial, and TFS that include files larger than 100MB. This ability is powered by [Git LFS](https://git-lfs.github.com). You can learn more about our LFS feature and working with large files [on our help site](https://help.github.com/articles/versioning-large-files/).",
-    "idName": "set-git-lfs-pref",
+    "idName": "set-lfs-preference",
     "documentationUrl": "https://developer.github.com/v3/migrations/source_imports/#set-git-lfs-preference"
   },
   {

--- a/routes/migrations.json
+++ b/routes/migrations.json
@@ -37,7 +37,7 @@
       }
     ],
     "description": "Initiates the generation of a migration archive.",
-    "idName": "start",
+    "idName": "start-for-org",
     "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#start-a-migration"
   },
   {
@@ -71,7 +71,7 @@
       }
     ],
     "description": "Lists the most recent migrations.",
-    "idName": "list",
+    "idName": "list-for-org",
     "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#get-a-list-of-migrations"
   },
   {
@@ -96,7 +96,7 @@
       }
     ],
     "description": "Fetches the status of a migration.\n\nThe `state` of a migration can be one of the following values:\n\n*   `pending`, which means the migration hasn't started yet.\n*   `exporting`, which means the migration is in progress.\n*   `exported`, which means the migration finished successfully.\n*   `failed`, which means the migration failed.",
-    "idName": "get-status",
+    "idName": "get-status-for-org",
     "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#get-the-status-of-a-migration"
   },
   {
@@ -121,7 +121,7 @@
       }
     ],
     "description": "Fetches the URL to a migration archive.\n\n",
-    "idName": "download-archive",
+    "idName": "download-archive-for-org",
     "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#download-a-migration-archive"
   },
   {
@@ -146,7 +146,7 @@
       }
     ],
     "description": "Deletes a previous migration archive. Migration archives are automatically deleted after seven days.",
-    "idName": "delete-archive",
+    "idName": "delete-archive-for-org",
     "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#delete-a-migration-archive"
   },
   {
@@ -178,7 +178,7 @@
       }
     ],
     "description": "Unlocks a repository that was locked for migration. You should unlock each migrated repository and [delete them](https://developer.github.com/v3/repos/#delete-a-repository) when the migration is complete and you no longer need the source data.",
-    "idName": "unlock-repo",
+    "idName": "unlock-org-repo",
     "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#unlock-a-repository"
   },
   {

--- a/routes/migrations/orgs/delete-a-migration-archive.json
+++ b/routes/migrations/orgs/delete-a-migration-archive.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "Deletes a previous migration archive. Migration archives are automatically deleted after seven days.",
-  "idName": "delete-archive",
+  "idName": "delete-archive-for-org",
   "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#delete-a-migration-archive"
 }

--- a/routes/migrations/orgs/download-a-migration-archive.json
+++ b/routes/migrations/orgs/download-a-migration-archive.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "Fetches the URL to a migration archive.\n\n",
-  "idName": "download-archive",
+  "idName": "download-archive-for-org",
   "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#download-a-migration-archive"
 }

--- a/routes/migrations/orgs/get-a-list-of-migrations.json
+++ b/routes/migrations/orgs/get-a-list-of-migrations.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "Lists the most recent migrations.",
-  "idName": "get-list",
+  "idName": "list",
   "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#get-a-list-of-migrations"
 }

--- a/routes/migrations/orgs/get-a-list-of-migrations.json
+++ b/routes/migrations/orgs/get-a-list-of-migrations.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "Lists the most recent migrations.",
-  "idName": "list",
+  "idName": "list-for-org",
   "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#get-a-list-of-migrations"
 }

--- a/routes/migrations/orgs/get-the-status-of-a-migration.json
+++ b/routes/migrations/orgs/get-the-status-of-a-migration.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "Fetches the status of a migration.\n\nThe `state` of a migration can be one of the following values:\n\n*   `pending`, which means the migration hasn't started yet.\n*   `exporting`, which means the migration is in progress.\n*   `exported`, which means the migration finished successfully.\n*   `failed`, which means the migration failed.",
-  "idName": "get-status",
+  "idName": "get-status-for-org",
   "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#get-the-status-of-a-migration"
 }

--- a/routes/migrations/orgs/start-a-migration.json
+++ b/routes/migrations/orgs/start-a-migration.json
@@ -36,6 +36,6 @@
     }
   ],
   "description": "Initiates the generation of a migration archive.",
-  "idName": "start",
+  "idName": "start-for-org",
   "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#start-a-migration"
 }

--- a/routes/migrations/orgs/unlock-a-repository.json
+++ b/routes/migrations/orgs/unlock-a-repository.json
@@ -27,6 +27,6 @@
     }
   ],
   "description": "Unlocks a repository that was locked for migration. You should unlock each migrated repository and [delete them](https://developer.github.com/v3/repos/#delete-a-repository) when the migration is complete and you no longer need the source data.",
-  "idName": "unlock-repo",
+  "idName": "unlock-org-repo",
   "documentationUrl": "https://developer.github.com/v3/migrations/orgs/#unlock-a-repository"
 }

--- a/routes/migrations/source-imports/set-git-lfs-preference.json
+++ b/routes/migrations/source-imports/set-git-lfs-preference.json
@@ -31,6 +31,6 @@
     }
   ],
   "description": "You can import repositories from Subversion, Mercurial, and TFS that include files larger than 100MB. This ability is powered by [Git LFS](https://git-lfs.github.com). You can learn more about our LFS feature and working with large files [on our help site](https://help.github.com/articles/versioning-large-files/).",
-  "idName": "set-git-lfs-pref",
+  "idName": "set-lfs-preference",
   "documentationUrl": "https://developer.github.com/v3/migrations/source_imports/#set-git-lfs-preference"
 }

--- a/routes/orgs.json
+++ b/routes/orgs.json
@@ -91,7 +91,7 @@
       }
     ],
     "description": "List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.\n\nThis method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List your organizations](#list-your-organizations) API instead.",
-    "idName": "list-user",
+    "idName": "list-for-user",
     "documentationUrl": "https://developer.github.com/v3/orgs/#list-user-organizations"
   },
   {
@@ -248,7 +248,7 @@
       }
     ],
     "description": "If the user is blocked:\n\nIf the user is not blocked:",
-    "idName": "check-whether-user-is-blocked",
+    "idName": "check-blocked-user",
     "documentationUrl": "https://developer.github.com/v3/orgs/blocking/#check-whether-a-user-is-blocked-from-an-organization"
   },
   {
@@ -357,7 +357,7 @@
       }
     ],
     "description": "List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.\n\n",
-    "idName": "members-list",
+    "idName": "list-members",
     "documentationUrl": "https://developer.github.com/v3/orgs/members/#members-list"
   },
   {
@@ -441,7 +441,7 @@
       }
     ],
     "description": "Members of an organization can choose to have their membership publicized or not.",
-    "idName": "public-members-list",
+    "idName": "list-public-members",
     "documentationUrl": "https://developer.github.com/v3/orgs/members/#public-members-list"
   },
   {

--- a/routes/orgs/blocking/check-whether-a-user-is-blocked-from-an-organization.json
+++ b/routes/orgs/blocking/check-whether-a-user-is-blocked-from-an-organization.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "If the user is blocked:\n\nIf the user is not blocked:",
-  "idName": "check-whether-user-is-blocked",
+  "idName": "check-blocked-user",
   "documentationUrl": "https://developer.github.com/v3/orgs/blocking/#check-whether-a-user-is-blocked-from-an-organization"
 }

--- a/routes/orgs/list-user-organizations.json
+++ b/routes/orgs/list-user-organizations.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.\n\nThis method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List your organizations](#list-your-organizations) API instead.",
-  "idName": "list-user",
+  "idName": "list-for-user",
   "documentationUrl": "https://developer.github.com/v3/orgs/#list-user-organizations"
 }

--- a/routes/orgs/members/members-list.json
+++ b/routes/orgs/members/members-list.json
@@ -54,6 +54,6 @@
     }
   ],
   "description": "List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.\n\n",
-  "idName": "members-list",
+  "idName": "list-members",
   "documentationUrl": "https://developer.github.com/v3/orgs/members/#members-list"
 }

--- a/routes/orgs/members/public-members-list.json
+++ b/routes/orgs/members/public-members-list.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "Members of an organization can choose to have their membership publicized or not.",
-  "idName": "public-members-list",
+  "idName": "list-public-members",
   "documentationUrl": "https://developer.github.com/v3/orgs/members/#public-members-list"
 }

--- a/routes/projects.json
+++ b/routes/projects.json
@@ -50,7 +50,7 @@
       }
     ],
     "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-    "idName": "list-repo",
+    "idName": "list-for-repo",
     "documentationUrl": "https://developer.github.com/v3/projects/#list-repository-projects"
   },
   {
@@ -97,7 +97,7 @@
       }
     ],
     "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-    "idName": "list-org",
+    "idName": "list-for-org",
     "documentationUrl": "https://developer.github.com/v3/projects/#list-organization-projects"
   },
   {
@@ -186,7 +186,7 @@
       }
     ],
     "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-    "idName": "create-repo",
+    "idName": "create-for-repo",
     "documentationUrl": "https://developer.github.com/v3/projects/#create-a-repository-project"
   },
   {
@@ -234,7 +234,7 @@
       }
     ],
     "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-    "idName": "create-org",
+    "idName": "create-for-org",
     "documentationUrl": "https://developer.github.com/v3/projects/#create-an-organization-project"
   },
   {

--- a/routes/projects/create-a-repository-project.json
+++ b/routes/projects/create-a-repository-project.json
@@ -50,6 +50,6 @@
     }
   ],
   "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-  "idName": "create-repo",
+  "idName": "create-for-repo",
   "documentationUrl": "https://developer.github.com/v3/projects/#create-a-repository-project"
 }

--- a/routes/projects/create-an-organization-project.json
+++ b/routes/projects/create-an-organization-project.json
@@ -43,6 +43,6 @@
     }
   ],
   "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-  "idName": "create-org",
+  "idName": "create-for-org",
   "documentationUrl": "https://developer.github.com/v3/projects/#create-an-organization-project"
 }

--- a/routes/projects/list-organization-projects.json
+++ b/routes/projects/list-organization-projects.json
@@ -42,6 +42,6 @@
     }
   ],
   "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-  "idName": "list-org",
+  "idName": "list-for-org",
   "documentationUrl": "https://developer.github.com/v3/projects/#list-organization-projects"
 }

--- a/routes/projects/list-repository-projects.json
+++ b/routes/projects/list-repository-projects.json
@@ -49,6 +49,6 @@
     }
   ],
   "description": "**Note**: The status code may also be `401` or `410`, depending on the scope of the authenticating token.",
-  "idName": "list-repo",
+  "idName": "list-for-repo",
   "documentationUrl": "https://developer.github.com/v3/projects/#list-repository-projects"
 }

--- a/routes/pulls.json
+++ b/routes/pulls.json
@@ -434,7 +434,7 @@
       }
     ],
     "description": "",
-    "idName": "get-if-merged",
+    "idName": "check-if-merged",
     "documentationUrl": "https://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged"
   },
   {
@@ -499,7 +499,7 @@
       }
     ],
     "description": "",
-    "idName": "merge-merge-button",
+    "idName": "merge",
     "documentationUrl": "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button"
   },
   {

--- a/routes/pulls/get-if-a-pull-request-has-been-merged.json
+++ b/routes/pulls/get-if-a-pull-request-has-been-merged.json
@@ -27,6 +27,6 @@
     }
   ],
   "description": "",
-  "idName": "get-if-merged",
+  "idName": "check-if-merged",
   "documentationUrl": "https://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged"
 }

--- a/routes/pulls/merge-a-pull-request-merge-button.json
+++ b/routes/pulls/merge-a-pull-request-merge-button.json
@@ -60,6 +60,6 @@
     }
   ],
   "description": "",
-  "idName": "merge-merge-button",
+  "idName": "merge",
   "documentationUrl": "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button"
 }

--- a/routes/rate-limit.json
+++ b/routes/rate-limit.json
@@ -6,7 +6,7 @@
     "path": "/rate_limit",
     "params": [],
     "description": "Note: Accessing this endpoint does not count against your rate limit.\n\n\n\n**Understanding Your Rate Limit Status**\n\nThe Search API has a [custom rate limit](https://developer.github.com/v3/search/#rate-limit), separate from the rate limit governing the rest of the API. For that reason, the response (shown above) categorizes your rate limit by resource. Within the `\"resources\"` object, the `\"search\"` object provides your rate limit status for the [Search API](https://developer.github.com/v3/search). The `\"core\"` object provides your rate limit status for all the _rest_ of the API.\n\nThe `\"rate\"` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code (or updating your existing code), you should use the `\"core\"` object instead of the `\"rate\"` object. The `\"core\"` object contains the same information that is present in the `\"rate\"` object.",
-    "idName": "get-current-rate-limit-status",
+    "idName": "get",
     "documentationUrl": "https://developer.github.com/v3/rate_limit/#get-your-current-rate-limit-status"
   }
 ]

--- a/routes/rate-limit/get-your-current-rate-limit-status.json
+++ b/routes/rate-limit/get-your-current-rate-limit-status.json
@@ -5,6 +5,6 @@
   "path": "/rate_limit",
   "params": [],
   "description": "Note: Accessing this endpoint does not count against your rate limit.\n\n\n\n**Understanding Your Rate Limit Status**\n\nThe Search API has a [custom rate limit](https://developer.github.com/v3/search/#rate-limit), separate from the rate limit governing the rest of the API. For that reason, the response (shown above) categorizes your rate limit by resource. Within the `\"resources\"` object, the `\"search\"` object provides your rate limit status for the [Search API](https://developer.github.com/v3/search). The `\"core\"` object provides your rate limit status for all the _rest_ of the API.\n\nThe `\"rate\"` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code (or updating your existing code), you should use the `\"core\"` object instead of the `\"rate\"` object. The `\"core\"` object contains the same information that is present in the `\"rate\"` object.",
-  "idName": "get-current-rate-limit-status",
+  "idName": "get",
   "documentationUrl": "https://developer.github.com/v3/rate_limit/#get-your-current-rate-limit-status"
 }

--- a/routes/repos.json
+++ b/routes/repos.json
@@ -163,7 +163,7 @@
       }
     ],
     "description": "List public repositories for the specified user.",
-    "idName": "list-user",
+    "idName": "list-for-user",
     "documentationUrl": "https://developer.github.com/v3/repos/#list-user-repositories"
   },
   {
@@ -213,7 +213,7 @@
       }
     ],
     "description": "List repositories for the specified org.",
-    "idName": "list-org",
+    "idName": "list-for-org",
     "documentationUrl": "https://developer.github.com/v3/repos/#list-organization-repositories"
   },
   {
@@ -2190,7 +2190,7 @@
       }
     ],
     "description": "Possible values for the `permission` key: `admin`, `write`, `read`, `none`.",
-    "idName": "review-user-permission-level",
+    "idName": "get-collaborator-permission-level",
     "documentationUrl": "https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level"
   },
   {
@@ -2699,7 +2699,7 @@
       }
     ],
     "description": "Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`. For example:\n\n```\nGET /repos/:owner/:repo/compare/hubot:branchname...octocat:branchname\n```\n\nThe response from the API is equivalent to running the `git log base..head` command; however, commits are returned in reverse chronological order.\n\nPass the appropriate [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.\n\n**Working with large comparisons**\n\nThe response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [Commit List API](https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository) to enumerate all commits in the range.\n\nFor comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long to generate. You can typically resolve this error by using a smaller commit range.",
-    "idName": "compare-two-commits",
+    "idName": "compare-commits",
     "documentationUrl": "https://developer.github.com/v3/repos/commits/#compare-two-commits"
   },
   {
@@ -3920,7 +3920,7 @@
       }
     ],
     "description": "When authenticating as a user, this endpoint will list all currently open repository invitations for that user.\n\n",
-    "idName": "list-user-invitations",
+    "idName": "list-invitations",
     "documentationUrl": "https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations"
   },
   {
@@ -4002,7 +4002,7 @@
       }
     ],
     "description": "",
-    "idName": "perform-merge",
+    "idName": "merge",
     "documentationUrl": "https://developer.github.com/v3/repos/merging/#perform-a-merge"
   },
   {
@@ -4027,7 +4027,7 @@
       }
     ],
     "description": "Responses during the preview period contain two additional fields:\n\n*   `html_url`: The absolute URL (with scheme) to the rendered site. For example, `https://username.github.io`.\n*   `source`: Information about the source branch and directory for the rendered site. The source field includes:\n    *   `branch`: The repo branch for [site source files](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/) For example, _master_ or _gh-pages_.\n    *   `path`: The repo directory from which the site publishes. Can be either `/` or `/docs`.",
-    "idName": "get-information-about-pages-site",
+    "idName": "get-pages",
     "documentationUrl": "https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site"
   },
   {
@@ -4959,7 +4959,7 @@
       }
     ],
     "description": "Get the top 10 referrers over the last 14 days.",
-    "idName": "list-referrers",
+    "idName": "get-top-referrers",
     "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-referrers"
   },
   {
@@ -4984,7 +4984,7 @@
       }
     ],
     "description": "Get the top 10 popular contents over the last 14 days.",
-    "idName": "list-paths",
+    "idName": "get-top-paths",
     "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-paths"
   },
   {
@@ -5021,7 +5021,7 @@
       }
     ],
     "description": "Get the total number of views and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
-    "idName": "views",
+    "idName": "get-views",
     "documentationUrl": "https://developer.github.com/v3/repos/traffic/#views"
   },
   {
@@ -5058,7 +5058,7 @@
       }
     ],
     "description": "Get the total number of clones and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
-    "idName": "clones",
+    "idName": "get-clones",
     "documentationUrl": "https://developer.github.com/v3/repos/traffic/#clones"
   },
   {

--- a/routes/repos/collaborators/review-a-users-permission-level.json
+++ b/routes/repos/collaborators/review-a-users-permission-level.json
@@ -27,6 +27,6 @@
     }
   ],
   "description": "Possible values for the `permission` key: `admin`, `write`, `read`, `none`.",
-  "idName": "review-user-permission-level",
+  "idName": "get-collaborator-permission-level",
   "documentationUrl": "https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level"
 }

--- a/routes/repos/commits/compare-two-commits.json
+++ b/routes/repos/commits/compare-two-commits.json
@@ -34,6 +34,6 @@
     }
   ],
   "description": "Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`. For example:\n\n```\nGET /repos/:owner/:repo/compare/hubot:branchname...octocat:branchname\n```\n\nThe response from the API is equivalent to running the `git log base..head` command; however, commits are returned in reverse chronological order.\n\nPass the appropriate [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.\n\n**Working with large comparisons**\n\nThe response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [Commit List API](https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository) to enumerate all commits in the range.\n\nFor comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long to generate. You can typically resolve this error by using a smaller commit range.",
-  "idName": "compare-two-commits",
+  "idName": "compare-commits",
   "documentationUrl": "https://developer.github.com/v3/repos/commits/#compare-two-commits"
 }

--- a/routes/repos/invitations/list-a-users-repository-invitations.json
+++ b/routes/repos/invitations/list-a-users-repository-invitations.json
@@ -22,6 +22,6 @@
     }
   ],
   "description": "When authenticating as a user, this endpoint will list all currently open repository invitations for that user.\n\n",
-  "idName": "list-user-invitations",
+  "idName": "list-invitations",
   "documentationUrl": "https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations"
 }

--- a/routes/repos/list-organization-repositories.json
+++ b/routes/repos/list-organization-repositories.json
@@ -45,6 +45,6 @@
     }
   ],
   "description": "List repositories for the specified org.",
-  "idName": "list-org",
+  "idName": "list-for-org",
   "documentationUrl": "https://developer.github.com/v3/repos/#list-organization-repositories"
 }

--- a/routes/repos/list-user-repositories.json
+++ b/routes/repos/list-user-repositories.json
@@ -68,6 +68,6 @@
     }
   ],
   "description": "List public repositories for the specified user.",
-  "idName": "list-user",
+  "idName": "list-for-user",
   "documentationUrl": "https://developer.github.com/v3/repos/#list-user-repositories"
 }

--- a/routes/repos/merging/perform-a-merge.json
+++ b/routes/repos/merging/perform-a-merge.json
@@ -41,6 +41,6 @@
     }
   ],
   "description": "",
-  "idName": "perform-merge",
+  "idName": "merge",
   "documentationUrl": "https://developer.github.com/v3/repos/merging/#perform-a-merge"
 }

--- a/routes/repos/pages/get-information-about-a-pages-site.json
+++ b/routes/repos/pages/get-information-about-a-pages-site.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "Responses during the preview period contain two additional fields:\n\n*   `html_url`: The absolute URL (with scheme) to the rendered site. For example, `https://username.github.io`.\n*   `source`: Information about the source branch and directory for the rendered site. The source field includes:\n    *   `branch`: The repo branch for [site source files](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/) For example, _master_ or _gh-pages_.\n    *   `path`: The repo directory from which the site publishes. Can be either `/` or `/docs`.",
-  "idName": "get-information-about-pages-site",
+  "idName": "get-pages",
   "documentationUrl": "https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site"
 }

--- a/routes/repos/traffic/clones.json
+++ b/routes/repos/traffic/clones.json
@@ -32,6 +32,6 @@
     }
   ],
   "description": "Get the total number of clones and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
-  "idName": "clones",
+  "idName": "get-clones",
   "documentationUrl": "https://developer.github.com/v3/repos/traffic/#clones"
 }

--- a/routes/repos/traffic/list-paths.json
+++ b/routes/repos/traffic/list-paths.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "Get the top 10 popular contents over the last 14 days.",
-  "idName": "list-paths",
+  "idName": "get-top-paths",
   "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-paths"
 }

--- a/routes/repos/traffic/list-referrers.json
+++ b/routes/repos/traffic/list-referrers.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "Get the top 10 referrers over the last 14 days.",
-  "idName": "list-referrers",
+  "idName": "get-top-referrers",
   "documentationUrl": "https://developer.github.com/v3/repos/traffic/#list-referrers"
 }

--- a/routes/repos/traffic/views.json
+++ b/routes/repos/traffic/views.json
@@ -32,6 +32,6 @@
     }
   ],
   "description": "Get the total number of views and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.",
-  "idName": "views",
+  "idName": "get-views",
   "documentationUrl": "https://developer.github.com/v3/repos/traffic/#views"
 }

--- a/routes/scim.json
+++ b/routes/scim.json
@@ -35,7 +35,7 @@
       }
     ],
     "description": "**Filter parameter**\n\nYou can filter results with the `id`, `userName`, `emails` and `external_id` query parameters.\n\n```\nGET /scim/v2/organizations/:organization/Users?filter=userName\n```\n\nRetrieves a paginated list of all provisioned organization members, including pending invitations.",
-    "idName": "get-provisioned-identities-list",
+    "idName": "get-provisioned-identities",
     "documentationUrl": "https://developer.github.com/v3/scim/#get-a-list-of-provisioned-identities"
   },
   {
@@ -78,7 +78,7 @@
       }
     ],
     "description": "Provision organization membership for and send activation emails to a list of email addresses.",
-    "idName": "provision-invite-users",
+    "idName": "provision-and-invite-users",
     "documentationUrl": "https://developer.github.com/v3/scim/#provision-and-invite-users"
   },
   {

--- a/routes/scim/get-a-list-of-provisioned-identities.json
+++ b/routes/scim/get-a-list-of-provisioned-identities.json
@@ -34,6 +34,6 @@
     }
   ],
   "description": "**Filter parameter**\n\nYou can filter results with the `id`, `userName`, `emails` and `external_id` query parameters.\n\n```\nGET /scim/v2/organizations/:organization/Users?filter=userName\n```\n\nRetrieves a paginated list of all provisioned organization members, including pending invitations.",
-  "idName": "get-provisioned-identities-list",
+  "idName": "get-provisioned-identities",
   "documentationUrl": "https://developer.github.com/v3/scim/#get-a-list-of-provisioned-identities"
 }

--- a/routes/scim/provision-and-invite-users.json
+++ b/routes/scim/provision-and-invite-users.json
@@ -13,6 +13,6 @@
     }
   ],
   "description": "Provision organization membership for and send activation emails to a list of email addresses.",
-  "idName": "provision-invite-users",
+  "idName": "provision-and-invite-users",
   "documentationUrl": "https://developer.github.com/v3/scim/#provision-and-invite-users"
 }

--- a/routes/teams.json
+++ b/routes/teams.json
@@ -406,7 +406,7 @@
       }
     ],
     "description": "List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) when authenticating via [OAuth](https://developer.github.com/apps/building-oauth-apps/).",
-    "idName": "list-user",
+    "idName": "list",
     "documentationUrl": "https://developer.github.com/v3/teams/#list-user-teams"
   },
   {
@@ -755,7 +755,7 @@
       }
     ],
     "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "idName": "list-comments",
+    "idName": "list-discussion-comments",
     "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#list-comments"
   },
   {
@@ -787,7 +787,7 @@
       }
     ],
     "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "idName": "get-comment",
+    "idName": "get-discussion-comment",
     "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment"
   },
   {
@@ -819,7 +819,7 @@
       }
     ],
     "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "idName": "create-comment",
+    "idName": "create-discussion-comment",
     "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#create-a-comment"
   },
   {
@@ -858,7 +858,7 @@
       }
     ],
     "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "idName": "edit-comment",
+    "idName": "edit-discussion-comment",
     "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment"
   },
   {
@@ -890,7 +890,7 @@
       }
     ],
     "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "idName": "delete-comment",
+    "idName": "delete-discussion-comment",
     "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment"
   },
   {

--- a/routes/teams/discussion-comments/create-a-comment.json
+++ b/routes/teams/discussion-comments/create-a-comment.json
@@ -27,6 +27,6 @@
     }
   ],
   "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-  "idName": "create-comment",
+  "idName": "create-discussion-comment",
   "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#create-a-comment"
 }

--- a/routes/teams/discussion-comments/delete-a-comment.json
+++ b/routes/teams/discussion-comments/delete-a-comment.json
@@ -27,6 +27,6 @@
     }
   ],
   "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-  "idName": "delete-comment",
+  "idName": "delete-discussion-comment",
   "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment"
 }

--- a/routes/teams/discussion-comments/edit-a-comment.json
+++ b/routes/teams/discussion-comments/edit-a-comment.json
@@ -34,6 +34,6 @@
     }
   ],
   "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-  "idName": "edit-comment",
+  "idName": "edit-discussion-comment",
   "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment"
 }

--- a/routes/teams/discussion-comments/get-a-single-comment.json
+++ b/routes/teams/discussion-comments/get-a-single-comment.json
@@ -27,6 +27,6 @@
     }
   ],
   "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-  "idName": "get-comment",
+  "idName": "get-discussion-comment",
   "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment"
 }

--- a/routes/teams/discussion-comments/list-comments.json
+++ b/routes/teams/discussion-comments/list-comments.json
@@ -48,6 +48,6 @@
     }
   ],
   "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-  "idName": "list-comments",
+  "idName": "list-discussion-comments",
   "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#list-comments"
 }

--- a/routes/teams/list-user-teams.json
+++ b/routes/teams/list-user-teams.json
@@ -22,6 +22,6 @@
     }
   ],
   "description": "List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) when authenticating via [OAuth](https://developer.github.com/apps/building-oauth-apps/).",
-  "idName": "list-user",
+  "idName": "list",
   "documentationUrl": "https://developer.github.com/v3/teams/#list-user-teams"
 }

--- a/routes/users.json
+++ b/routes/users.json
@@ -14,7 +14,7 @@
       }
     ],
     "description": "Provides publicly available information about someone with a GitHub account.\n\nThe `email` key in the following response is the publicly visible email address from your GitHub [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub. For more information, see [Authentication](https://developer.github.com/v3/#authentication).\n\nThe Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see \"[Emails API](https://developer.github.com/v3/users/emails/)\".",
-    "idName": "get",
+    "idName": "get-by-username",
     "documentationUrl": "https://developer.github.com/v3/users/#get-a-single-user"
   },
   {
@@ -156,7 +156,7 @@
       }
     ],
     "description": "Lists all users, in the order that they signed up on GitHub. This list includes personal user accounts and organization accounts.\n\nNote: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://developer.github.com/v3/#link-header) to get the URL for the next page of users.",
-    "idName": "get",
+    "idName": "list",
     "documentationUrl": "https://developer.github.com/v3/users/#get-all-users"
   },
   {
@@ -184,7 +184,7 @@
       }
     ],
     "description": "If the user is blocked:\n\nIf the user is not blocked:",
-    "idName": "check-whether-youve-blocked",
+    "idName": "check-blocked",
     "documentationUrl": "https://developer.github.com/v3/users/blocking/#check-whether-youve-blocked-a-user"
   },
   {
@@ -414,7 +414,7 @@
       }
     ],
     "description": "",
-    "idName": "list-who-is-following-for-user",
+    "idName": "list-following-for-user",
     "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user"
   },
   {
@@ -441,7 +441,7 @@
       }
     ],
     "description": "",
-    "idName": "list-who-is-following",
+    "idName": "list-following",
     "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user"
   },
   {
@@ -484,7 +484,7 @@
       }
     ],
     "description": "",
-    "idName": "check-one-follows-another-for-user",
+    "idName": "check-following-for-user",
     "documentationUrl": "https://developer.github.com/v3/users/followers/#check-if-one-user-follows-another"
   },
   {

--- a/routes/users/blocking/check-whether-youve-blocked-a-user.json
+++ b/routes/users/blocking/check-whether-youve-blocked-a-user.json
@@ -13,6 +13,6 @@
     }
   ],
   "description": "If the user is blocked:\n\nIf the user is not blocked:",
-  "idName": "check-whether-youve-blocked",
+  "idName": "check-blocked",
   "documentationUrl": "https://developer.github.com/v3/users/blocking/#check-whether-youve-blocked-a-user"
 }

--- a/routes/users/followers/check-if-one-user-follows-another.json
+++ b/routes/users/followers/check-if-one-user-follows-another.json
@@ -20,6 +20,6 @@
     }
   ],
   "description": "",
-  "idName": "check-one-follows-another-for-user",
+  "idName": "check-following-for-user",
   "documentationUrl": "https://developer.github.com/v3/users/followers/#check-if-one-user-follows-another"
 }

--- a/routes/users/followers/list-who-a-user-is-following.json
+++ b/routes/users/followers/list-who-a-user-is-following.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "",
-  "idName": "list-who-is-following-for-user",
+  "idName": "list-following-for-user",
   "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user"
 }

--- a/routes/users/followers/list-who-the-authenticated-user-is-following.json
+++ b/routes/users/followers/list-who-the-authenticated-user-is-following.json
@@ -22,6 +22,6 @@
     }
   ],
   "description": "",
-  "idName": "list-who-is-following",
+  "idName": "list-following",
   "documentationUrl": "https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user"
 }

--- a/routes/users/get-a-single-user.json
+++ b/routes/users/get-a-single-user.json
@@ -13,6 +13,6 @@
     }
   ],
   "description": "Provides publicly available information about someone with a GitHub account.\n\nThe `email` key in the following response is the publicly visible email address from your GitHub [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub. For more information, see [Authentication](https://developer.github.com/v3/#authentication).\n\nThe Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see \"[Emails API](https://developer.github.com/v3/users/emails/)\".",
-  "idName": "get",
+  "idName": "get-by-username",
   "documentationUrl": "https://developer.github.com/v3/users/#get-a-single-user"
 }

--- a/routes/users/get-all-users.json
+++ b/routes/users/get-all-users.json
@@ -29,6 +29,6 @@
     }
   ],
   "description": "Lists all users, in the order that they signed up on GitHub. This list includes personal user accounts and organization accounts.\n\nNote: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://developer.github.com/v3/#link-header) to get the URL for the next page of users.",
-  "idName": "get",
+  "idName": "list",
   "documentationUrl": "https://developer.github.com/v3/users/#get-all-users"
 }


### PR DESCRIPTION
Workaround for #173. Depends on #175