### PR TITLE
remove incorrect "id" parameter for "List deployment statuses" and "Get a single deployment status"

### DIFF
--- a/index.json
+++ b/index.json
@@ -33747,13 +33747,6 @@
           "location": "url"
         },
         {
-          "name": "id",
-          "type": "integer",
-          "description": "The deployment ID to list the statuses from.",
-          "required": true,
-          "location": "query"
-        },
-        {
           "name": "per_page",
           "type": "integer",
           "required": false,
@@ -33862,13 +33855,6 @@
           "required": true,
           "description": "",
           "location": "url"
-        },
-        {
-          "name": "id",
-          "type": "integer",
-          "description": "The deployment ID to list the statuses from.",
-          "required": true,
-          "location": "query"
         },
         {
           "name": "status_id",

--- a/lib/endpoint/overrides/workarounds.js
+++ b/lib/endpoint/overrides/workarounds.js
@@ -19,5 +19,12 @@ function workarounds (state) {
       result.name = 'Create a Pull Request from an Issue'
       result.idName = 'create-from-issue'
     }
+
+    // remove once `id` no longer listed in parameter table for
+    // 1. https://developer.github.com/v3/repos/deployments/#get-a-single-deployment-status
+    // 2. https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+    if (['Get a single deployment status', 'List deployment statuses'].includes(result.name)) {
+      result.params = result.params.filter(param => param.name !== 'id')
+    }
   })
 }

--- a/routes/repos.json
+++ b/routes/repos.json
@@ -7142,13 +7142,6 @@
         "location": "url"
       },
       {
-        "name": "id",
-        "type": "integer",
-        "description": "The deployment ID to list the statuses from.",
-        "required": true,
-        "location": "query"
-      },
-      {
         "name": "per_page",
         "type": "integer",
         "required": false,
@@ -7257,13 +7250,6 @@
         "required": true,
         "description": "",
         "location": "url"
-      },
-      {
-        "name": "id",
-        "type": "integer",
-        "description": "The deployment ID to list the statuses from.",
-        "required": true,
-        "location": "query"
       },
       {
         "name": "status_id",

--- a/routes/repos/deployments/get-a-single-deployment-status.json
+++ b/routes/repos/deployments/get-a-single-deployment-status.json
@@ -43,13 +43,6 @@
       "location": "url"
     },
     {
-      "name": "id",
-      "type": "integer",
-      "description": "The deployment ID to list the statuses from.",
-      "required": true,
-      "location": "query"
-    },
-    {
       "name": "status_id",
       "type": "integer",
       "description": "The deployment status ID.",

--- a/routes/repos/deployments/list-deployment-statuses.json
+++ b/routes/repos/deployments/list-deployment-statuses.json
@@ -38,13 +38,6 @@
       "location": "url"
     },
     {
-      "name": "id",
-      "type": "integer",
-      "description": "The deployment ID to list the statuses from.",
-      "required": true,
-      "location": "query"
-    },
-    {
       "name": "per_page",
       "type": "integer",
       "required": false,


### PR DESCRIPTION
the API Docs team is fixing that already but it’s a blocker for https://github.com/octokit/rest.js/pull/1043 so I implemented a temporary workaround