### PR TITLE
Fix: update GHE 'Add labels to an issue' params

### DIFF
--- a/lib/endpoint/get.js
+++ b/lib/endpoint/get.js
@@ -14,7 +14,10 @@ const toIdName = require('./to-id-name')
 async function getEndpoint (state, url) {
   const [pageUrl, id] = url.split('#')
   const { path: pagePath } = parseUrl(url)
-  const pageOverridePath = joinPath(__dirname, 'overrides', `${pagePath.replace(/\/enterprise\/[^/]+/, '')}${id}.json`)
+
+  const [, gheVersion, docPath] = pagePath.match(/^(?:\/enterprise\/([^/]+))?(.*)$/)
+
+  const pageOverridePath = joinPath(__dirname, 'overrides', `${docPath}${id}.json`)
   const pageEndpointPath = `${pagePath}${id}.html`
   let endpointHtml
 
@@ -47,7 +50,7 @@ async function getEndpoint (state, url) {
     await state.cache.writeHtml(pageEndpointPath, endpointHtml)
   }
 
-  const endpoints = await htmlToJson(endpointHtml)
+  const endpoints = await htmlToJson(endpointHtml, gheVersion)
   if (!endpoints) {
     return
   }

--- a/lib/endpoint/html-to-json.js
+++ b/lib/endpoint/html-to-json.js
@@ -12,7 +12,7 @@ const findRoutes = require('./find-routes')
 const htmlContainsEndpoint = require('./html-contains-endpoint')
 const workarounds = require('./overrides/workarounds')
 
-async function htmlToJson (html) {
+async function htmlToJson (html, gheVersion) {
   if (!htmlContainsEndpoint(html)) {
     return
   }
@@ -51,7 +51,7 @@ async function htmlToJson (html) {
   findDescription(state)
   findResponse(state)
   addTriggersNotificationFlag(state)
-  workarounds(state)
+  workarounds(state, gheVersion)
 
   return state.results
 }

--- a/lib/endpoint/overrides/workarounds.js
+++ b/lib/endpoint/overrides/workarounds.js
@@ -1,6 +1,6 @@
 module.exports = workarounds
 
-function workarounds (state) {
+function workarounds (state, gheVersion) {
   state.results.forEach(result => {
     // There are few cases when a whole page describes a single endpoint.
     // The titles on these pages don’t map well to method names, hence the overide
@@ -25,6 +25,18 @@ function workarounds (state) {
     // 2. https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
     if (['Get a single deployment status', 'List deployment statuses'].includes(result.name)) {
       result.params = result.params.filter(param => param.name !== 'id')
+    }
+
+    // https://github.com/octokit/routes/issues/332
+    if (result.name === 'Add labels to an issue' && (gheVersion === '2.13' || gheVersion === '2.14' || gheVersion === '2.15')) {
+      result.params.push({
+        'mapTo': 'input',
+        'name': 'labels',
+        'type': 'string',
+        'required': true,
+        'description': '',
+        'location': 'body'
+      })
     }
   })
 }


### PR DESCRIPTION
GHE 2.15 and earlier do not accept `{ labels }` and expect the labels array directly in the body.

fixes #332 
replace #333 (see https://github.com/octokit/routes/pull/333#discussion_r245380418)
