### PR TITLE
only publish route definition files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
   "description": "Machine-readable, always up-to-date GitHub REST API route specifications",
   "author": "Gregor Martynus (https://github.com/gr2m)",
   "main": "index.json",
-  "bin": {
-    "octokit-rest-routes": "bin/octokit-rest-routes.js"
-  },
   "scripts": {
     "pretest": "standard",
     "test": "tap --coverage 'test/**/*-test.js'",
@@ -49,5 +46,9 @@
     "semantic-release": "^15.1.2",
     "standard": "^12.0.0",
     "tap": "^12.0.0"
-  }
+  },
+  "files": [
+    "index.json",
+    "routes"
+  ]
 }


### PR DESCRIPTION
null

-----
[View rendered README.md](https://github.com/octokit/routes/blob/npm-files/README.md)