### PR TITLE
Tweak override for git refs endpoints

### DIFF
--- a/index.json
+++ b/index.json
@@ -3233,7 +3233,7 @@
       "documentationUrl": "https://developer.github.com/v3/git/commits/#create-a-commit"
     },
     {
-      "name": "Get a Reference",
+      "name": "Get a reference",
       "enabledForApps": true,
       "method": "GET",
       "path": "/repos/:owner/:repo/git/refs/:ref",
@@ -3266,7 +3266,7 @@
       "documentationUrl": "https://developer.github.com/v3/git/refs/#get-a-reference"
     },
     {
-      "name": "Get all References",
+      "name": "Get all references",
       "enabledForApps": true,
       "method": "GET",
       "path": "/repos/:owner/:repo/git/refs/:namespace",

--- a/lib/endpoint/overrides/v3/git/refs/get-a-reference.json
+++ b/lib/endpoint/overrides/v3/git/refs/get-a-reference.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Get a Reference",
+    "name": "Get a reference",
     "enabledForApps": true,
     "method": "GET",
     "path": "/repos/:owner/:repo/git/refs/:ref",

--- a/lib/endpoint/overrides/v3/git/refs/get-all-references.json
+++ b/lib/endpoint/overrides/v3/git/refs/get-all-references.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Get all References",
+    "name": "Get all references",
     "enabledForApps": true,
     "method": "GET",
     "path": "/repos/:owner/:repo/git/refs/:namespace",

--- a/routes/git.json
+++ b/routes/git.json
@@ -162,7 +162,7 @@
     "documentationUrl": "https://developer.github.com/v3/git/commits/#create-a-commit"
   },
   {
-    "name": "Get a Reference",
+    "name": "Get a reference",
     "enabledForApps": true,
     "method": "GET",
     "path": "/repos/:owner/:repo/git/refs/:ref",
@@ -195,7 +195,7 @@
     "documentationUrl": "https://developer.github.com/v3/git/refs/#get-a-reference"
   },
   {
-    "name": "Get all References",
+    "name": "Get all references",
     "enabledForApps": true,
     "method": "GET",
     "path": "/repos/:owner/:repo/git/refs/:namespace",

--- a/routes/git/refs/get-a-reference.json
+++ b/routes/git/refs/get-a-reference.json
@@ -1,5 +1,5 @@
 {
-  "name": "Get a Reference",
+  "name": "Get a reference",
   "enabledForApps": true,
   "method": "GET",
   "path": "/repos/:owner/:repo/git/refs/:ref",

--- a/routes/git/refs/get-all-references.json
+++ b/routes/git/refs/get-all-references.json
@@ -1,5 +1,5 @@
 {
-  "name": "Get all References",
+  "name": "Get all references",
   "enabledForApps": true,
   "method": "GET",
   "path": "/repos/:owner/:repo/git/refs/:namespace",


### PR DESCRIPTION
This changes the name to be sentence-case, instead of treating 'reference' as a
proper noun.

I tried deleting the two overrides in question instead of editing them, as I think we might not need them anymore... but then the command failed and I didn't know where to start digging so I figured I'd open the PR first so we can discuss it.

fixes #181

