### PR TITLE
Fix preview requirements

### DIFF
--- a/index.json
+++ b/index.json
@@ -8398,7 +8398,7 @@
         {
           "name": "corsair",
           "description": "**Note:** To access the Content Attachments API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.corsair-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -14903,7 +14903,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -15085,7 +15085,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -15257,7 +15257,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -15297,7 +15297,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -15337,7 +15337,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -16150,7 +16150,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -16331,7 +16331,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -16501,7 +16501,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -16534,7 +16534,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [
@@ -16567,7 +16567,7 @@
         {
           "name": "wyandotte",
           "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-          "required": false
+          "required": true
         }
       ],
       "params": [

--- a/index.json
+++ b/index.json
@@ -17336,7 +17336,7 @@
         {
           "name": "surtur",
           "description": "**Note:** New repository creation permissions are available to preview. You can now set the `members_allowed_repository_creation_type` parameter to configure whether organization members can create repositories and the type of repositories they can create.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.surtur-preview+json\n\n```",
-          "required": true
+          "required": false
         }
       ],
       "params": [
@@ -17413,7 +17413,7 @@
         {
           "name": "surtur",
           "description": "**Note:** New repository creation permissions are available to preview. You can now set the `members_allowed_repository_creation_type` parameter to configure whether organization members can create repositories and the type of repositories they can create.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.surtur-preview+json\n\n```",
-          "required": true
+          "required": false
         }
       ],
       "params": [

--- a/lib/endpoint/overrides/workarounds.js
+++ b/lib/endpoint/overrides/workarounds.js
@@ -26,5 +26,13 @@ function workarounds (state) {
     if (['Get a single deployment status', 'List deployment statuses'].includes(result.name)) {
       result.params = result.params.filter(param => param.name !== 'id')
     }
+
+    // "surtur" preview is not required
+    // https://github.com/octokit/routes/issues/316
+    result.previews.forEach(preview => {
+      if (preview.name === 'surtur') {
+        preview.required = false
+      }
+    })
   })
 }

--- a/lib/endpoint/tags/div.alert.note-or-tip.js
+++ b/lib/endpoint/tags/div.alert.note-or-tip.js
@@ -14,7 +14,7 @@ module.exports = {
 
     const matches = text.match(REGEX_PREVIEW_ACCEPT_HEADER)
     const isAdditional = /^(\*\*Note:\*\* )?An additional/i.test(text)
-    const isRequiredForAccess = /to access (the|this) (API|endpoint)/i.test(text)
+    const isRequiredForAccess = /to access (the([^,.]*)|this) (API|endpoint)/i.test(text)
 
     if (matches) {
       // workarounds, can be removed once the wording in the docs is clarified

--- a/routes/apps.json
+++ b/routes/apps.json
@@ -709,7 +709,7 @@
       {
         "name": "corsair",
         "description": "**Note:** To access the Content Attachments API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.corsair-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [

--- a/routes/apps/create-a-content-attachment.json
+++ b/routes/apps/create-a-content-attachment.json
@@ -7,7 +7,7 @@
     {
       "name": "corsair",
       "description": "**Note:** To access the Content Attachments API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.corsair-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations.json
+++ b/routes/migrations.json
@@ -197,7 +197,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [
@@ -379,7 +379,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [
@@ -551,7 +551,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [
@@ -591,7 +591,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [
@@ -631,7 +631,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [
@@ -1444,7 +1444,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [
@@ -1625,7 +1625,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [
@@ -1795,7 +1795,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [
@@ -1828,7 +1828,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [
@@ -1861,7 +1861,7 @@
       {
         "name": "wyandotte",
         "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ],
     "params": [

--- a/routes/migrations/orgs/delete-an-organization-migration-archive.json
+++ b/routes/migrations/orgs/delete-an-organization-migration-archive.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations/orgs/download-an-organization-migration-archive.json
+++ b/routes/migrations/orgs/download-an-organization-migration-archive.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations/orgs/get-a-list-of-organization-migrations.json
+++ b/routes/migrations/orgs/get-a-list-of-organization-migrations.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations/orgs/get-the-status-of-an-organization-migration.json
+++ b/routes/migrations/orgs/get-the-status-of-an-organization-migration.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations/orgs/unlock-an-organization-repository.json
+++ b/routes/migrations/orgs/unlock-an-organization-repository.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations/users/delete-a-user-migration-archive.json
+++ b/routes/migrations/users/delete-a-user-migration-archive.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations/users/download-a-user-migration-archive.json
+++ b/routes/migrations/users/download-a-user-migration-archive.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations/users/get-a-list-of-user-migrations.json
+++ b/routes/migrations/users/get-a-list-of-user-migrations.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations/users/get-the-status-of-a-user-migration.json
+++ b/routes/migrations/users/get-the-status-of-a-user-migration.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/migrations/users/unlock-a-user-repository.json
+++ b/routes/migrations/users/unlock-a-user-repository.json
@@ -7,7 +7,7 @@
     {
       "name": "wyandotte",
       "description": "To access the Migrations API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.wyandotte-preview+json\n\n```",
-      "required": false
+      "required": true
     }
   ],
   "params": [

--- a/routes/orgs.json
+++ b/routes/orgs.json
@@ -178,7 +178,7 @@
       {
         "name": "surtur",
         "description": "**Note:** New repository creation permissions are available to preview. You can now set the `members_allowed_repository_creation_type` parameter to configure whether organization members can create repositories and the type of repositories they can create.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.surtur-preview+json\n\n```",
-        "required": true
+        "required": false
       }
     ],
     "params": [
@@ -255,7 +255,7 @@
       {
         "name": "surtur",
         "description": "**Note:** New repository creation permissions are available to preview. You can now set the `members_allowed_repository_creation_type` parameter to configure whether organization members can create repositories and the type of repositories they can create.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.surtur-preview+json\n\n```",
-        "required": true
+        "required": false
       }
     ],
     "params": [

--- a/routes/orgs/edit-an-organization.json
+++ b/routes/orgs/edit-an-organization.json
@@ -7,7 +7,7 @@
     {
       "name": "surtur",
       "description": "**Note:** New repository creation permissions are available to preview. You can now set the `members_allowed_repository_creation_type` parameter to configure whether organization members can create repositories and the type of repositories they can create.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.surtur-preview+json\n\n```",
-      "required": true
+      "required": false
     }
   ],
   "params": [

--- a/routes/orgs/get-an-organization.json
+++ b/routes/orgs/get-an-organization.json
@@ -7,7 +7,7 @@
     {
       "name": "surtur",
       "description": "**Note:** New repository creation permissions are available to preview. You can now set the `members_allowed_repository_creation_type` parameter to configure whether organization members can create repositories and the type of repositories they can create.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.surtur-preview+json\n\n```",
-      "required": true
+      "required": false
     }
   ],
   "params": [


### PR DESCRIPTION
This includes 
- `wyandotte` and `corsair` previews are now correctly marked as required
- `surtur` preview is now correctly marked as not required, via a workaround for #316