### PR TITLE
fix: Location of index.json in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Downloads
 
-- All routes: [octokit.github.io/routes/index.json](https://octokit.github.io/routes/index.json)
+- All routes: [octokit.github.io/index.json](https://octokit.github.io/index.json)
 - All routes for a scope, e.g. `repos`: [octokit.github.io/routes/routes/repos.json](https://octokit.github.io/routes/routes/repos.json)
 - A single route, e.g. `GET /repos/:owner/:repo`: [octokit.github.io/routes/routes/repos/get.json](https://octokit.github.io/routes/routes/repos/get.json)
 


### PR DESCRIPTION
`index.json` is not in the `routes` directory according to the readme.

fixes #<ADD ISSUE NUMBER HERE>
