### PR TITLE
feat: sort routes map keys alphabetically

### DIFF
--- a/cache/api.github.com/pages.json
+++ b/cache/api.github.com/pages.json
@@ -1,29 +1,5 @@
 [
   {
-    "url": "https://developer.github.com/v3/media/",
-    "scope": "media"
-  },
-  {
-    "url": "https://developer.github.com/v3/oauth_authorizations/",
-    "scope": "oauth_authorizations"
-  },
-  {
-    "url": "https://developer.github.com/v3/auth/",
-    "scope": "auth"
-  },
-  {
-    "url": "https://developer.github.com/v3/troubleshooting/",
-    "scope": "troubleshooting"
-  },
-  {
-    "url": "https://developer.github.com/v3/previews/",
-    "scope": "previews"
-  },
-  {
-    "url": "https://developer.github.com/v3/versions/",
-    "scope": "versions"
-  },
-  {
     "url": "https://developer.github.com/v3/activity/",
     "scope": "activity"
   },
@@ -58,6 +34,34 @@
     "subScope": "watching"
   },
   {
+    "url": "https://developer.github.com/v3/apps/",
+    "scope": "apps"
+  },
+  {
+    "url": "https://developer.github.com/v3/apps/available-endpoints/",
+    "scope": "apps",
+    "subScope": "available-endpoints"
+  },
+  {
+    "url": "https://developer.github.com/v3/apps/installations/",
+    "scope": "apps",
+    "subScope": "installations"
+  },
+  {
+    "url": "https://developer.github.com/v3/apps/marketplace/",
+    "scope": "apps",
+    "subScope": "marketplace"
+  },
+  {
+    "url": "https://developer.github.com/v3/apps/permissions/",
+    "scope": "apps",
+    "subScope": "permissions"
+  },
+  {
+    "url": "https://developer.github.com/v3/auth/",
+    "scope": "auth"
+  },
+  {
     "url": "https://developer.github.com/v3/checks/",
     "scope": "checks"
   },
@@ -70,6 +74,14 @@
     "url": "https://developer.github.com/v3/checks/suites/",
     "scope": "checks",
     "subScope": "suites"
+  },
+  {
+    "url": "https://developer.github.com/v3/codes_of_conduct/",
+    "scope": "codes_of_conduct"
+  },
+  {
+    "url": "https://developer.github.com/v3/emojis/",
+    "scope": "emojis"
   },
   {
     "url": "https://developer.github.com/v3/gists/",
@@ -110,28 +122,8 @@
     "subScope": "trees"
   },
   {
-    "url": "https://developer.github.com/v3/apps/",
-    "scope": "apps"
-  },
-  {
-    "url": "https://developer.github.com/v3/apps/installations/",
-    "scope": "apps",
-    "subScope": "installations"
-  },
-  {
-    "url": "https://developer.github.com/v3/apps/permissions/",
-    "scope": "apps",
-    "subScope": "permissions"
-  },
-  {
-    "url": "https://developer.github.com/v3/apps/available-endpoints/",
-    "scope": "apps",
-    "subScope": "available-endpoints"
-  },
-  {
-    "url": "https://developer.github.com/v3/apps/marketplace/",
-    "scope": "apps",
-    "subScope": "marketplace"
+    "url": "https://developer.github.com/v3/gitignore/",
+    "scope": "gitignore"
   },
   {
     "url": "https://developer.github.com/v3/interactions/",
@@ -182,6 +174,22 @@
     "subScope": "timeline"
   },
   {
+    "url": "https://developer.github.com/v3/licenses/",
+    "scope": "licenses"
+  },
+  {
+    "url": "https://developer.github.com/v3/markdown/",
+    "scope": "markdown"
+  },
+  {
+    "url": "https://developer.github.com/v3/media/",
+    "scope": "media"
+  },
+  {
+    "url": "https://developer.github.com/v3/meta/",
+    "scope": "meta"
+  },
+  {
     "url": "https://developer.github.com/v3/migrations/",
     "scope": "migrations"
   },
@@ -205,32 +213,8 @@
     "scope": "misc"
   },
   {
-    "url": "https://developer.github.com/v3/codes_of_conduct/",
-    "scope": "codes_of_conduct"
-  },
-  {
-    "url": "https://developer.github.com/v3/emojis/",
-    "scope": "emojis"
-  },
-  {
-    "url": "https://developer.github.com/v3/gitignore/",
-    "scope": "gitignore"
-  },
-  {
-    "url": "https://developer.github.com/v3/licenses/",
-    "scope": "licenses"
-  },
-  {
-    "url": "https://developer.github.com/v3/markdown/",
-    "scope": "markdown"
-  },
-  {
-    "url": "https://developer.github.com/v3/meta/",
-    "scope": "meta"
-  },
-  {
-    "url": "https://developer.github.com/v3/rate_limit/",
-    "scope": "rate_limit"
+    "url": "https://developer.github.com/v3/oauth_authorizations/",
+    "scope": "oauth_authorizations"
   },
   {
     "url": "https://developer.github.com/v3/orgs/",
@@ -240,6 +224,11 @@
     "url": "https://developer.github.com/v3/orgs/blocking/",
     "scope": "orgs",
     "subScope": "blocking"
+  },
+  {
+    "url": "https://developer.github.com/v3/orgs/hooks/",
+    "scope": "orgs",
+    "subScope": "hooks"
   },
   {
     "url": "https://developer.github.com/v3/orgs/members/",
@@ -252,9 +241,8 @@
     "subScope": "outside_collaborators"
   },
   {
-    "url": "https://developer.github.com/v3/orgs/hooks/",
-    "scope": "orgs",
-    "subScope": "hooks"
+    "url": "https://developer.github.com/v3/previews/",
+    "scope": "previews"
   },
   {
     "url": "https://developer.github.com/v3/projects/",
@@ -280,11 +268,6 @@
     "scope": "pulls"
   },
   {
-    "url": "https://developer.github.com/v3/pulls/reviews/",
-    "scope": "pulls",
-    "subScope": "reviews"
-  },
-  {
     "url": "https://developer.github.com/v3/pulls/comments/",
     "scope": "pulls",
     "subScope": "comments"
@@ -293,6 +276,15 @@
     "url": "https://developer.github.com/v3/pulls/review_requests/",
     "scope": "pulls",
     "subScope": "review_requests"
+  },
+  {
+    "url": "https://developer.github.com/v3/pulls/reviews/",
+    "scope": "pulls",
+    "subScope": "reviews"
+  },
+  {
+    "url": "https://developer.github.com/v3/rate_limit/",
+    "scope": "rate_limit"
   },
   {
     "url": "https://developer.github.com/v3/reactions/",
@@ -333,11 +325,6 @@
     "subScope": "contents"
   },
   {
-    "url": "https://developer.github.com/v3/repos/keys/",
-    "scope": "repos",
-    "subScope": "keys"
-  },
-  {
     "url": "https://developer.github.com/v3/repos/deployments/",
     "scope": "repos",
     "subScope": "deployments"
@@ -353,9 +340,19 @@
     "subScope": "forks"
   },
   {
+    "url": "https://developer.github.com/v3/repos/hooks/",
+    "scope": "repos",
+    "subScope": "hooks"
+  },
+  {
     "url": "https://developer.github.com/v3/repos/invitations/",
     "scope": "repos",
     "subScope": "invitations"
+  },
+  {
+    "url": "https://developer.github.com/v3/repos/keys/",
+    "scope": "repos",
+    "subScope": "keys"
   },
   {
     "url": "https://developer.github.com/v3/repos/merging/",
@@ -388,9 +385,8 @@
     "subScope": "traffic"
   },
   {
-    "url": "https://developer.github.com/v3/repos/hooks/",
-    "scope": "repos",
-    "subScope": "hooks"
+    "url": "https://developer.github.com/v3/scim/",
+    "scope": "scim"
   },
   {
     "url": "https://developer.github.com/v3/search/",
@@ -406,14 +402,14 @@
     "scope": "teams"
   },
   {
-    "url": "https://developer.github.com/v3/teams/discussions/",
-    "scope": "teams",
-    "subScope": "discussions"
-  },
-  {
     "url": "https://developer.github.com/v3/teams/discussion_comments/",
     "scope": "teams",
     "subScope": "discussion_comments"
+  },
+  {
+    "url": "https://developer.github.com/v3/teams/discussions/",
+    "scope": "teams",
+    "subScope": "discussions"
   },
   {
     "url": "https://developer.github.com/v3/teams/members/",
@@ -421,8 +417,8 @@
     "subScope": "members"
   },
   {
-    "url": "https://developer.github.com/v3/scim/",
-    "scope": "scim"
+    "url": "https://developer.github.com/v3/troubleshooting/",
+    "scope": "troubleshooting"
   },
   {
     "url": "https://developer.github.com/v3/users/",
@@ -444,13 +440,17 @@
     "subScope": "followers"
   },
   {
+    "url": "https://developer.github.com/v3/users/gpg_keys/",
+    "scope": "users",
+    "subScope": "gpg_keys"
+  },
+  {
     "url": "https://developer.github.com/v3/users/keys/",
     "scope": "users",
     "subScope": "keys"
   },
   {
-    "url": "https://developer.github.com/v3/users/gpg_keys/",
-    "scope": "users",
-    "subScope": "gpg_keys"
+    "url": "https://developer.github.com/v3/versions/",
+    "scope": "versions"
   }
 ]

--- a/cache/ghe-2.13/pages.json
+++ b/cache/ghe-2.13/pages.json
@@ -1,29 +1,5 @@
 [
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/media/",
-    "scope": "media"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/",
-    "scope": "oauth_authorizations"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/auth/",
-    "scope": "auth"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/troubleshooting/",
-    "scope": "troubleshooting"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/previews/",
-    "scope": "previews"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/versions/",
-    "scope": "versions"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.13/v3/activity/",
     "scope": "activity"
   },
@@ -58,6 +34,37 @@
     "subScope": "watching"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.13/v3/apps/",
+    "scope": "apps"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/apps/available-endpoints/",
+    "scope": "apps",
+    "subScope": "available-endpoints"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/apps/installations/",
+    "scope": "apps",
+    "subScope": "installations"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/apps/permissions/",
+    "scope": "apps",
+    "subScope": "permissions"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/auth/",
+    "scope": "auth"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/codes_of_conduct/",
+    "scope": "codes_of_conduct"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/emojis/",
+    "scope": "emojis"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/",
     "scope": "enterprise-admin"
   },
@@ -87,14 +94,14 @@
     "subScope": "management_console"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/",
-    "scope": "enterprise-admin",
-    "subScope": "orgs"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/org_pre_receive_hooks/",
     "scope": "enterprise-admin",
     "subScope": "org_pre_receive_hooks"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/",
+    "scope": "enterprise-admin",
+    "subScope": "orgs"
   },
   {
     "url": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/pre_receive_environments/",
@@ -160,23 +167,8 @@
     "subScope": "trees"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/apps/",
-    "scope": "apps"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/apps/installations/",
-    "scope": "apps",
-    "subScope": "installations"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/apps/permissions/",
-    "scope": "apps",
-    "subScope": "permissions"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/apps/available-endpoints/",
-    "scope": "apps",
-    "subScope": "available-endpoints"
+    "url": "https://developer.github.com/enterprise/2.13/v3/gitignore/",
+    "scope": "gitignore"
   },
   {
     "url": "https://developer.github.com/enterprise/2.13/v3/issues/",
@@ -213,22 +205,6 @@
     "subScope": "timeline"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/misc/",
-    "scope": "misc"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/codes_of_conduct/",
-    "scope": "codes_of_conduct"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/emojis/",
-    "scope": "emojis"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.13/v3/gitignore/",
-    "scope": "gitignore"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.13/v3/licenses/",
     "scope": "licenses"
   },
@@ -237,16 +213,29 @@
     "scope": "markdown"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.13/v3/media/",
+    "scope": "media"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.13/v3/meta/",
     "scope": "meta"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/rate_limit/",
-    "scope": "rate_limit"
+    "url": "https://developer.github.com/enterprise/2.13/v3/misc/",
+    "scope": "misc"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/",
+    "scope": "oauth_authorizations"
   },
   {
     "url": "https://developer.github.com/enterprise/2.13/v3/orgs/",
     "scope": "orgs"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/",
+    "scope": "orgs",
+    "subScope": "hooks"
   },
   {
     "url": "https://developer.github.com/enterprise/2.13/v3/orgs/members/",
@@ -259,9 +248,8 @@
     "subScope": "outside_collaborators"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/",
-    "scope": "orgs",
-    "subScope": "hooks"
+    "url": "https://developer.github.com/enterprise/2.13/v3/previews/",
+    "scope": "previews"
   },
   {
     "url": "https://developer.github.com/enterprise/2.13/v3/projects/",
@@ -282,11 +270,6 @@
     "scope": "pulls"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/",
-    "scope": "pulls",
-    "subScope": "reviews"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.13/v3/pulls/comments/",
     "scope": "pulls",
     "subScope": "comments"
@@ -295,6 +278,15 @@
     "url": "https://developer.github.com/enterprise/2.13/v3/pulls/review_requests/",
     "scope": "pulls",
     "subScope": "review_requests"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/",
+    "scope": "pulls",
+    "subScope": "reviews"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/rate_limit/",
+    "scope": "rate_limit"
   },
   {
     "url": "https://developer.github.com/enterprise/2.13/v3/reactions/",
@@ -330,11 +322,6 @@
     "subScope": "contents"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/repos/keys/",
-    "scope": "repos",
-    "subScope": "keys"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.13/v3/repos/deployments/",
     "scope": "repos",
     "subScope": "deployments"
@@ -350,9 +337,19 @@
     "subScope": "forks"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/",
+    "scope": "repos",
+    "subScope": "hooks"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.13/v3/repos/invitations/",
     "scope": "repos",
     "subScope": "invitations"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/repos/keys/",
+    "scope": "repos",
+    "subScope": "keys"
   },
   {
     "url": "https://developer.github.com/enterprise/2.13/v3/repos/merging/",
@@ -380,11 +377,6 @@
     "subScope": "statuses"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/",
-    "scope": "repos",
-    "subScope": "hooks"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.13/v3/search/",
     "scope": "search"
   },
@@ -398,19 +390,23 @@
     "scope": "teams"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/teams/discussions/",
-    "scope": "teams",
-    "subScope": "discussions"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/",
     "scope": "teams",
     "subScope": "discussion_comments"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.13/v3/teams/discussions/",
+    "scope": "teams",
+    "subScope": "discussions"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.13/v3/teams/members/",
     "scope": "teams",
     "subScope": "members"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.13/v3/troubleshooting/",
+    "scope": "troubleshooting"
   },
   {
     "url": "https://developer.github.com/enterprise/2.13/v3/users/",
@@ -427,13 +423,17 @@
     "subScope": "followers"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.13/v3/users/gpg_keys/",
+    "scope": "users",
+    "subScope": "gpg_keys"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.13/v3/users/keys/",
     "scope": "users",
     "subScope": "keys"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.13/v3/users/gpg_keys/",
-    "scope": "users",
-    "subScope": "gpg_keys"
+    "url": "https://developer.github.com/enterprise/2.13/v3/versions/",
+    "scope": "versions"
   }
 ]

--- a/cache/ghe-2.14/pages.json
+++ b/cache/ghe-2.14/pages.json
@@ -1,29 +1,5 @@
 [
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/media/",
-    "scope": "media"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/",
-    "scope": "oauth_authorizations"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/auth/",
-    "scope": "auth"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/troubleshooting/",
-    "scope": "troubleshooting"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/previews/",
-    "scope": "previews"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/versions/",
-    "scope": "versions"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.14/v3/activity/",
     "scope": "activity"
   },
@@ -58,6 +34,29 @@
     "subScope": "watching"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.14/v3/apps/",
+    "scope": "apps"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/apps/available-endpoints/",
+    "scope": "apps",
+    "subScope": "available-endpoints"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/apps/installations/",
+    "scope": "apps",
+    "subScope": "installations"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/apps/permissions/",
+    "scope": "apps",
+    "subScope": "permissions"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/auth/",
+    "scope": "auth"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.14/v3/checks/",
     "scope": "checks"
   },
@@ -70,6 +69,14 @@
     "url": "https://developer.github.com/enterprise/2.14/v3/checks/suites/",
     "scope": "checks",
     "subScope": "suites"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/codes_of_conduct/",
+    "scope": "codes_of_conduct"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/emojis/",
+    "scope": "emojis"
   },
   {
     "url": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/",
@@ -101,14 +108,14 @@
     "subScope": "management_console"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/",
-    "scope": "enterprise-admin",
-    "subScope": "orgs"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/org_pre_receive_hooks/",
     "scope": "enterprise-admin",
     "subScope": "org_pre_receive_hooks"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/",
+    "scope": "enterprise-admin",
+    "subScope": "orgs"
   },
   {
     "url": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/pre_receive_environments/",
@@ -174,23 +181,8 @@
     "subScope": "trees"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/apps/",
-    "scope": "apps"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/apps/installations/",
-    "scope": "apps",
-    "subScope": "installations"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/apps/permissions/",
-    "scope": "apps",
-    "subScope": "permissions"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/apps/available-endpoints/",
-    "scope": "apps",
-    "subScope": "available-endpoints"
+    "url": "https://developer.github.com/enterprise/2.14/v3/gitignore/",
+    "scope": "gitignore"
   },
   {
     "url": "https://developer.github.com/enterprise/2.14/v3/issues/",
@@ -227,22 +219,6 @@
     "subScope": "timeline"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/misc/",
-    "scope": "misc"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/codes_of_conduct/",
-    "scope": "codes_of_conduct"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/emojis/",
-    "scope": "emojis"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.14/v3/gitignore/",
-    "scope": "gitignore"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.14/v3/licenses/",
     "scope": "licenses"
   },
@@ -251,16 +227,29 @@
     "scope": "markdown"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.14/v3/media/",
+    "scope": "media"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.14/v3/meta/",
     "scope": "meta"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/rate_limit/",
-    "scope": "rate_limit"
+    "url": "https://developer.github.com/enterprise/2.14/v3/misc/",
+    "scope": "misc"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/",
+    "scope": "oauth_authorizations"
   },
   {
     "url": "https://developer.github.com/enterprise/2.14/v3/orgs/",
     "scope": "orgs"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/",
+    "scope": "orgs",
+    "subScope": "hooks"
   },
   {
     "url": "https://developer.github.com/enterprise/2.14/v3/orgs/members/",
@@ -273,9 +262,8 @@
     "subScope": "outside_collaborators"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/",
-    "scope": "orgs",
-    "subScope": "hooks"
+    "url": "https://developer.github.com/enterprise/2.14/v3/previews/",
+    "scope": "previews"
   },
   {
     "url": "https://developer.github.com/enterprise/2.14/v3/projects/",
@@ -301,11 +289,6 @@
     "scope": "pulls"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/",
-    "scope": "pulls",
-    "subScope": "reviews"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.14/v3/pulls/comments/",
     "scope": "pulls",
     "subScope": "comments"
@@ -314,6 +297,15 @@
     "url": "https://developer.github.com/enterprise/2.14/v3/pulls/review_requests/",
     "scope": "pulls",
     "subScope": "review_requests"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/",
+    "scope": "pulls",
+    "subScope": "reviews"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/rate_limit/",
+    "scope": "rate_limit"
   },
   {
     "url": "https://developer.github.com/enterprise/2.14/v3/reactions/",
@@ -349,11 +341,6 @@
     "subScope": "contents"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/repos/keys/",
-    "scope": "repos",
-    "subScope": "keys"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.14/v3/repos/deployments/",
     "scope": "repos",
     "subScope": "deployments"
@@ -369,9 +356,19 @@
     "subScope": "forks"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/",
+    "scope": "repos",
+    "subScope": "hooks"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.14/v3/repos/invitations/",
     "scope": "repos",
     "subScope": "invitations"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/repos/keys/",
+    "scope": "repos",
+    "subScope": "keys"
   },
   {
     "url": "https://developer.github.com/enterprise/2.14/v3/repos/merging/",
@@ -399,11 +396,6 @@
     "subScope": "statuses"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/",
-    "scope": "repos",
-    "subScope": "hooks"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.14/v3/search/",
     "scope": "search"
   },
@@ -417,19 +409,23 @@
     "scope": "teams"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/teams/discussions/",
-    "scope": "teams",
-    "subScope": "discussions"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/",
     "scope": "teams",
     "subScope": "discussion_comments"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.14/v3/teams/discussions/",
+    "scope": "teams",
+    "subScope": "discussions"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.14/v3/teams/members/",
     "scope": "teams",
     "subScope": "members"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.14/v3/troubleshooting/",
+    "scope": "troubleshooting"
   },
   {
     "url": "https://developer.github.com/enterprise/2.14/v3/users/",
@@ -446,13 +442,17 @@
     "subScope": "followers"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.14/v3/users/gpg_keys/",
+    "scope": "users",
+    "subScope": "gpg_keys"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.14/v3/users/keys/",
     "scope": "users",
     "subScope": "keys"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.14/v3/users/gpg_keys/",
-    "scope": "users",
-    "subScope": "gpg_keys"
+    "url": "https://developer.github.com/enterprise/2.14/v3/versions/",
+    "scope": "versions"
   }
 ]

--- a/cache/ghe-2.15/pages.json
+++ b/cache/ghe-2.15/pages.json
@@ -1,29 +1,5 @@
 [
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/media/",
-    "scope": "media"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/",
-    "scope": "oauth_authorizations"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/auth/",
-    "scope": "auth"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/troubleshooting/",
-    "scope": "troubleshooting"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/previews/",
-    "scope": "previews"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/versions/",
-    "scope": "versions"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.15/v3/activity/",
     "scope": "activity"
   },
@@ -58,6 +34,29 @@
     "subScope": "watching"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.15/v3/apps/",
+    "scope": "apps"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/apps/available-endpoints/",
+    "scope": "apps",
+    "subScope": "available-endpoints"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/apps/installations/",
+    "scope": "apps",
+    "subScope": "installations"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/apps/permissions/",
+    "scope": "apps",
+    "subScope": "permissions"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/auth/",
+    "scope": "auth"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.15/v3/checks/",
     "scope": "checks"
   },
@@ -70,6 +69,14 @@
     "url": "https://developer.github.com/enterprise/2.15/v3/checks/suites/",
     "scope": "checks",
     "subScope": "suites"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/codes_of_conduct/",
+    "scope": "codes_of_conduct"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/emojis/",
+    "scope": "emojis"
   },
   {
     "url": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/",
@@ -101,14 +108,14 @@
     "subScope": "management_console"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/",
-    "scope": "enterprise-admin",
-    "subScope": "orgs"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/org_pre_receive_hooks/",
     "scope": "enterprise-admin",
     "subScope": "org_pre_receive_hooks"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/",
+    "scope": "enterprise-admin",
+    "subScope": "orgs"
   },
   {
     "url": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/pre_receive_environments/",
@@ -174,23 +181,8 @@
     "subScope": "trees"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/apps/",
-    "scope": "apps"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/apps/installations/",
-    "scope": "apps",
-    "subScope": "installations"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/apps/permissions/",
-    "scope": "apps",
-    "subScope": "permissions"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/apps/available-endpoints/",
-    "scope": "apps",
-    "subScope": "available-endpoints"
+    "url": "https://developer.github.com/enterprise/2.15/v3/gitignore/",
+    "scope": "gitignore"
   },
   {
     "url": "https://developer.github.com/enterprise/2.15/v3/issues/",
@@ -227,22 +219,6 @@
     "subScope": "timeline"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/misc/",
-    "scope": "misc"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/codes_of_conduct/",
-    "scope": "codes_of_conduct"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/emojis/",
-    "scope": "emojis"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.15/v3/gitignore/",
-    "scope": "gitignore"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.15/v3/licenses/",
     "scope": "licenses"
   },
@@ -251,16 +227,29 @@
     "scope": "markdown"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.15/v3/media/",
+    "scope": "media"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.15/v3/meta/",
     "scope": "meta"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/rate_limit/",
-    "scope": "rate_limit"
+    "url": "https://developer.github.com/enterprise/2.15/v3/misc/",
+    "scope": "misc"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/",
+    "scope": "oauth_authorizations"
   },
   {
     "url": "https://developer.github.com/enterprise/2.15/v3/orgs/",
     "scope": "orgs"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/",
+    "scope": "orgs",
+    "subScope": "hooks"
   },
   {
     "url": "https://developer.github.com/enterprise/2.15/v3/orgs/members/",
@@ -273,9 +262,8 @@
     "subScope": "outside_collaborators"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/",
-    "scope": "orgs",
-    "subScope": "hooks"
+    "url": "https://developer.github.com/enterprise/2.15/v3/previews/",
+    "scope": "previews"
   },
   {
     "url": "https://developer.github.com/enterprise/2.15/v3/projects/",
@@ -301,11 +289,6 @@
     "scope": "pulls"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/",
-    "scope": "pulls",
-    "subScope": "reviews"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.15/v3/pulls/comments/",
     "scope": "pulls",
     "subScope": "comments"
@@ -314,6 +297,15 @@
     "url": "https://developer.github.com/enterprise/2.15/v3/pulls/review_requests/",
     "scope": "pulls",
     "subScope": "review_requests"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/",
+    "scope": "pulls",
+    "subScope": "reviews"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/rate_limit/",
+    "scope": "rate_limit"
   },
   {
     "url": "https://developer.github.com/enterprise/2.15/v3/reactions/",
@@ -349,11 +341,6 @@
     "subScope": "contents"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/repos/keys/",
-    "scope": "repos",
-    "subScope": "keys"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.15/v3/repos/deployments/",
     "scope": "repos",
     "subScope": "deployments"
@@ -369,9 +356,19 @@
     "subScope": "forks"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/",
+    "scope": "repos",
+    "subScope": "hooks"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.15/v3/repos/invitations/",
     "scope": "repos",
     "subScope": "invitations"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/repos/keys/",
+    "scope": "repos",
+    "subScope": "keys"
   },
   {
     "url": "https://developer.github.com/enterprise/2.15/v3/repos/merging/",
@@ -399,11 +396,6 @@
     "subScope": "statuses"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/",
-    "scope": "repos",
-    "subScope": "hooks"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.15/v3/search/",
     "scope": "search"
   },
@@ -417,19 +409,23 @@
     "scope": "teams"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/teams/discussions/",
-    "scope": "teams",
-    "subScope": "discussions"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/",
     "scope": "teams",
     "subScope": "discussion_comments"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.15/v3/teams/discussions/",
+    "scope": "teams",
+    "subScope": "discussions"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.15/v3/teams/members/",
     "scope": "teams",
     "subScope": "members"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.15/v3/troubleshooting/",
+    "scope": "troubleshooting"
   },
   {
     "url": "https://developer.github.com/enterprise/2.15/v3/users/",
@@ -446,13 +442,17 @@
     "subScope": "followers"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.15/v3/users/gpg_keys/",
+    "scope": "users",
+    "subScope": "gpg_keys"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.15/v3/users/keys/",
     "scope": "users",
     "subScope": "keys"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.15/v3/users/gpg_keys/",
-    "scope": "users",
-    "subScope": "gpg_keys"
+    "url": "https://developer.github.com/enterprise/2.15/v3/versions/",
+    "scope": "versions"
   }
 ]

--- a/cache/ghe-2.16/pages.json
+++ b/cache/ghe-2.16/pages.json
@@ -1,29 +1,5 @@
 [
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/media/",
-    "scope": "media"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/",
-    "scope": "oauth_authorizations"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/auth/",
-    "scope": "auth"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/troubleshooting/",
-    "scope": "troubleshooting"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/previews/",
-    "scope": "previews"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/versions/",
-    "scope": "versions"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.16/v3/activity/",
     "scope": "activity"
   },
@@ -58,6 +34,29 @@
     "subScope": "watching"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.16/v3/apps/",
+    "scope": "apps"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/apps/available-endpoints/",
+    "scope": "apps",
+    "subScope": "available-endpoints"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/apps/installations/",
+    "scope": "apps",
+    "subScope": "installations"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/apps/permissions/",
+    "scope": "apps",
+    "subScope": "permissions"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/auth/",
+    "scope": "auth"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.16/v3/checks/",
     "scope": "checks"
   },
@@ -70,6 +69,14 @@
     "url": "https://developer.github.com/enterprise/2.16/v3/checks/suites/",
     "scope": "checks",
     "subScope": "suites"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/codes_of_conduct/",
+    "scope": "codes_of_conduct"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/emojis/",
+    "scope": "emojis"
   },
   {
     "url": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/",
@@ -101,14 +108,14 @@
     "subScope": "management_console"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/",
-    "scope": "enterprise-admin",
-    "subScope": "orgs"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/org_pre_receive_hooks/",
     "scope": "enterprise-admin",
     "subScope": "org_pre_receive_hooks"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/",
+    "scope": "enterprise-admin",
+    "subScope": "orgs"
   },
   {
     "url": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/pre_receive_environments/",
@@ -174,23 +181,8 @@
     "subScope": "trees"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/apps/",
-    "scope": "apps"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/apps/installations/",
-    "scope": "apps",
-    "subScope": "installations"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/apps/permissions/",
-    "scope": "apps",
-    "subScope": "permissions"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/apps/available-endpoints/",
-    "scope": "apps",
-    "subScope": "available-endpoints"
+    "url": "https://developer.github.com/enterprise/2.16/v3/gitignore/",
+    "scope": "gitignore"
   },
   {
     "url": "https://developer.github.com/enterprise/2.16/v3/issues/",
@@ -227,22 +219,6 @@
     "subScope": "timeline"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/misc/",
-    "scope": "misc"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/codes_of_conduct/",
-    "scope": "codes_of_conduct"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/emojis/",
-    "scope": "emojis"
-  },
-  {
-    "url": "https://developer.github.com/enterprise/2.16/v3/gitignore/",
-    "scope": "gitignore"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.16/v3/licenses/",
     "scope": "licenses"
   },
@@ -251,16 +227,29 @@
     "scope": "markdown"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.16/v3/media/",
+    "scope": "media"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.16/v3/meta/",
     "scope": "meta"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/rate_limit/",
-    "scope": "rate_limit"
+    "url": "https://developer.github.com/enterprise/2.16/v3/misc/",
+    "scope": "misc"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/",
+    "scope": "oauth_authorizations"
   },
   {
     "url": "https://developer.github.com/enterprise/2.16/v3/orgs/",
     "scope": "orgs"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/",
+    "scope": "orgs",
+    "subScope": "hooks"
   },
   {
     "url": "https://developer.github.com/enterprise/2.16/v3/orgs/members/",
@@ -273,9 +262,8 @@
     "subScope": "outside_collaborators"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/",
-    "scope": "orgs",
-    "subScope": "hooks"
+    "url": "https://developer.github.com/enterprise/2.16/v3/previews/",
+    "scope": "previews"
   },
   {
     "url": "https://developer.github.com/enterprise/2.16/v3/projects/",
@@ -301,11 +289,6 @@
     "scope": "pulls"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/",
-    "scope": "pulls",
-    "subScope": "reviews"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.16/v3/pulls/comments/",
     "scope": "pulls",
     "subScope": "comments"
@@ -314,6 +297,15 @@
     "url": "https://developer.github.com/enterprise/2.16/v3/pulls/review_requests/",
     "scope": "pulls",
     "subScope": "review_requests"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/",
+    "scope": "pulls",
+    "subScope": "reviews"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/rate_limit/",
+    "scope": "rate_limit"
   },
   {
     "url": "https://developer.github.com/enterprise/2.16/v3/reactions/",
@@ -349,11 +341,6 @@
     "subScope": "contents"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/repos/keys/",
-    "scope": "repos",
-    "subScope": "keys"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.16/v3/repos/deployments/",
     "scope": "repos",
     "subScope": "deployments"
@@ -369,9 +356,19 @@
     "subScope": "forks"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/",
+    "scope": "repos",
+    "subScope": "hooks"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.16/v3/repos/invitations/",
     "scope": "repos",
     "subScope": "invitations"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/repos/keys/",
+    "scope": "repos",
+    "subScope": "keys"
   },
   {
     "url": "https://developer.github.com/enterprise/2.16/v3/repos/merging/",
@@ -399,11 +396,6 @@
     "subScope": "statuses"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/",
-    "scope": "repos",
-    "subScope": "hooks"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.16/v3/search/",
     "scope": "search"
   },
@@ -417,19 +409,23 @@
     "scope": "teams"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/teams/discussions/",
-    "scope": "teams",
-    "subScope": "discussions"
-  },
-  {
     "url": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/",
     "scope": "teams",
     "subScope": "discussion_comments"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.16/v3/teams/discussions/",
+    "scope": "teams",
+    "subScope": "discussions"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.16/v3/teams/members/",
     "scope": "teams",
     "subScope": "members"
+  },
+  {
+    "url": "https://developer.github.com/enterprise/2.16/v3/troubleshooting/",
+    "scope": "troubleshooting"
   },
   {
     "url": "https://developer.github.com/enterprise/2.16/v3/users/",
@@ -446,13 +442,17 @@
     "subScope": "followers"
   },
   {
+    "url": "https://developer.github.com/enterprise/2.16/v3/users/gpg_keys/",
+    "scope": "users",
+    "subScope": "gpg_keys"
+  },
+  {
     "url": "https://developer.github.com/enterprise/2.16/v3/users/keys/",
     "scope": "users",
     "subScope": "keys"
   },
   {
-    "url": "https://developer.github.com/enterprise/2.16/v3/users/gpg_keys/",
-    "scope": "users",
-    "subScope": "gpg_keys"
+    "url": "https://developer.github.com/enterprise/2.16/v3/versions/",
+    "scope": "versions"
   }
 ]

--- a/lib/endpoint/overrides/deprecations.js
+++ b/lib/endpoint/overrides/deprecations.js
@@ -65,6 +65,26 @@ function deprecations (endpoints) {
     }
     endpoints.push(deprecated)
   }
+
+  // 2019-03-05 – "List all licenses" renamed to "List commonly used licenses"
+  const listLicenses = findByRoute(endpoints, 'GET /licenses')
+
+  if (listLicenses) {
+    const deprecated = Object.assign({}, listLicenses)
+    deprecated.name = 'List all licenses'
+    deprecated.idName = 'list'
+    deprecated.deprecated = {
+      date: '2019-03-05',
+      message: '"List all licenses" renamed to "List commonly used licenses"',
+      before: {
+        idName: 'list'
+      },
+      after: {
+        idName: 'list-commonly-used'
+      }
+    }
+    endpoints.push(deprecated)
+  }
 }
 
 function findByRoute (endpoints, route) {

--- a/lib/landing-page/to-pages-json.js
+++ b/lib/landing-page/to-pages-json.js
@@ -35,4 +35,5 @@ function landingPageHtmlToRoutesJson (state, html) {
 
       return true
     })
+    .sort((a, b) => a.url.localeCompare(b.url, 'en', { sensitivity: 'base' }))
 }

--- a/routes/api.github.com/index.json
+++ b/routes/api.github.com/index.json
@@ -17224,6 +17224,80 @@
       "documentationUrl": "https://developer.github.com/v3/licenses/#list-commonly-used-licenses"
     },
     {
+      "name": "List all licenses",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/licenses",
+      "previews": [],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "mit",
+              "name": "MIT License",
+              "spdx_id": "MIT",
+              "url": "https://api.github.com/licenses/mit",
+              "node_id": "MDc6TGljZW5zZW1pdA=="
+            },
+            {
+              "key": "lgpl-3.0",
+              "name": "GNU Lesser General Public License v3.0",
+              "spdx_id": "LGPL-3.0",
+              "url": "https://api.github.com/licenses/lgpl-3.0"
+            },
+            {
+              "key": "mpl-2.0",
+              "name": "Mozilla Public License 2.0",
+              "spdx_id": "MPL-2.0",
+              "url": "https://api.github.com/licenses/mpl-2.0"
+            },
+            {
+              "key": "agpl-3.0",
+              "name": "GNU Affero General Public License v3.0",
+              "spdx_id": "AGPL-3.0",
+              "url": "https://api.github.com/licenses/agpl-3.0"
+            },
+            {
+              "key": "unlicense",
+              "name": "The Unlicense",
+              "spdx_id": "Unlicense",
+              "url": "https://api.github.com/licenses/unlicense"
+            },
+            {
+              "key": "apache-2.0",
+              "name": "Apache License 2.0",
+              "spdx_id": "Apache-2.0",
+              "url": "https://api.github.com/licenses/apache-2.0"
+            },
+            {
+              "key": "gpl-3.0",
+              "name": "GNU General Public License v3.0",
+              "spdx_id": "GPL-3.0",
+              "url": "https://api.github.com/licenses/gpl-3.0"
+            }
+          ]
+        }
+      ],
+      "idName": "list",
+      "documentationUrl": "https://developer.github.com/v3/licenses/#list-commonly-used-licenses",
+      "deprecated": {
+        "date": "2019-03-05",
+        "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+        "before": {
+          "idName": "list"
+        },
+        "after": {
+          "idName": "list-commonly-used"
+        }
+      }
+    },
+    {
       "name": "Get an individual license",
       "enabledForApps": true,
       "method": "GET",

--- a/routes/api.github.com/index.json
+++ b/routes/api.github.com/index.json
@@ -1,860 +1,4 @@
 {
-  "oauthAuthorizations": [
-    {
-      "name": "List your grants",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/applications/grants/1",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "created_at": "2011-09-06T17:26:27Z",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "scopes": [
-                "public_repo"
-              ]
-            }
-          ]
-        }
-      ],
-      "idName": "list-grants",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#list-your-grants"
-    },
-    {
-      "name": "Get a single grant",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/applications/grants/1",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "created_at": "2011-09-06T17:26:27Z",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "scopes": [
-              "public_repo"
-            ]
-          }
-        }
-      ],
-      "idName": "get-grant",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-a-single-grant"
-    },
-    {
-      "name": "Delete a grant",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-grant",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#delete-a-grant"
-    },
-    {
-      "name": "List your authorizations",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/authorizations/1",
-              "scopes": [
-                "public_repo"
-              ],
-              "token": "",
-              "token_last_eight": "12345678",
-              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "note": "optional note",
-              "note_url": "http://optional/note/url",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z",
-              "fingerprint": "jklmnop12345678"
-            }
-          ]
-        }
-      ],
-      "idName": "list-authorizations",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations"
-    },
-    {
-      "name": "Get a single authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "get-authorization",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization"
-    },
-    {
-      "name": "Create a new authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_id",
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "If you need a small number of personal access tokens, implementing the [web flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).\n\nOrganizations that enforce SAML SSO require personal access tokens to be whitelisted. Read more about whitelisting tokens on the [GitHub Help site](https://help.github.com/articles/about-identity-and-access-management-with-saml-single-sign-on).",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": ""
-          }
-        }
-      ],
-      "idName": "create-authorization",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-and-fingerprint",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-fingerprint",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
-      "deprecated": {
-        "date": "2018-12-27",
-        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
-        "before": {
-          "idName": "get-or-create-authorization-for-app-fingerprint"
-        },
-        "after": {
-          "idName": "get-or-create-authorization-for-app-and-fingerprint"
-        }
-      }
-    },
-    {
-      "name": "Update an existing authorization",
-      "enabledForApps": false,
-      "method": "PATCH",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "Replaces the authorization scopes with these.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to add to this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to remove from this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "add_scopes": [
-            "repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "You can only send one of these scope keys at a time.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "update-authorization",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization"
-    },
-    {
-      "name": "Delete an authorization",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-authorization",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#delete-an-authorization"
-    },
-    {
-      "name": "Check an authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "check-authorization",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#check-an-authorization"
-    },
-    {
-      "name": "Reset an authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "reset-authorization",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization"
-    },
-    {
-      "name": "Revoke an authorization for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-authorization-for-application",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
-    },
-    {
-      "name": "Revoke a grant for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/grants/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-grant-for-application",
-      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
-    }
-  ],
   "activity": [
     {
       "name": "List public events",
@@ -2966,6 +2110,1859 @@
       ],
       "idName": "stop-watching-repo-legacy",
       "documentationUrl": "https://developer.github.com/v3/activity/watching/#stop-watching-a-repository-legacy"
+    }
+  ],
+  "apps": [
+    {
+      "name": "Get a single GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/apps/:app_slug",
+      "previews": [],
+      "params": [
+        {
+          "name": "app_slug",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-by-slug",
+      "documentationUrl": "https://developer.github.com/v3/apps/#get-a-single-github-app"
+    },
+    {
+      "name": "Get the authenticated GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-authenticated",
+      "documentationUrl": "https://developer.github.com/v3/apps/#get-the-authenticated-github-app"
+    },
+    {
+      "name": "Find installations",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "account": {
+                "login": "github",
+                "id": 1,
+                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                "url": "https://api.github.com/orgs/github",
+                "repos_url": "https://api.github.com/orgs/github/repos",
+                "events_url": "https://api.github.com/orgs/github/events",
+                "hooks_url": "https://api.github.com/orgs/github/hooks",
+                "issues_url": "https://api.github.com/orgs/github/issues",
+                "members_url": "https://api.github.com/orgs/github/members{/member}",
+                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "description": "A great organization"
+              },
+              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+              "repositories_url": "https://api.github.com/installation/repositories",
+              "html_url": "https://github.com/organizations/github/settings/installations/1",
+              "app_id": 1,
+              "target_id": 1,
+              "target_type": "Organization",
+              "permissions": {
+                "metadata": "read",
+                "contents": "read",
+                "issues": "write",
+                "single_file": "write"
+              },
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "single_file_name": "config.yml",
+              "repository_selection": "selected"
+            }
+          ],
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations",
+      "documentationUrl": "https://developer.github.com/v3/apps/#find-installations"
+    },
+    {
+      "name": "Get a single installation",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations/:installation_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "metadata": "read",
+              "contents": "read",
+              "issues": "write",
+              "single_file": "write"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "single_file_name": "config.yml",
+            "repository_selection": "selected"
+          }
+        }
+      ],
+      "idName": "get-installation",
+      "documentationUrl": "https://developer.github.com/v3/apps/#get-a-single-installation"
+    },
+    {
+      "name": "List installations for user",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 2,
+            "installations": [
+              {
+                "id": 1,
+                "account": {
+                  "login": "github",
+                  "id": 1,
+                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                  "url": "https://api.github.com/orgs/github",
+                  "repos_url": "https://api.github.com/orgs/github/repos",
+                  "events_url": "https://api.github.com/orgs/github/events",
+                  "hooks_url": "https://api.github.com/orgs/github/hooks",
+                  "issues_url": "https://api.github.com/orgs/github/issues",
+                  "members_url": "https://api.github.com/orgs/github/members{/member}",
+                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "description": "A great organization"
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              },
+              {
+                "id": 3,
+                "account": {
+                  "login": "octocat",
+                  "id": 2,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              }
+            ]
+          },
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/v3/apps/#list-installations-for-user"
+    },
+    {
+      "name": "Create a new installation token",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/app/installations/:installation_id/access_tokens",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "token": "v1.1f699f1069f60xxx",
+            "expires_at": "2016-07-11T22:14:10Z"
+          }
+        }
+      ],
+      "idName": "create-installation-token",
+      "documentationUrl": "https://developer.github.com/v3/apps/#create-a-new-installation-token"
+    },
+    {
+      "name": "Find organization installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/orgs/:org/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-org-installation",
+      "documentationUrl": "https://developer.github.com/v3/apps/#find-organization-installation"
+    },
+    {
+      "name": "Find repository installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-repo-installation",
+      "documentationUrl": "https://developer.github.com/v3/apps/#find-repository-installation"
+    },
+    {
+      "name": "Find user installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/users/:username/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 3,
+            "account": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "repository_selection": "selected",
+            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/3",
+            "app_id": 2,
+            "target_id": 1,
+            "target_type": "User",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "label"
+            ],
+            "created_at": "2018-02-22T20:51:14Z",
+            "updated_at": "2018-02-22T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-user-installation",
+      "documentationUrl": "https://developer.github.com/v3/apps/#find-user-installation"
+    },
+    {
+      "name": "Create a GitHub App from a manifest",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/app-manifests/:code/conversions",
+      "previews": [
+        {
+          "name": "fury",
+          "description": "**Note:** GitHub App Manifests are currently available for developers to preview. To access this API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.fury-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "code",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Use this endpoint to complete the handshake necessary when implementing the [GitHub App Manifest flow](https://developer.github.com/apps/building-github-apps/creating-github-apps-from-a-manifest/). When you create a GitHub App with the manifest flow, you receive a temporary `code` used to retrieve the GitHub App's `id`, `pem` (private key), and `webhook_secret`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDM6QXBwNTk=",
+            "owner": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "name": "octoapp",
+            "description": null,
+            "external_url": "https://www.example.com",
+            "html_url": "https://github.com/apps/octoapp",
+            "created_at": "2018-09-13T12:28:37Z",
+            "updated_at": "2018-09-13T12:28:37Z",
+            "webhook_secret": "e340154128314309424b7c8e90325147d99fdafa",
+            "pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAuEPzOUE+kiEH1WLiMeBytTEF856j0hOVcSUSUkZxKvqczkWM\n9vo1gDyC7ZXhdH9fKh32aapba3RSsp4ke+giSmYTk2mGR538ShSDxh0OgpJmjiKP\nX0Bj4j5sFqfXuCtl9SkH4iueivv4R53ktqM+n6hk98l6hRwC39GVIblAh2lEM4L/\n6WvYwuQXPMM5OG2Ryh2tDZ1WS5RKfgq+9ksNJ5Q9UtqtqHkO+E63N5OK9sbzpUUm\noNaOl3udTlZD3A8iqwMPVxH4SxgATBPAc+bmjk6BMJ0qIzDcVGTrqrzUiywCTLma\nszdk8GjzXtPDmuBgNn+o6s02qVGpyydgEuqmTQIDAQABAoIBACL6AvkjQVVLn8kJ\ndBYznJJ4M8ECo+YEgaFwgAHODT0zRQCCgzd+Vxl4YwHmKV2Lr+y2s0drZt8GvYva\nKOK8NYYZyi15IlwFyRXmvvykF1UBpSXluYFDH7KaVroWMgRreHcIys5LqVSIb6Bo\ngDmK0yBLPp8qR29s2b7ScZRtLaqGJiX+j55rNzrZwxHkxFHyG9OG+u9IsBElcKCP\nkYCVE8ZdYexfnKOZbgn2kZB9qu0T/Mdvki8yk3I2bI6xYO24oQmhnT36qnqWoCBX\nNuCNsBQgpYZeZET8mEAUmo9d+ABmIHIvSs005agK8xRaP4+6jYgy6WwoejJRF5yd\nNBuF7aECgYEA50nZ4FiZYV0vcJDxFYeY3kYOvVuKn8OyW+2rg7JIQTremIjv8FkE\nZnwuF9ZRxgqLxUIfKKfzp/5l5LrycNoj2YKfHKnRejxRWXqG+ZETfxxlmlRns0QG\nJ4+BYL0CoanDSeA4fuyn4Bv7cy/03TDhfg/Uq0Aeg+hhcPE/vx3ebPsCgYEAy/Pv\neDLssOSdeyIxf0Brtocg6aPXIVaLdus+bXmLg77rJIFytAZmTTW8SkkSczWtucI3\nFI1I6sei/8FdPzAl62/JDdlf7Wd9K7JIotY4TzT7Tm7QU7xpfLLYIP1bOFjN81rk\n77oOD4LsXcosB/U6s1blPJMZ6AlO2EKs10UuR1cCgYBipzuJ2ADEaOz9RLWwi0AH\nPza2Sj+c2epQD9ZivD7Zo/Sid3ZwvGeGF13JyR7kLEdmAkgsHUdu1rI7mAolXMaB\n1pdrsHureeLxGbRM6za3tzMXWv1Il7FQWoPC8ZwXvMOR1VQDv4nzq7vbbA8z8c+c\n57+8tALQHOTDOgQIzwK61QKBgERGVc0EJy4Uag+VY8J4m1ZQKBluqo7TfP6DQ7O8\nM5MX73maB/7yAX8pVO39RjrhJlYACRZNMbK+v/ckEQYdJSSKmGCVe0JrGYDuPtic\nI9+IGfSorf7KHPoMmMN6bPYQ7Gjh7a++tgRFTMEc8956Hnt4xGahy9NcglNtBpVN\n6G8jAoGBAMCh028pdzJa/xeBHLLaVB2sc0Fe7993WlsPmnVE779dAz7qMscOtXJK\nfgtriltLSSD6rTA9hUAsL/X62rY0wdXuNdijjBb/qvrx7CAV6i37NK1CjABNjsfG\nZM372Ac6zc1EqSrid2IjET1YqyIW2KGLI1R2xbQc98UGlt48OdWu\n-----END RSA PRIVATE KEY-----\n"
+          }
+        }
+      ],
+      "idName": "create-from-manifest",
+      "documentationUrl": "https://developer.github.com/v3/apps/#create-a-github-app-from-a-manifest"
+    },
+    {
+      "name": "Create a content attachment",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/content_references/:content_reference_id/attachments",
+      "previews": [
+        {
+          "name": "corsair",
+          "description": "**Note:** To access the Content Attachments API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.corsair-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "content_reference_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "description": "The title of the content attachment displayed in the body or comment of an issue or pull request.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The body text of the content attachment displayed in the body or comment of an issue or pull request. This parameter supports markdown.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "[A-1234] Error found in core/models.py file",
+          "body": "You have used an email that already exists for the user_email_uniq field.\n ## DETAILS:\n\nThe (email)=(Octocat@github.com) already exists.\n\n The error was found in core/models.py in get_or_create_user at line 62.\n\nself.save()"
+        }
+      ],
+      "description": "Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](https://developer.github.com/v3/activity/events/types/#contentreferenceevent) to create an attachment.\n\nThe app must create a content attachment within six hours of the content reference URL being posted. See \"[Using content attachments](https://developer.github.com/apps/using-content-attachments/)\" for details about content attachments.\n\nYou must use an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.\n\nThis example creates a content attachment for the domain `https://errors.ai/`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 101,
+            "title": "[A-1234] Error found in core/models.py file'",
+            "body": "You have used an email that already exists for the user_email_uniq field.\n ## DETAILS:\n\nThe (email)=(Octocat@github.com) already exists.\n\n The error was found in core/models.py in get_or_create_user at line 62.\n\n self.save()"
+          }
+        }
+      ],
+      "idName": "create-content-attachment",
+      "documentationUrl": "https://developer.github.com/v3/apps/#create-a-content-attachment"
+    },
+    {
+      "name": "List repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/installation/repositories",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0
+              }
+            ]
+          }
+        }
+      ],
+      "idName": "list-repos",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#list-repositories"
+    },
+    {
+      "name": "List repositories accessible to the user for an installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations/:installation_id/repositories",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        },
+        {
+          "name": "mercy",
+          "description": "**Note:** The `topics` property for repositories on GitHub is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "permissions": {
+                  "admin": false,
+                  "push": false,
+                  "pull": true
+                },
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0
+              }
+            ]
+          },
+          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+        }
+      ],
+      "idName": "list-installation-repos-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
+    },
+    {
+      "name": "Add repository to installation",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](https://developer.github.com/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "add-repo-to-installation",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#add-repository-to-installation"
+    },
+    {
+      "name": "Remove repository from installation",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](https://developer.github.com/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-repo-from-installation",
+      "documentationUrl": "https://developer.github.com/v3/apps/installations/#remove-repository-from-installation"
+    },
+    {
+      "name": "List all plans for your Marketplace listing",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/marketplace_listing/plans",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "url": "https://api.github.com/marketplace_listing/plans/1313",
+              "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
+              "id": 1313,
+              "number": 3,
+              "name": "Pro",
+              "description": "A professional-grade CI solution",
+              "monthly_price_in_cents": 1099,
+              "yearly_price_in_cents": 11870,
+              "price_model": "flat-rate",
+              "has_free_trial": true,
+              "unit_name": null,
+              "state": "published",
+              "bullets": [
+                "Up to 25 private repositories",
+                "11 concurrent builds"
+              ]
+            }
+          ]
+        }
+      ],
+      "idName": "list-plans",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-plans-for-your-marketplace-listing"
+    },
+    {
+      "name": "List all plans for your Marketplace listing (stubbed)",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/marketplace_listing/stubbed/plans",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "url": "https://api.github.com/marketplace_listing/plans/1313",
+              "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
+              "id": 1313,
+              "number": 3,
+              "name": "Pro",
+              "description": "A professional-grade CI solution",
+              "monthly_price_in_cents": 1099,
+              "yearly_price_in_cents": 11870,
+              "price_model": "flat-rate",
+              "has_free_trial": true,
+              "unit_name": null,
+              "state": "published",
+              "bullets": [
+                "Up to 25 private repositories",
+                "11 concurrent builds"
+              ]
+            }
+          ]
+        }
+      ],
+      "idName": "list-plans-stubbed",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-plans-for-your-marketplace-listing"
+    },
+    {
+      "name": "List all GitHub accounts (user or organization) on a specific plan",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/marketplace_listing/plans/:plan_id/accounts",
+      "previews": [],
+      "params": [
+        {
+          "name": "plan_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "sort",
+          "type": "string",
+          "description": "Sorts the GitHub accounts by the date they were created or last updated. Can be one of `created` or `updated`.",
+          "default": "created",
+          "required": false,
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "location": "query"
+        },
+        {
+          "name": "direction",
+          "type": "string",
+          "description": "To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without the `sort` parameter.",
+          "required": false,
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "location": "query"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "url": "https://api.github.com/orgs/github",
+              "type": "Organization",
+              "id": 4,
+              "login": "github",
+              "email": null,
+              "organization_billing_email": "billing@github.com",
+              "marketplace_pending_change": {
+                "effective_date": "2017-11-11T00:00:00Z",
+                "unit_count": null,
+                "id": 77,
+                "plan": {
+                  "url": "https://api.github.com/marketplace_listing/plans/1111",
+                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
+                  "id": 1111,
+                  "number": 2,
+                  "name": "Startup",
+                  "description": "A professional-grade CI solution",
+                  "monthly_price_in_cents": 699,
+                  "yearly_price_in_cents": 7870,
+                  "price_model": "flat-rate",
+                  "has_free_trial": true,
+                  "state": "published",
+                  "unit_name": null,
+                  "bullets": [
+                    "Up to 10 private repositories",
+                    "3 concurrent builds"
+                  ]
+                }
+              },
+              "marketplace_purchase": {
+                "billing_cycle": "monthly",
+                "next_billing_date": "2017-11-11T00:00:00Z",
+                "unit_count": null,
+                "on_free_trial": true,
+                "free_trial_ends_on": "2017-11-11T00:00:00Z",
+                "updated_at": "2017-11-02T01:12:12Z",
+                "plan": {
+                  "url": "https://api.github.com/marketplace_listing/plans/1313",
+                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
+                  "id": 1313,
+                  "number": 3,
+                  "name": "Pro",
+                  "description": "A professional-grade CI solution",
+                  "monthly_price_in_cents": 1099,
+                  "yearly_price_in_cents": 11870,
+                  "price_model": "flat-rate",
+                  "has_free_trial": true,
+                  "unit_name": null,
+                  "state": "published",
+                  "bullets": [
+                    "Up to 25 private repositories",
+                    "11 concurrent builds"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "list-accounts-user-or-org-on-plan",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-github-accounts-user-or-organization-on-a-specific-plan"
+    },
+    {
+      "name": "List all GitHub accounts (user or organization) on a specific plan (stubbed)",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/marketplace_listing/stubbed/plans/:plan_id/accounts",
+      "previews": [],
+      "params": [
+        {
+          "name": "plan_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "sort",
+          "type": "string",
+          "description": "Sorts the GitHub accounts by the date they were created or last updated. Can be one of `created` or `updated`.",
+          "default": "created",
+          "required": false,
+          "enum": [
+            "created",
+            "updated"
+          ],
+          "location": "query"
+        },
+        {
+          "name": "direction",
+          "type": "string",
+          "description": "To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without the `sort` parameter.",
+          "required": false,
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "location": "query"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "url": "https://api.github.com/orgs/github",
+              "type": "Organization",
+              "id": 4,
+              "login": "github",
+              "email": null,
+              "organization_billing_email": "billing@github.com",
+              "marketplace_pending_change": {
+                "effective_date": "2017-11-11T00:00:00Z",
+                "unit_count": null,
+                "id": 77,
+                "plan": {
+                  "url": "https://api.github.com/marketplace_listing/plans/1111",
+                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
+                  "id": 1111,
+                  "number": 2,
+                  "name": "Startup",
+                  "description": "A professional-grade CI solution",
+                  "monthly_price_in_cents": 699,
+                  "yearly_price_in_cents": 7870,
+                  "price_model": "flat-rate",
+                  "has_free_trial": true,
+                  "state": "published",
+                  "unit_name": null,
+                  "bullets": [
+                    "Up to 10 private repositories",
+                    "3 concurrent builds"
+                  ]
+                }
+              },
+              "marketplace_purchase": {
+                "billing_cycle": "monthly",
+                "next_billing_date": "2017-11-11T00:00:00Z",
+                "unit_count": null,
+                "on_free_trial": true,
+                "free_trial_ends_on": "2017-11-11T00:00:00Z",
+                "updated_at": "2017-11-02T01:12:12Z",
+                "plan": {
+                  "url": "https://api.github.com/marketplace_listing/plans/1313",
+                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
+                  "id": 1313,
+                  "number": 3,
+                  "name": "Pro",
+                  "description": "A professional-grade CI solution",
+                  "monthly_price_in_cents": 1099,
+                  "yearly_price_in_cents": 11870,
+                  "price_model": "flat-rate",
+                  "has_free_trial": true,
+                  "unit_name": null,
+                  "state": "published",
+                  "bullets": [
+                    "Up to 25 private repositories",
+                    "11 concurrent builds"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "list-accounts-user-or-org-on-plan-stubbed",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-github-accounts-user-or-organization-on-a-specific-plan"
+    },
+    {
+      "name": "Check if a GitHub account is associated with any Marketplace listing",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/marketplace_listing/accounts/:account_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "account_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Shows whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "url": "https://api.github.com/orgs/github",
+            "type": "Organization",
+            "id": 4,
+            "login": "github",
+            "email": null,
+            "organization_billing_email": "billing@github.com",
+            "marketplace_pending_change": {
+              "effective_date": "2017-11-11T00:00:00Z",
+              "unit_count": null,
+              "id": 77,
+              "plan": {
+                "url": "https://api.github.com/marketplace_listing/plans/1111",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
+                "id": 1111,
+                "number": 2,
+                "name": "Startup",
+                "description": "A professional-grade CI solution",
+                "monthly_price_in_cents": 699,
+                "yearly_price_in_cents": 7870,
+                "price_model": "flat-rate",
+                "has_free_trial": true,
+                "state": "published",
+                "unit_name": null,
+                "bullets": [
+                  "Up to 10 private repositories",
+                  "3 concurrent builds"
+                ]
+              }
+            },
+            "marketplace_purchase": {
+              "billing_cycle": "monthly",
+              "next_billing_date": "2017-11-11T00:00:00Z",
+              "unit_count": null,
+              "on_free_trial": true,
+              "free_trial_ends_on": "2017-11-11T00:00:00Z",
+              "updated_at": "2017-11-02T01:12:12Z",
+              "plan": {
+                "url": "https://api.github.com/marketplace_listing/plans/1313",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
+                "id": 1313,
+                "number": 3,
+                "name": "Pro",
+                "description": "A professional-grade CI solution",
+                "monthly_price_in_cents": 1099,
+                "yearly_price_in_cents": 11870,
+                "price_model": "flat-rate",
+                "has_free_trial": true,
+                "unit_name": null,
+                "state": "published",
+                "bullets": [
+                  "Up to 25 private repositories",
+                  "11 concurrent builds"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "idName": "check-account-is-associated-with-any",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#check-if-a-github-account-is-associated-with-any-marketplace-listing"
+    },
+    {
+      "name": "Check if a GitHub account is associated with any Marketplace listing (stubbed)",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/marketplace_listing/stubbed/accounts/:account_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "account_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Shows whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "url": "https://api.github.com/orgs/github",
+            "type": "Organization",
+            "id": 4,
+            "login": "github",
+            "email": null,
+            "organization_billing_email": "billing@github.com",
+            "marketplace_pending_change": {
+              "effective_date": "2017-11-11T00:00:00Z",
+              "unit_count": null,
+              "id": 77,
+              "plan": {
+                "url": "https://api.github.com/marketplace_listing/plans/1111",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
+                "id": 1111,
+                "number": 2,
+                "name": "Startup",
+                "description": "A professional-grade CI solution",
+                "monthly_price_in_cents": 699,
+                "yearly_price_in_cents": 7870,
+                "price_model": "flat-rate",
+                "has_free_trial": true,
+                "state": "published",
+                "unit_name": null,
+                "bullets": [
+                  "Up to 10 private repositories",
+                  "3 concurrent builds"
+                ]
+              }
+            },
+            "marketplace_purchase": {
+              "billing_cycle": "monthly",
+              "next_billing_date": "2017-11-11T00:00:00Z",
+              "unit_count": null,
+              "on_free_trial": true,
+              "free_trial_ends_on": "2017-11-11T00:00:00Z",
+              "updated_at": "2017-11-02T01:12:12Z",
+              "plan": {
+                "url": "https://api.github.com/marketplace_listing/plans/1313",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
+                "id": 1313,
+                "number": 3,
+                "name": "Pro",
+                "description": "A professional-grade CI solution",
+                "monthly_price_in_cents": 1099,
+                "yearly_price_in_cents": 11870,
+                "price_model": "flat-rate",
+                "has_free_trial": true,
+                "unit_name": null,
+                "state": "published",
+                "bullets": [
+                  "Up to 25 private repositories",
+                  "11 concurrent builds"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "idName": "check-account-is-associated-with-any-stubbed",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#check-if-a-github-account-is-associated-with-any-marketplace-listing"
+    },
+    {
+      "name": "Get a user's Marketplace purchases",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/marketplace_purchases",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Returns only active subscriptions. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. . OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "billing_cycle": "monthly",
+              "next_billing_date": "2017-11-11T00:00:00Z",
+              "unit_count": null,
+              "on_free_trial": true,
+              "free_trial_ends_on": "2017-11-11T00:00:00Z",
+              "updated_at": "2017-11-02T01:12:12Z",
+              "account": {
+                "login": "github",
+                "id": 4,
+                "url": "https://api.github.com/orgs/github",
+                "email": null,
+                "organization_billing_email": "billing@github.com",
+                "type": "Organization"
+              },
+              "plan": {
+                "url": "https://api.github.com/marketplace_listing/plans/1313",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
+                "id": 1313,
+                "number": 3,
+                "name": "Pro",
+                "description": "A professional-grade CI solution",
+                "monthly_price_in_cents": 1099,
+                "yearly_price_in_cents": 11870,
+                "price_model": "flat-rate",
+                "has_free_trial": true,
+                "unit_name": null,
+                "state": "published",
+                "bullets": [
+                  "Up to 25 private repositories",
+                  "11 concurrent builds"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "list-marketplace-purchases-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
+    },
+    {
+      "name": "Get a user's Marketplace purchases (stubbed)",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/marketplace_purchases/stubbed",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Returns only active subscriptions. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. . OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "billing_cycle": "monthly",
+              "next_billing_date": "2017-11-11T00:00:00Z",
+              "unit_count": null,
+              "on_free_trial": true,
+              "free_trial_ends_on": "2017-11-11T00:00:00Z",
+              "updated_at": "2017-11-02T01:12:12Z",
+              "account": {
+                "login": "github",
+                "id": 4,
+                "url": "https://api.github.com/orgs/github",
+                "email": null,
+                "organization_billing_email": "billing@github.com",
+                "type": "Organization"
+              },
+              "plan": {
+                "url": "https://api.github.com/marketplace_listing/plans/1313",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
+                "id": 1313,
+                "number": 3,
+                "name": "Pro",
+                "description": "A professional-grade CI solution",
+                "monthly_price_in_cents": 1099,
+                "yearly_price_in_cents": 11870,
+                "price_model": "flat-rate",
+                "has_free_trial": true,
+                "unit_name": null,
+                "state": "published",
+                "bullets": [
+                  "Up to 25 private repositories",
+                  "11 concurrent builds"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "list-marketplace-purchases-for-authenticated-user-stubbed",
+      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
     }
   ],
   "checks": [
@@ -5089,6 +6086,151 @@
       ],
       "idName": "rerequest-suite",
       "documentationUrl": "https://developer.github.com/v3/checks/suites/#rerequest-check-suite"
+    }
+  ],
+  "codesOfConduct": [
+    {
+      "name": "List all codes of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "citizen_code_of_conduct",
+              "name": "Citizen Code of Conduct",
+              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
+            },
+            {
+              "key": "contributor_covenant",
+              "name": "Contributor Covenant",
+              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
+            }
+          ]
+        }
+      ],
+      "idName": "list-conduct-codes",
+      "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#list-all-codes-of-conduct"
+    },
+    {
+      "name": "Get an individual code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct/:key",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-conduct-code",
+      "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
+    },
+    {
+      "name": "Get the contents of a repository's code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/community/code_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-for-repo",
+      "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
+    }
+  ],
+  "emojis": [
+    {
+      "name": "Get",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/emojis",
+      "previews": [],
+      "params": [],
+      "description": "Lists all the emojis available to use on GitHub.\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/v3/emojis/#emojis"
     }
   ],
   "gists": [
@@ -7758,791 +8900,51 @@
       "documentationUrl": "https://developer.github.com/v3/git/trees/#create-a-tree"
     }
   ],
-  "apps": [
+  "gitignore": [
     {
-      "name": "Get a single GitHub App",
+      "name": "Listing available templates",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/apps/:app_slug",
+      "path": "/gitignore/templates",
       "previews": [],
-      "params": [
-        {
-          "name": "app_slug",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
-        }
-      ],
-      "idName": "get-by-slug",
-      "documentationUrl": "https://developer.github.com/v3/apps/#get-a-single-github-app"
-    },
-    {
-      "name": "Get the authenticated GitHub App",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
       "params": [],
-      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "description": "List all templates available to pass as an option when [creating a repository](https://developer.github.com/v3/repos/#create).",
       "responses": [
         {
           "headers": {
             "status": "200 OK",
             "content-type": "application/json; charset=utf-8"
           },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
+          "body": [
+            "Actionscript",
+            "Android",
+            "AppceleratorTitanium",
+            "Autotools",
+            "Bancha",
+            "C",
+            "C++"
+          ]
         }
       ],
-      "idName": "get-authenticated",
-      "documentationUrl": "https://developer.github.com/v3/apps/#get-the-authenticated-github-app"
+      "idName": "list-templates",
+      "documentationUrl": "https://developer.github.com/v3/gitignore/#listing-available-templates"
     },
     {
-      "name": "Find installations",
+      "name": "Get a single template",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/app/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "account": {
-                "login": "github",
-                "id": 1,
-                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                "url": "https://api.github.com/orgs/github",
-                "repos_url": "https://api.github.com/orgs/github/repos",
-                "events_url": "https://api.github.com/orgs/github/events",
-                "hooks_url": "https://api.github.com/orgs/github/hooks",
-                "issues_url": "https://api.github.com/orgs/github/issues",
-                "members_url": "https://api.github.com/orgs/github/members{/member}",
-                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "description": "A great organization"
-              },
-              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-              "repositories_url": "https://api.github.com/installation/repositories",
-              "html_url": "https://github.com/organizations/github/settings/installations/1",
-              "app_id": 1,
-              "target_id": 1,
-              "target_type": "Organization",
-              "permissions": {
-                "metadata": "read",
-                "contents": "read",
-                "issues": "write",
-                "single_file": "write"
-              },
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "single_file_name": "config.yml",
-              "repository_selection": "selected"
-            }
-          ],
-          "description": "The permissions the installation has are included under the `permissions` key."
-        }
-      ],
-      "idName": "list-installations",
-      "documentationUrl": "https://developer.github.com/v3/apps/#find-installations"
-    },
-    {
-      "name": "Get a single installation",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app/installations/:installation_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "metadata": "read",
-              "contents": "read",
-              "issues": "write",
-              "single_file": "write"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "single_file_name": "config.yml",
-            "repository_selection": "selected"
-          }
-        }
-      ],
-      "idName": "get-installation",
-      "documentationUrl": "https://developer.github.com/v3/apps/#get-a-single-installation"
-    },
-    {
-      "name": "List installations for user",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "total_count": 2,
-            "installations": [
-              {
-                "id": 1,
-                "account": {
-                  "login": "github",
-                  "id": 1,
-                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                  "url": "https://api.github.com/orgs/github",
-                  "repos_url": "https://api.github.com/orgs/github/repos",
-                  "events_url": "https://api.github.com/orgs/github/events",
-                  "hooks_url": "https://api.github.com/orgs/github/hooks",
-                  "issues_url": "https://api.github.com/orgs/github/issues",
-                  "members_url": "https://api.github.com/orgs/github/members{/member}",
-                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "description": "A great organization"
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              },
-              {
-                "id": 3,
-                "account": {
-                  "login": "octocat",
-                  "id": 2,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              }
-            ]
-          },
-          "description": "The permissions the installation has are included under the `permissions` key."
-        }
-      ],
-      "idName": "list-installations-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/v3/apps/#list-installations-for-user"
-    },
-    {
-      "name": "Create a new installation token",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/app/installations/:installation_id/access_tokens",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "token": "v1.1f699f1069f60xxx",
-            "expires_at": "2016-07-11T22:14:10Z"
-          }
-        }
-      ],
-      "idName": "create-installation-token",
-      "documentationUrl": "https://developer.github.com/v3/apps/#create-a-new-installation-token"
-    },
-    {
-      "name": "Find organization installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/orgs/:org/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-org-installation",
-      "documentationUrl": "https://developer.github.com/v3/apps/#find-organization-installation"
-    },
-    {
-      "name": "Find repository installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-repo-installation",
-      "documentationUrl": "https://developer.github.com/v3/apps/#find-repository-installation"
-    },
-    {
-      "name": "Find user installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/users/:username/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 3,
-            "account": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "repository_selection": "selected",
-            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/3",
-            "app_id": 2,
-            "target_id": 1,
-            "target_type": "User",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "label"
-            ],
-            "created_at": "2018-02-22T20:51:14Z",
-            "updated_at": "2018-02-22T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-user-installation",
-      "documentationUrl": "https://developer.github.com/v3/apps/#find-user-installation"
-    },
-    {
-      "name": "Create a GitHub App from a manifest",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/app-manifests/:code/conversions",
-      "previews": [
-        {
-          "name": "fury",
-          "description": "**Note:** GitHub App Manifests are currently available for developers to preview. To access this API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.fury-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "code",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Use this endpoint to complete the handshake necessary when implementing the [GitHub App Manifest flow](https://developer.github.com/apps/building-github-apps/creating-github-apps-from-a-manifest/). When you create a GitHub App with the manifest flow, you receive a temporary `code` used to retrieve the GitHub App's `id`, `pem` (private key), and `webhook_secret`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDM6QXBwNTk=",
-            "owner": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "name": "octoapp",
-            "description": null,
-            "external_url": "https://www.example.com",
-            "html_url": "https://github.com/apps/octoapp",
-            "created_at": "2018-09-13T12:28:37Z",
-            "updated_at": "2018-09-13T12:28:37Z",
-            "webhook_secret": "e340154128314309424b7c8e90325147d99fdafa",
-            "pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAuEPzOUE+kiEH1WLiMeBytTEF856j0hOVcSUSUkZxKvqczkWM\n9vo1gDyC7ZXhdH9fKh32aapba3RSsp4ke+giSmYTk2mGR538ShSDxh0OgpJmjiKP\nX0Bj4j5sFqfXuCtl9SkH4iueivv4R53ktqM+n6hk98l6hRwC39GVIblAh2lEM4L/\n6WvYwuQXPMM5OG2Ryh2tDZ1WS5RKfgq+9ksNJ5Q9UtqtqHkO+E63N5OK9sbzpUUm\noNaOl3udTlZD3A8iqwMPVxH4SxgATBPAc+bmjk6BMJ0qIzDcVGTrqrzUiywCTLma\nszdk8GjzXtPDmuBgNn+o6s02qVGpyydgEuqmTQIDAQABAoIBACL6AvkjQVVLn8kJ\ndBYznJJ4M8ECo+YEgaFwgAHODT0zRQCCgzd+Vxl4YwHmKV2Lr+y2s0drZt8GvYva\nKOK8NYYZyi15IlwFyRXmvvykF1UBpSXluYFDH7KaVroWMgRreHcIys5LqVSIb6Bo\ngDmK0yBLPp8qR29s2b7ScZRtLaqGJiX+j55rNzrZwxHkxFHyG9OG+u9IsBElcKCP\nkYCVE8ZdYexfnKOZbgn2kZB9qu0T/Mdvki8yk3I2bI6xYO24oQmhnT36qnqWoCBX\nNuCNsBQgpYZeZET8mEAUmo9d+ABmIHIvSs005agK8xRaP4+6jYgy6WwoejJRF5yd\nNBuF7aECgYEA50nZ4FiZYV0vcJDxFYeY3kYOvVuKn8OyW+2rg7JIQTremIjv8FkE\nZnwuF9ZRxgqLxUIfKKfzp/5l5LrycNoj2YKfHKnRejxRWXqG+ZETfxxlmlRns0QG\nJ4+BYL0CoanDSeA4fuyn4Bv7cy/03TDhfg/Uq0Aeg+hhcPE/vx3ebPsCgYEAy/Pv\neDLssOSdeyIxf0Brtocg6aPXIVaLdus+bXmLg77rJIFytAZmTTW8SkkSczWtucI3\nFI1I6sei/8FdPzAl62/JDdlf7Wd9K7JIotY4TzT7Tm7QU7xpfLLYIP1bOFjN81rk\n77oOD4LsXcosB/U6s1blPJMZ6AlO2EKs10UuR1cCgYBipzuJ2ADEaOz9RLWwi0AH\nPza2Sj+c2epQD9ZivD7Zo/Sid3ZwvGeGF13JyR7kLEdmAkgsHUdu1rI7mAolXMaB\n1pdrsHureeLxGbRM6za3tzMXWv1Il7FQWoPC8ZwXvMOR1VQDv4nzq7vbbA8z8c+c\n57+8tALQHOTDOgQIzwK61QKBgERGVc0EJy4Uag+VY8J4m1ZQKBluqo7TfP6DQ7O8\nM5MX73maB/7yAX8pVO39RjrhJlYACRZNMbK+v/ckEQYdJSSKmGCVe0JrGYDuPtic\nI9+IGfSorf7KHPoMmMN6bPYQ7Gjh7a++tgRFTMEc8956Hnt4xGahy9NcglNtBpVN\n6G8jAoGBAMCh028pdzJa/xeBHLLaVB2sc0Fe7993WlsPmnVE779dAz7qMscOtXJK\nfgtriltLSSD6rTA9hUAsL/X62rY0wdXuNdijjBb/qvrx7CAV6i37NK1CjABNjsfG\nZM372Ac6zc1EqSrid2IjET1YqyIW2KGLI1R2xbQc98UGlt48OdWu\n-----END RSA PRIVATE KEY-----\n"
-          }
-        }
-      ],
-      "idName": "create-from-manifest",
-      "documentationUrl": "https://developer.github.com/v3/apps/#create-a-github-app-from-a-manifest"
-    },
-    {
-      "name": "Create a content attachment",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/content_references/:content_reference_id/attachments",
-      "previews": [
-        {
-          "name": "corsair",
-          "description": "**Note:** To access the Content Attachments API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.corsair-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "content_reference_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "title",
-          "type": "string",
-          "description": "The title of the content attachment displayed in the body or comment of an issue or pull request.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The body text of the content attachment displayed in the body or comment of an issue or pull request. This parameter supports markdown.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "[A-1234] Error found in core/models.py file",
-          "body": "You have used an email that already exists for the user_email_uniq field.\n ## DETAILS:\n\nThe (email)=(Octocat@github.com) already exists.\n\n The error was found in core/models.py in get_or_create_user at line 62.\n\nself.save()"
-        }
-      ],
-      "description": "Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](https://developer.github.com/v3/activity/events/types/#contentreferenceevent) to create an attachment.\n\nThe app must create a content attachment within six hours of the content reference URL being posted. See \"[Using content attachments](https://developer.github.com/apps/using-content-attachments/)\" for details about content attachments.\n\nYou must use an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.\n\nThis example creates a content attachment for the domain `https://errors.ai/`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 101,
-            "title": "[A-1234] Error found in core/models.py file'",
-            "body": "You have used an email that already exists for the user_email_uniq field.\n ## DETAILS:\n\nThe (email)=(Octocat@github.com) already exists.\n\n The error was found in core/models.py in get_or_create_user at line 62.\n\n self.save()"
-          }
-        }
-      ],
-      "idName": "create-content-attachment",
-      "documentationUrl": "https://developer.github.com/v3/apps/#create-a-content-attachment"
-    },
-    {
-      "name": "List repositories",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/installation/repositories",
+      "path": "/gitignore/templates/:name",
       "previews": [],
       "params": [
         {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
         }
       ],
-      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](https://developer.github.com/v3/media/) to get the raw contents.\n\n",
       "responses": [
         {
           "headers": {
@@ -8550,1065 +8952,20 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0
-              }
-            ]
+            "name": "C",
+            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
           }
-        }
-      ],
-      "idName": "list-repos",
-      "documentationUrl": "https://developer.github.com/v3/apps/installations/#list-repositories"
-    },
-    {
-      "name": "List repositories accessible to the user for an installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations/:installation_id/repositories",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
         },
-        {
-          "name": "mercy",
-          "description": "**Note:** The `topics` property for repositories on GitHub is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
-      "responses": [
         {
           "headers": {
             "status": "200 OK",
             "content-type": "application/json; charset=utf-8"
           },
-          "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "permissions": {
-                  "admin": false,
-                  "push": false,
-                  "pull": true
-                },
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0
-              }
-            ]
-          },
-          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+          "description": "Use the raw [media type](/v3/media/) to get the raw contents."
         }
       ],
-      "idName": "list-installation-repos-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
-    },
-    {
-      "name": "Add repository to installation",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](https://developer.github.com/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "add-repo-to-installation",
-      "documentationUrl": "https://developer.github.com/v3/apps/installations/#add-repository-to-installation"
-    },
-    {
-      "name": "Remove repository from installation",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](https://developer.github.com/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-repo-from-installation",
-      "documentationUrl": "https://developer.github.com/v3/apps/installations/#remove-repository-from-installation"
-    },
-    {
-      "name": "List all plans for your Marketplace listing",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/marketplace_listing/plans",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "url": "https://api.github.com/marketplace_listing/plans/1313",
-              "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-              "id": 1313,
-              "number": 3,
-              "name": "Pro",
-              "description": "A professional-grade CI solution",
-              "monthly_price_in_cents": 1099,
-              "yearly_price_in_cents": 11870,
-              "price_model": "flat-rate",
-              "has_free_trial": true,
-              "unit_name": null,
-              "state": "published",
-              "bullets": [
-                "Up to 25 private repositories",
-                "11 concurrent builds"
-              ]
-            }
-          ]
-        }
-      ],
-      "idName": "list-plans",
-      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-plans-for-your-marketplace-listing"
-    },
-    {
-      "name": "List all plans for your Marketplace listing (stubbed)",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/marketplace_listing/stubbed/plans",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "url": "https://api.github.com/marketplace_listing/plans/1313",
-              "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-              "id": 1313,
-              "number": 3,
-              "name": "Pro",
-              "description": "A professional-grade CI solution",
-              "monthly_price_in_cents": 1099,
-              "yearly_price_in_cents": 11870,
-              "price_model": "flat-rate",
-              "has_free_trial": true,
-              "unit_name": null,
-              "state": "published",
-              "bullets": [
-                "Up to 25 private repositories",
-                "11 concurrent builds"
-              ]
-            }
-          ]
-        }
-      ],
-      "idName": "list-plans-stubbed",
-      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-plans-for-your-marketplace-listing"
-    },
-    {
-      "name": "List all GitHub accounts (user or organization) on a specific plan",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/marketplace_listing/plans/:plan_id/accounts",
-      "previews": [],
-      "params": [
-        {
-          "name": "plan_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "sort",
-          "type": "string",
-          "description": "Sorts the GitHub accounts by the date they were created or last updated. Can be one of `created` or `updated`.",
-          "default": "created",
-          "required": false,
-          "enum": [
-            "created",
-            "updated"
-          ],
-          "location": "query"
-        },
-        {
-          "name": "direction",
-          "type": "string",
-          "description": "To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without the `sort` parameter.",
-          "required": false,
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "location": "query"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "url": "https://api.github.com/orgs/github",
-              "type": "Organization",
-              "id": 4,
-              "login": "github",
-              "email": null,
-              "organization_billing_email": "billing@github.com",
-              "marketplace_pending_change": {
-                "effective_date": "2017-11-11T00:00:00Z",
-                "unit_count": null,
-                "id": 77,
-                "plan": {
-                  "url": "https://api.github.com/marketplace_listing/plans/1111",
-                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
-                  "id": 1111,
-                  "number": 2,
-                  "name": "Startup",
-                  "description": "A professional-grade CI solution",
-                  "monthly_price_in_cents": 699,
-                  "yearly_price_in_cents": 7870,
-                  "price_model": "flat-rate",
-                  "has_free_trial": true,
-                  "state": "published",
-                  "unit_name": null,
-                  "bullets": [
-                    "Up to 10 private repositories",
-                    "3 concurrent builds"
-                  ]
-                }
-              },
-              "marketplace_purchase": {
-                "billing_cycle": "monthly",
-                "next_billing_date": "2017-11-11T00:00:00Z",
-                "unit_count": null,
-                "on_free_trial": true,
-                "free_trial_ends_on": "2017-11-11T00:00:00Z",
-                "updated_at": "2017-11-02T01:12:12Z",
-                "plan": {
-                  "url": "https://api.github.com/marketplace_listing/plans/1313",
-                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                  "id": 1313,
-                  "number": 3,
-                  "name": "Pro",
-                  "description": "A professional-grade CI solution",
-                  "monthly_price_in_cents": 1099,
-                  "yearly_price_in_cents": 11870,
-                  "price_model": "flat-rate",
-                  "has_free_trial": true,
-                  "unit_name": null,
-                  "state": "published",
-                  "bullets": [
-                    "Up to 25 private repositories",
-                    "11 concurrent builds"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "list-accounts-user-or-org-on-plan",
-      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-github-accounts-user-or-organization-on-a-specific-plan"
-    },
-    {
-      "name": "List all GitHub accounts (user or organization) on a specific plan (stubbed)",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/marketplace_listing/stubbed/plans/:plan_id/accounts",
-      "previews": [],
-      "params": [
-        {
-          "name": "plan_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "sort",
-          "type": "string",
-          "description": "Sorts the GitHub accounts by the date they were created or last updated. Can be one of `created` or `updated`.",
-          "default": "created",
-          "required": false,
-          "enum": [
-            "created",
-            "updated"
-          ],
-          "location": "query"
-        },
-        {
-          "name": "direction",
-          "type": "string",
-          "description": "To return the oldest accounts first, set to `asc`. Can be one of `asc` or `desc`. Ignored without the `sort` parameter.",
-          "required": false,
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "location": "query"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "url": "https://api.github.com/orgs/github",
-              "type": "Organization",
-              "id": 4,
-              "login": "github",
-              "email": null,
-              "organization_billing_email": "billing@github.com",
-              "marketplace_pending_change": {
-                "effective_date": "2017-11-11T00:00:00Z",
-                "unit_count": null,
-                "id": 77,
-                "plan": {
-                  "url": "https://api.github.com/marketplace_listing/plans/1111",
-                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
-                  "id": 1111,
-                  "number": 2,
-                  "name": "Startup",
-                  "description": "A professional-grade CI solution",
-                  "monthly_price_in_cents": 699,
-                  "yearly_price_in_cents": 7870,
-                  "price_model": "flat-rate",
-                  "has_free_trial": true,
-                  "state": "published",
-                  "unit_name": null,
-                  "bullets": [
-                    "Up to 10 private repositories",
-                    "3 concurrent builds"
-                  ]
-                }
-              },
-              "marketplace_purchase": {
-                "billing_cycle": "monthly",
-                "next_billing_date": "2017-11-11T00:00:00Z",
-                "unit_count": null,
-                "on_free_trial": true,
-                "free_trial_ends_on": "2017-11-11T00:00:00Z",
-                "updated_at": "2017-11-02T01:12:12Z",
-                "plan": {
-                  "url": "https://api.github.com/marketplace_listing/plans/1313",
-                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                  "id": 1313,
-                  "number": 3,
-                  "name": "Pro",
-                  "description": "A professional-grade CI solution",
-                  "monthly_price_in_cents": 1099,
-                  "yearly_price_in_cents": 11870,
-                  "price_model": "flat-rate",
-                  "has_free_trial": true,
-                  "unit_name": null,
-                  "state": "published",
-                  "bullets": [
-                    "Up to 25 private repositories",
-                    "11 concurrent builds"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "list-accounts-user-or-org-on-plan-stubbed",
-      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#list-all-github-accounts-user-or-organization-on-a-specific-plan"
-    },
-    {
-      "name": "Check if a GitHub account is associated with any Marketplace listing",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/marketplace_listing/accounts/:account_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "account_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Shows whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "url": "https://api.github.com/orgs/github",
-            "type": "Organization",
-            "id": 4,
-            "login": "github",
-            "email": null,
-            "organization_billing_email": "billing@github.com",
-            "marketplace_pending_change": {
-              "effective_date": "2017-11-11T00:00:00Z",
-              "unit_count": null,
-              "id": 77,
-              "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1111",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
-                "id": 1111,
-                "number": 2,
-                "name": "Startup",
-                "description": "A professional-grade CI solution",
-                "monthly_price_in_cents": 699,
-                "yearly_price_in_cents": 7870,
-                "price_model": "flat-rate",
-                "has_free_trial": true,
-                "state": "published",
-                "unit_name": null,
-                "bullets": [
-                  "Up to 10 private repositories",
-                  "3 concurrent builds"
-                ]
-              }
-            },
-            "marketplace_purchase": {
-              "billing_cycle": "monthly",
-              "next_billing_date": "2017-11-11T00:00:00Z",
-              "unit_count": null,
-              "on_free_trial": true,
-              "free_trial_ends_on": "2017-11-11T00:00:00Z",
-              "updated_at": "2017-11-02T01:12:12Z",
-              "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1313",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                "id": 1313,
-                "number": 3,
-                "name": "Pro",
-                "description": "A professional-grade CI solution",
-                "monthly_price_in_cents": 1099,
-                "yearly_price_in_cents": 11870,
-                "price_model": "flat-rate",
-                "has_free_trial": true,
-                "unit_name": null,
-                "state": "published",
-                "bullets": [
-                  "Up to 25 private repositories",
-                  "11 concurrent builds"
-                ]
-              }
-            }
-          }
-        }
-      ],
-      "idName": "check-account-is-associated-with-any",
-      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#check-if-a-github-account-is-associated-with-any-marketplace-listing"
-    },
-    {
-      "name": "Check if a GitHub account is associated with any Marketplace listing (stubbed)",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/marketplace_listing/stubbed/accounts/:account_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "account_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Shows whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "url": "https://api.github.com/orgs/github",
-            "type": "Organization",
-            "id": 4,
-            "login": "github",
-            "email": null,
-            "organization_billing_email": "billing@github.com",
-            "marketplace_pending_change": {
-              "effective_date": "2017-11-11T00:00:00Z",
-              "unit_count": null,
-              "id": 77,
-              "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1111",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
-                "id": 1111,
-                "number": 2,
-                "name": "Startup",
-                "description": "A professional-grade CI solution",
-                "monthly_price_in_cents": 699,
-                "yearly_price_in_cents": 7870,
-                "price_model": "flat-rate",
-                "has_free_trial": true,
-                "state": "published",
-                "unit_name": null,
-                "bullets": [
-                  "Up to 10 private repositories",
-                  "3 concurrent builds"
-                ]
-              }
-            },
-            "marketplace_purchase": {
-              "billing_cycle": "monthly",
-              "next_billing_date": "2017-11-11T00:00:00Z",
-              "unit_count": null,
-              "on_free_trial": true,
-              "free_trial_ends_on": "2017-11-11T00:00:00Z",
-              "updated_at": "2017-11-02T01:12:12Z",
-              "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1313",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                "id": 1313,
-                "number": 3,
-                "name": "Pro",
-                "description": "A professional-grade CI solution",
-                "monthly_price_in_cents": 1099,
-                "yearly_price_in_cents": 11870,
-                "price_model": "flat-rate",
-                "has_free_trial": true,
-                "unit_name": null,
-                "state": "published",
-                "bullets": [
-                  "Up to 25 private repositories",
-                  "11 concurrent builds"
-                ]
-              }
-            }
-          }
-        }
-      ],
-      "idName": "check-account-is-associated-with-any-stubbed",
-      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#check-if-a-github-account-is-associated-with-any-marketplace-listing"
-    },
-    {
-      "name": "Get a user's Marketplace purchases",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/marketplace_purchases",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Returns only active subscriptions. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. . OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "billing_cycle": "monthly",
-              "next_billing_date": "2017-11-11T00:00:00Z",
-              "unit_count": null,
-              "on_free_trial": true,
-              "free_trial_ends_on": "2017-11-11T00:00:00Z",
-              "updated_at": "2017-11-02T01:12:12Z",
-              "account": {
-                "login": "github",
-                "id": 4,
-                "url": "https://api.github.com/orgs/github",
-                "email": null,
-                "organization_billing_email": "billing@github.com",
-                "type": "Organization"
-              },
-              "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1313",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                "id": 1313,
-                "number": 3,
-                "name": "Pro",
-                "description": "A professional-grade CI solution",
-                "monthly_price_in_cents": 1099,
-                "yearly_price_in_cents": 11870,
-                "price_model": "flat-rate",
-                "has_free_trial": true,
-                "unit_name": null,
-                "state": "published",
-                "bullets": [
-                  "Up to 25 private repositories",
-                  "11 concurrent builds"
-                ]
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "list-marketplace-purchases-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
-    },
-    {
-      "name": "Get a user's Marketplace purchases (stubbed)",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/marketplace_purchases/stubbed",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Returns only active subscriptions. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. . OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "billing_cycle": "monthly",
-              "next_billing_date": "2017-11-11T00:00:00Z",
-              "unit_count": null,
-              "on_free_trial": true,
-              "free_trial_ends_on": "2017-11-11T00:00:00Z",
-              "updated_at": "2017-11-02T01:12:12Z",
-              "account": {
-                "login": "github",
-                "id": 4,
-                "url": "https://api.github.com/orgs/github",
-                "email": null,
-                "organization_billing_email": "billing@github.com",
-                "type": "Organization"
-              },
-              "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1313",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                "id": 1313,
-                "number": 3,
-                "name": "Pro",
-                "description": "A professional-grade CI solution",
-                "monthly_price_in_cents": 1099,
-                "yearly_price_in_cents": 11870,
-                "price_model": "flat-rate",
-                "has_free_trial": true,
-                "unit_name": null,
-                "state": "published",
-                "bullets": [
-                  "Up to 25 private repositories",
-                  "11 concurrent builds"
-                ]
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "list-marketplace-purchases-for-authenticated-user-stubbed",
-      "documentationUrl": "https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases"
+      "idName": "get-template",
+      "documentationUrl": "https://developer.github.com/v3/gitignore/#get-a-single-template"
     }
   ],
   "interactions": [
@@ -15050,6 +14407,378 @@
       "documentationUrl": "https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue"
     }
   ],
+  "licenses": [
+    {
+      "name": "List commonly used licenses",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/licenses",
+      "previews": [],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "mit",
+              "name": "MIT License",
+              "spdx_id": "MIT",
+              "url": "https://api.github.com/licenses/mit",
+              "node_id": "MDc6TGljZW5zZW1pdA=="
+            },
+            {
+              "key": "lgpl-3.0",
+              "name": "GNU Lesser General Public License v3.0",
+              "spdx_id": "LGPL-3.0",
+              "url": "https://api.github.com/licenses/lgpl-3.0"
+            },
+            {
+              "key": "mpl-2.0",
+              "name": "Mozilla Public License 2.0",
+              "spdx_id": "MPL-2.0",
+              "url": "https://api.github.com/licenses/mpl-2.0"
+            },
+            {
+              "key": "agpl-3.0",
+              "name": "GNU Affero General Public License v3.0",
+              "spdx_id": "AGPL-3.0",
+              "url": "https://api.github.com/licenses/agpl-3.0"
+            },
+            {
+              "key": "unlicense",
+              "name": "The Unlicense",
+              "spdx_id": "Unlicense",
+              "url": "https://api.github.com/licenses/unlicense"
+            },
+            {
+              "key": "apache-2.0",
+              "name": "Apache License 2.0",
+              "spdx_id": "Apache-2.0",
+              "url": "https://api.github.com/licenses/apache-2.0"
+            },
+            {
+              "key": "gpl-3.0",
+              "name": "GNU General Public License v3.0",
+              "spdx_id": "GPL-3.0",
+              "url": "https://api.github.com/licenses/gpl-3.0"
+            }
+          ]
+        }
+      ],
+      "idName": "list-commonly-used",
+      "documentationUrl": "https://developer.github.com/v3/licenses/#list-commonly-used-licenses"
+    },
+    {
+      "name": "List all licenses",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/licenses",
+      "previews": [],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "mit",
+              "name": "MIT License",
+              "spdx_id": "MIT",
+              "url": "https://api.github.com/licenses/mit",
+              "node_id": "MDc6TGljZW5zZW1pdA=="
+            },
+            {
+              "key": "lgpl-3.0",
+              "name": "GNU Lesser General Public License v3.0",
+              "spdx_id": "LGPL-3.0",
+              "url": "https://api.github.com/licenses/lgpl-3.0"
+            },
+            {
+              "key": "mpl-2.0",
+              "name": "Mozilla Public License 2.0",
+              "spdx_id": "MPL-2.0",
+              "url": "https://api.github.com/licenses/mpl-2.0"
+            },
+            {
+              "key": "agpl-3.0",
+              "name": "GNU Affero General Public License v3.0",
+              "spdx_id": "AGPL-3.0",
+              "url": "https://api.github.com/licenses/agpl-3.0"
+            },
+            {
+              "key": "unlicense",
+              "name": "The Unlicense",
+              "spdx_id": "Unlicense",
+              "url": "https://api.github.com/licenses/unlicense"
+            },
+            {
+              "key": "apache-2.0",
+              "name": "Apache License 2.0",
+              "spdx_id": "Apache-2.0",
+              "url": "https://api.github.com/licenses/apache-2.0"
+            },
+            {
+              "key": "gpl-3.0",
+              "name": "GNU General Public License v3.0",
+              "spdx_id": "GPL-3.0",
+              "url": "https://api.github.com/licenses/gpl-3.0"
+            }
+          ]
+        }
+      ],
+      "idName": "list",
+      "documentationUrl": "https://developer.github.com/v3/licenses/#list-commonly-used-licenses",
+      "deprecated": {
+        "date": "2019-03-05",
+        "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+        "before": {
+          "idName": "list"
+        },
+        "after": {
+          "idName": "list-commonly-used"
+        }
+      }
+    },
+    {
+      "name": "Get an individual license",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/licenses/:license",
+      "previews": [],
+      "params": [
+        {
+          "name": "license",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "mit",
+            "name": "MIT License",
+            "spdx_id": "MIT",
+            "url": "https://api.github.com/licenses/mit",
+            "node_id": "MDc6TGljZW5zZW1pdA==",
+            "html_url": "http://choosealicense.com/licenses/mit/",
+            "description": "A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty.",
+            "implementation": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.",
+            "permissions": [
+              "commercial-use",
+              "modifications",
+              "distribution",
+              "sublicense",
+              "private-use"
+            ],
+            "conditions": [
+              "include-copyright"
+            ],
+            "limitations": [
+              "no-liability"
+            ],
+            "body": "\n\nThe MIT License (MIT)\n\nCopyright (c) [year] [fullname]\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n",
+            "featured": true
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/v3/licenses/#get-an-individual-license"
+    },
+    {
+      "name": "Get the contents of a repository's license",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/license",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This method returns the contents of the repository's license file, if one is detected.\n\nSimilar to [the repository contents API](https://developer.github.com/v3/repos/contents/#get-contents), this method also supports [custom media types](https://developer.github.com/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "name": "LICENSE",
+            "path": "LICENSE",
+            "sha": "401c59dcc4570b954dd6d345e76199e1f4e76266",
+            "size": 1077,
+            "url": "https://api.github.com/repos/benbalter/gman/contents/LICENSE?ref=master",
+            "html_url": "https://github.com/benbalter/gman/blob/master/LICENSE",
+            "git_url": "https://api.github.com/repos/benbalter/gman/git/blobs/401c59dcc4570b954dd6d345e76199e1f4e76266",
+            "download_url": "https://raw.githubusercontent.com/benbalter/gman/master/LICENSE?lab=true",
+            "type": "file",
+            "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIDIwMTMgQmVu\nIEJhbHRlcgoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBv\nZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZgp0\naGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmls\nZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8gZGVhbCBpbgp0aGUgU29mdHdhcmUg\nd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRh\ndGlvbiB0aGUgcmlnaHRzIHRvCnVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwg\ncHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yIHNlbGwg\nY29waWVzIG9mCnRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25z\nIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywK\nc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJv\ndmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGlj\nZSBzaGFsbCBiZSBpbmNsdWRlZCBpbiBhbGwKY29waWVzIG9yIHN1YnN0YW50\naWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJ\nUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBL\nSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJ\nTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLCBG\nSVRORVNTCkZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklO\nR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUgQVVUSE9SUyBPUgpDT1BZ\nUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdF\nUyBPUiBPVEhFUiBMSUFCSUxJVFksIFdIRVRIRVIKSU4gQU4gQUNUSU9OIE9G\nIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORyBGUk9NLCBP\nVVQgT0YgT1IgSU4KQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBU\nSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTIElOIFRIRSBTT0ZUV0FSRS4K\n",
+            "encoding": "base64",
+            "_links": {
+              "self": "https://api.github.com/repos/benbalter/gman/contents/LICENSE?ref=master",
+              "git": "https://api.github.com/repos/benbalter/gman/git/blobs/401c59dcc4570b954dd6d345e76199e1f4e76266",
+              "html": "https://github.com/benbalter/gman/blob/master/LICENSE"
+            },
+            "license": {
+              "key": "mit",
+              "name": "MIT License",
+              "spdx_id": "MIT",
+              "url": "https://api.github.com/licenses/mit",
+              "node_id": "MDc6TGljZW5zZW1pdA=="
+            }
+          }
+        }
+      ],
+      "idName": "get-for-repo",
+      "documentationUrl": "https://developer.github.com/v3/licenses/#get-the-contents-of-a-repositorys-license"
+    }
+  ],
+  "markdown": [
+    {
+      "name": "Render an arbitrary Markdown document",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/markdown",
+      "previews": [],
+      "params": [
+        {
+          "name": "text",
+          "type": "string",
+          "description": "The Markdown text to render in HTML. Markdown content must be 400 KB or less.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "mode",
+          "type": "string",
+          "description": "The rendering mode. Can be either:  \n\\* `markdown` to render a document in plain Markdown, just like README.md files are rendered.  \n\\* `gfm` to render a document in [GitHub Flavored Markdown](https://github.github.com/gfm/), which creates links for user mentions as well as references to SHA-1 hashes, issues, and pull requests.",
+          "default": "markdown",
+          "required": false,
+          "enum": [
+            "markdown",
+            "gfm"
+          ],
+          "location": "body"
+        },
+        {
+          "name": "context",
+          "type": "string",
+          "description": "The repository context to use when creating references in `gfm` mode. Omit this parameter when using `markdown` mode.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "text": "Hello world github/linguist#1 **cool**, and #1!",
+          "mode": "gfm",
+          "context": "github/gollum"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "render",
+      "documentationUrl": "https://developer.github.com/v3/markdown/#render-an-arbitrary-markdown-document"
+    },
+    {
+      "name": "Render a Markdown document in raw mode",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/markdown/raw",
+      "previews": [],
+      "params": [
+        {
+          "mapTo": "input",
+          "name": "data",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "body"
+        }
+      ],
+      "description": "You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "render-raw",
+      "documentationUrl": "https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode"
+    }
+  ],
+  "meta": [
+    {
+      "name": "Get",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/meta",
+      "previews": [],
+      "params": [],
+      "description": "This endpoint provides a list of GitHub's IP addresses. For more information, see \"[About GitHub's IP addresses](https://help.github.com/articles/about-github-s-ip-addresses/).\"",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "verifiable_password_authentication": true,
+            "hooks": [
+              "127.0.0.1/32"
+            ],
+            "git": [
+              "127.0.0.1/32"
+            ],
+            "pages": [
+              "192.30.252.153/32",
+              "192.30.252.154/32"
+            ],
+            "importer": [
+              "54.158.161.132",
+              "54.226.70.38"
+            ]
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/v3/meta/#meta"
+    }
+  ],
   "migrations": [
     {
       "name": "Start an organization migration",
@@ -16945,562 +16674,668 @@
       "documentationUrl": "https://developer.github.com/v3/migrations/users/#unlock-a-user-repository"
     }
   ],
-  "codesOfConduct": [
+  "oauthAuthorizations": [
     {
-      "name": "List all codes of conduct",
-      "enabledForApps": true,
+      "name": "List your grants",
+      "enabledForApps": false,
       "method": "GET",
-      "path": "/codes_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "key": "citizen_code_of_conduct",
-              "name": "Citizen Code of Conduct",
-              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
-            },
-            {
-              "key": "contributor_covenant",
-              "name": "Contributor Covenant",
-              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
-            }
-          ]
-        }
-      ],
-      "idName": "list-conduct-codes",
-      "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#list-all-codes-of-conduct"
-    },
-    {
-      "name": "Get an individual code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/codes_of_conduct/:key",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "key",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-conduct-code",
-      "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
-    },
-    {
-      "name": "Get the contents of a repository's code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/community/code_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-for-repo",
-      "documentationUrl": "https://developer.github.com/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
-    }
-  ],
-  "emojis": [
-    {
-      "name": "Get",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/emojis",
-      "previews": [],
-      "params": [],
-      "description": "Lists all the emojis available to use on GitHub.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/v3/emojis/#emojis"
-    }
-  ],
-  "gitignore": [
-    {
-      "name": "Listing available templates",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates",
-      "previews": [],
-      "params": [],
-      "description": "List all templates available to pass as an option when [creating a repository](https://developer.github.com/v3/repos/#create).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            "Actionscript",
-            "Android",
-            "AppceleratorTitanium",
-            "Autotools",
-            "Bancha",
-            "C",
-            "C++"
-          ]
-        }
-      ],
-      "idName": "list-templates",
-      "documentationUrl": "https://developer.github.com/v3/gitignore/#listing-available-templates"
-    },
-    {
-      "name": "Get a single template",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates/:name",
+      "path": "/applications/grants",
       "previews": [],
       "params": [
         {
-          "name": "name",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](https://developer.github.com/v3/media/) to get the raw contents.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "name": "C",
-            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
-          }
-        },
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "description": "Use the raw [media type](/v3/media/) to get the raw contents."
-        }
-      ],
-      "idName": "get-template",
-      "documentationUrl": "https://developer.github.com/v3/gitignore/#get-a-single-template"
-    }
-  ],
-  "licenses": [
-    {
-      "name": "List commonly used licenses",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/licenses",
-      "previews": [],
-      "params": [],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "key": "mit",
-              "name": "MIT License",
-              "spdx_id": "MIT",
-              "url": "https://api.github.com/licenses/mit",
-              "node_id": "MDc6TGljZW5zZW1pdA=="
-            },
-            {
-              "key": "lgpl-3.0",
-              "name": "GNU Lesser General Public License v3.0",
-              "spdx_id": "LGPL-3.0",
-              "url": "https://api.github.com/licenses/lgpl-3.0"
-            },
-            {
-              "key": "mpl-2.0",
-              "name": "Mozilla Public License 2.0",
-              "spdx_id": "MPL-2.0",
-              "url": "https://api.github.com/licenses/mpl-2.0"
-            },
-            {
-              "key": "agpl-3.0",
-              "name": "GNU Affero General Public License v3.0",
-              "spdx_id": "AGPL-3.0",
-              "url": "https://api.github.com/licenses/agpl-3.0"
-            },
-            {
-              "key": "unlicense",
-              "name": "The Unlicense",
-              "spdx_id": "Unlicense",
-              "url": "https://api.github.com/licenses/unlicense"
-            },
-            {
-              "key": "apache-2.0",
-              "name": "Apache License 2.0",
-              "spdx_id": "Apache-2.0",
-              "url": "https://api.github.com/licenses/apache-2.0"
-            },
-            {
-              "key": "gpl-3.0",
-              "name": "GNU General Public License v3.0",
-              "spdx_id": "GPL-3.0",
-              "url": "https://api.github.com/licenses/gpl-3.0"
-            }
-          ]
-        }
-      ],
-      "idName": "list-commonly-used",
-      "documentationUrl": "https://developer.github.com/v3/licenses/#list-commonly-used-licenses"
-    },
-    {
-      "name": "List all licenses",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/licenses",
-      "previews": [],
-      "params": [],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "key": "mit",
-              "name": "MIT License",
-              "spdx_id": "MIT",
-              "url": "https://api.github.com/licenses/mit",
-              "node_id": "MDc6TGljZW5zZW1pdA=="
-            },
-            {
-              "key": "lgpl-3.0",
-              "name": "GNU Lesser General Public License v3.0",
-              "spdx_id": "LGPL-3.0",
-              "url": "https://api.github.com/licenses/lgpl-3.0"
-            },
-            {
-              "key": "mpl-2.0",
-              "name": "Mozilla Public License 2.0",
-              "spdx_id": "MPL-2.0",
-              "url": "https://api.github.com/licenses/mpl-2.0"
-            },
-            {
-              "key": "agpl-3.0",
-              "name": "GNU Affero General Public License v3.0",
-              "spdx_id": "AGPL-3.0",
-              "url": "https://api.github.com/licenses/agpl-3.0"
-            },
-            {
-              "key": "unlicense",
-              "name": "The Unlicense",
-              "spdx_id": "Unlicense",
-              "url": "https://api.github.com/licenses/unlicense"
-            },
-            {
-              "key": "apache-2.0",
-              "name": "Apache License 2.0",
-              "spdx_id": "Apache-2.0",
-              "url": "https://api.github.com/licenses/apache-2.0"
-            },
-            {
-              "key": "gpl-3.0",
-              "name": "GNU General Public License v3.0",
-              "spdx_id": "GPL-3.0",
-              "url": "https://api.github.com/licenses/gpl-3.0"
-            }
-          ]
-        }
-      ],
-      "idName": "list",
-      "documentationUrl": "https://developer.github.com/v3/licenses/#list-commonly-used-licenses",
-      "deprecated": {
-        "date": "2019-03-05",
-        "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
-        "before": {
-          "idName": "list"
-        },
-        "after": {
-          "idName": "list-commonly-used"
-        }
-      }
-    },
-    {
-      "name": "Get an individual license",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/licenses/:license",
-      "previews": [],
-      "params": [
-        {
-          "name": "license",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "mit",
-            "name": "MIT License",
-            "spdx_id": "MIT",
-            "url": "https://api.github.com/licenses/mit",
-            "node_id": "MDc6TGljZW5zZW1pdA==",
-            "html_url": "http://choosealicense.com/licenses/mit/",
-            "description": "A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty.",
-            "implementation": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.",
-            "permissions": [
-              "commercial-use",
-              "modifications",
-              "distribution",
-              "sublicense",
-              "private-use"
-            ],
-            "conditions": [
-              "include-copyright"
-            ],
-            "limitations": [
-              "no-liability"
-            ],
-            "body": "\n\nThe MIT License (MIT)\n\nCopyright (c) [year] [fullname]\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n",
-            "featured": true
-          }
-        }
-      ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/v3/licenses/#get-an-individual-license"
-    },
-    {
-      "name": "Get the contents of a repository's license",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/license",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This method returns the contents of the repository's license file, if one is detected.\n\nSimilar to [the repository contents API](https://developer.github.com/v3/repos/contents/#get-contents), this method also supports [custom media types](https://developer.github.com/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "name": "LICENSE",
-            "path": "LICENSE",
-            "sha": "401c59dcc4570b954dd6d345e76199e1f4e76266",
-            "size": 1077,
-            "url": "https://api.github.com/repos/benbalter/gman/contents/LICENSE?ref=master",
-            "html_url": "https://github.com/benbalter/gman/blob/master/LICENSE",
-            "git_url": "https://api.github.com/repos/benbalter/gman/git/blobs/401c59dcc4570b954dd6d345e76199e1f4e76266",
-            "download_url": "https://raw.githubusercontent.com/benbalter/gman/master/LICENSE?lab=true",
-            "type": "file",
-            "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIDIwMTMgQmVu\nIEJhbHRlcgoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBv\nZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZgp0\naGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmls\nZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8gZGVhbCBpbgp0aGUgU29mdHdhcmUg\nd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRh\ndGlvbiB0aGUgcmlnaHRzIHRvCnVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwg\ncHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yIHNlbGwg\nY29waWVzIG9mCnRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25z\nIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywK\nc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJv\ndmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGlj\nZSBzaGFsbCBiZSBpbmNsdWRlZCBpbiBhbGwKY29waWVzIG9yIHN1YnN0YW50\naWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJ\nUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBL\nSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJ\nTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLCBG\nSVRORVNTCkZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklO\nR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUgQVVUSE9SUyBPUgpDT1BZ\nUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdF\nUyBPUiBPVEhFUiBMSUFCSUxJVFksIFdIRVRIRVIKSU4gQU4gQUNUSU9OIE9G\nIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORyBGUk9NLCBP\nVVQgT0YgT1IgSU4KQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBU\nSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTIElOIFRIRSBTT0ZUV0FSRS4K\n",
-            "encoding": "base64",
-            "_links": {
-              "self": "https://api.github.com/repos/benbalter/gman/contents/LICENSE?ref=master",
-              "git": "https://api.github.com/repos/benbalter/gman/git/blobs/401c59dcc4570b954dd6d345e76199e1f4e76266",
-              "html": "https://github.com/benbalter/gman/blob/master/LICENSE"
-            },
-            "license": {
-              "key": "mit",
-              "name": "MIT License",
-              "spdx_id": "MIT",
-              "url": "https://api.github.com/licenses/mit",
-              "node_id": "MDc6TGljZW5zZW1pdA=="
-            }
-          }
-        }
-      ],
-      "idName": "get-for-repo",
-      "documentationUrl": "https://developer.github.com/v3/licenses/#get-the-contents-of-a-repositorys-license"
-    }
-  ],
-  "markdown": [
-    {
-      "name": "Render an arbitrary Markdown document",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/markdown",
-      "previews": [],
-      "params": [
-        {
-          "name": "text",
-          "type": "string",
-          "description": "The Markdown text to render in HTML. Markdown content must be 400 KB or less.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "mode",
-          "type": "string",
-          "description": "The rendering mode. Can be either:  \n\\* `markdown` to render a document in plain Markdown, just like README.md files are rendered.  \n\\* `gfm` to render a document in [GitHub Flavored Markdown](https://github.github.com/gfm/), which creates links for user mentions as well as references to SHA-1 hashes, issues, and pull requests.",
-          "default": "markdown",
+          "name": "per_page",
+          "type": "integer",
           "required": false,
-          "enum": [
-            "markdown",
-            "gfm"
-          ],
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/applications/grants/1",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "created_at": "2011-09-06T17:26:27Z",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "scopes": [
+                "public_repo"
+              ]
+            }
+          ]
+        }
+      ],
+      "idName": "list-grants",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#list-your-grants"
+    },
+    {
+      "name": "Get a single grant",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/applications/grants/1",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "created_at": "2011-09-06T17:26:27Z",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "scopes": [
+              "public_repo"
+            ]
+          }
+        }
+      ],
+      "idName": "get-grant",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-a-single-grant"
+    },
+    {
+      "name": "Delete a grant",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-grant",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#delete-a-grant"
+    },
+    {
+      "name": "List your authorizations",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/authorizations/1",
+              "scopes": [
+                "public_repo"
+              ],
+              "token": "",
+              "token_last_eight": "12345678",
+              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "note": "optional note",
+              "note_url": "http://optional/note/url",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z",
+              "fingerprint": "jklmnop12345678"
+            }
+          ]
+        }
+      ],
+      "idName": "list-authorizations",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations"
+    },
+    {
+      "name": "Get a single authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "get-authorization",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization"
+    },
+    {
+      "name": "Create a new authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
           "location": "body"
         },
         {
-          "name": "context",
+          "name": "note",
           "type": "string",
-          "description": "The repository context to use when creating references in `gfm` mode. Omit this parameter when using `markdown` mode.",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_id",
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
           "required": false,
           "location": "body"
         }
       ],
       "requests": [
         {
-          "text": "Hello world github/linguist#1 **cool**, and #1!",
-          "mode": "gfm",
-          "context": "github/gollum"
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "If you need a small number of personal access tokens, implementing the [web flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).\n\nOrganizations that enforce SAML SSO require personal access tokens to be whitelisted. Read more about whitelisting tokens on the [GitHub Help site](https://help.github.com/articles/about-identity-and-access-management-with-saml-single-sign-on).",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": ""
+          }
+        }
+      ],
+      "idName": "create-authorization",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-and-fingerprint",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-fingerprint",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
+      "deprecated": {
+        "date": "2018-12-27",
+        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
+        "before": {
+          "idName": "get-or-create-authorization-for-app-fingerprint"
+        },
+        "after": {
+          "idName": "get-or-create-authorization-for-app-and-fingerprint"
+        }
+      }
+    },
+    {
+      "name": "Update an existing authorization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "Replaces the authorization scopes with these.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to add to this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to remove from this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "add_scopes": [
+            "repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "You can only send one of these scope keys at a time.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "update-authorization",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization"
+    },
+    {
+      "name": "Delete an authorization",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
         }
       ],
       "description": "",
       "responses": [
         {
           "headers": {
-            "status": "200 OK",
+            "status": "204 No Content",
             "content-type": "application/json; charset=utf-8"
           }
         }
       ],
-      "idName": "render",
-      "documentationUrl": "https://developer.github.com/v3/markdown/#render-an-arbitrary-markdown-document"
+      "idName": "delete-authorization",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#delete-an-authorization"
     },
     {
-      "name": "Render a Markdown document in raw mode",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/markdown/raw",
+      "name": "Check an authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/:client_id/tokens/:access_token",
       "previews": [],
       "params": [
         {
-          "mapTo": "input",
-          "name": "data",
+          "name": "client_id",
           "type": "string",
           "required": true,
           "description": "",
-          "location": "body"
-        }
-      ],
-      "description": "You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.\n\n",
-      "responses": [
+          "location": "url"
+        },
         {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          }
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
         }
       ],
-      "idName": "render-raw",
-      "documentationUrl": "https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode"
-    }
-  ],
-  "meta": [
-    {
-      "name": "Get",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/meta",
-      "previews": [],
-      "params": [],
-      "description": "This endpoint provides a list of GitHub's IP addresses. For more information, see \"[About GitHub's IP addresses](https://help.github.com/articles/about-github-s-ip-addresses/).\"",
+      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
       "responses": [
         {
           "headers": {
@@ -17508,71 +17343,191 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "verifiable_password_authentication": true,
-            "hooks": [
-              "127.0.0.1/32"
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
             ],
-            "git": [
-              "127.0.0.1/32"
-            ],
-            "pages": [
-              "192.30.252.153/32",
-              "192.30.252.154/32"
-            ],
-            "importer": [
-              "54.158.161.132",
-              "54.226.70.38"
-            ]
-          }
-        }
-      ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/v3/meta/#meta"
-    }
-  ],
-  "rateLimit": [
-    {
-      "name": "Get your current rate limit status",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/rate_limit",
-      "previews": [],
-      "params": [],
-      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](https://developer.github.com/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](https://developer.github.com/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](https://developer.github.com/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "resources": {
-              "core": {
-                "limit": 5000,
-                "remaining": 4999,
-                "reset": 1372700873
-              },
-              "search": {
-                "limit": 30,
-                "remaining": 18,
-                "reset": 1372697452
-              },
-              "graphql": {
-                "limit": 5000,
-                "remaining": 4993,
-                "reset": 1372700389
-              }
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
             },
-            "rate": {
-              "limit": 5000,
-              "remaining": 4999,
-              "reset": 1372700873
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
             }
           }
         }
       ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/v3/rate_limit/#get-your-current-rate-limit-status"
+      "idName": "check-authorization",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#check-an-authorization"
+    },
+    {
+      "name": "Reset an authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            }
+          }
+        }
+      ],
+      "idName": "reset-authorization",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization"
+    },
+    {
+      "name": "Revoke an authorization for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-authorization-for-application",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
+    },
+    {
+      "name": "Revoke a grant for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/grants/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-grant-for-application",
+      "documentationUrl": "https://developer.github.com/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
     }
   ],
   "orgs": [
@@ -18162,6 +18117,412 @@
       ],
       "idName": "unblock-user",
       "documentationUrl": "https://developer.github.com/v3/orgs/blocking/#unblock-a-user"
+    },
+    {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/orgs/octocat/hooks/1",
+              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Must be passed as \"web\".",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Here's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#delete-a-hook"
     },
     {
       "name": "Members list",
@@ -19250,412 +19611,6 @@
       ],
       "idName": "convert-member-to-outside-collaborator",
       "documentationUrl": "https://developer.github.com/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-    },
-    {
-      "name": "List hooks",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/orgs/octocat/hooks/1",
-              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#list-hooks"
-    },
-    {
-      "name": "Get single hook",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#get-single-hook"
-    },
-    {
-      "name": "Create a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Must be passed as \"web\".",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Here's how you can create a hook that posts payloads in JSON format:",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#create-a-hook"
-    },
-    {
-      "name": "Edit a hook",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "active": true,
-          "events": [
-            "pull_request"
-          ]
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#edit-a-hook"
-    },
-    {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#delete-a-hook"
     }
   ],
   "projects": [
@@ -24605,828 +24560,6 @@
       "documentationUrl": "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button"
     },
     {
-      "name": "List reviews on a pull request",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "The list of reviews returns in chronological order.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 80,
-              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Here is the body for the review.",
-              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-              "state": "APPROVED",
-              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-              "_links": {
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-                }
-              }
-            }
-          ],
-          "description": "The list of reviews returns in chronological order."
-        }
-      ],
-      "idName": "list-reviews",
-      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-    },
-    {
-      "name": "Get a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "get-review",
-      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-a-single-review"
-    },
-    {
-      "name": "Delete a pending review",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "PENDING",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "delete-pending-review",
-      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review"
-    },
-    {
-      "name": "Get comments for a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-              "id": 10,
-              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-              "pull_request_review_id": 42,
-              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-              "path": "file1.txt",
-              "position": 1,
-              "original_position": 4,
-              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-              "in_reply_to_id": 8,
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Great stuff",
-              "created_at": "2011-04-14T16:00:49Z",
-              "updated_at": "2011-04-14T16:00:49Z",
-              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-              "_links": {
-                "self": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-                },
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "get-comments-for-review",
-      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review"
-    },
-    {
-      "name": "Create a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "commit_id",
-          "type": "string",
-          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-          "required": false,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        },
-        {
-          "name": "comments",
-          "type": "object[]",
-          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "comments[].path",
-          "type": "string",
-          "description": "The relative path to the file that necessitates a review comment.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].position",
-          "type": "integer",
-          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].body",
-          "type": "string",
-          "description": "Text of the review comment.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "event": "REQUEST_CHANGES",
-          "comments": [
-            {
-              "path": "file.md",
-              "position": 6,
-              "body": "Please add more information here, and fix this typo."
-            }
-          ]
-        }
-      ],
-      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)\" and \"[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://developer.github.com/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "This is close to perfect! Please address the suggested inline change.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "CHANGES_REQUESTED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-review",
-      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review"
-    },
-    {
-      "name": "Update a pull request review",
-      "enabledForApps": true,
-      "method": "PUT",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The body text of the pull request review.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "This is close to perfect! Please address the suggested inline change. And add more about this."
-        }
-      ],
-      "description": "Update the review summary comment with new text.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "This is close to perfect! Please address the suggested inline change. And add more about this.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "CHANGES_REQUESTED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "update-review",
-      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#update-a-pull-request-review"
-    },
-    {
-      "name": "Submit a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The body text of the pull request review",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-          "required": true,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "submit-review",
-      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review"
-    },
-    {
-      "name": "Dismiss a pull request review",
-      "enabledForApps": true,
-      "method": "PUT",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "message",
-          "type": "string",
-          "description": "The message for the pull request review dismissal",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "description": "**Note:** To dismiss a pull request review on a [protected branch](https://developer.github.com/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "DISMISSED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "dismiss-review",
-      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review"
-    },
-    {
       "name": "List comments on a pull request",
       "enabledForApps": true,
       "method": "GET",
@@ -26940,6 +26073,873 @@
       ],
       "idName": "delete-review-request",
       "documentationUrl": "https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request"
+    },
+    {
+      "name": "List reviews on a pull request",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "The list of reviews returns in chronological order.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 80,
+              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Here is the body for the review.",
+              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+              "state": "APPROVED",
+              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+              "_links": {
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+                }
+              }
+            }
+          ],
+          "description": "The list of reviews returns in chronological order."
+        }
+      ],
+      "idName": "list-reviews",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+    },
+    {
+      "name": "Get a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "get-review",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-a-single-review"
+    },
+    {
+      "name": "Delete a pending review",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "PENDING",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "delete-pending-review",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review"
+    },
+    {
+      "name": "Get comments for a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+              "id": 10,
+              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+              "pull_request_review_id": 42,
+              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+              "path": "file1.txt",
+              "position": 1,
+              "original_position": 4,
+              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+              "in_reply_to_id": 8,
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Great stuff",
+              "created_at": "2011-04-14T16:00:49Z",
+              "updated_at": "2011-04-14T16:00:49Z",
+              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+              "_links": {
+                "self": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+                },
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "get-comments-for-review",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review"
+    },
+    {
+      "name": "Create a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "commit_id",
+          "type": "string",
+          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+          "required": false,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        },
+        {
+          "name": "comments",
+          "type": "object[]",
+          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "comments[].path",
+          "type": "string",
+          "description": "The relative path to the file that necessitates a review comment.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].position",
+          "type": "integer",
+          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].body",
+          "type": "string",
+          "description": "Text of the review comment.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "event": "REQUEST_CHANGES",
+          "comments": [
+            {
+              "path": "file.md",
+              "position": 6,
+              "body": "Please add more information here, and fix this typo."
+            }
+          ]
+        }
+      ],
+      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)\" and \"[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://developer.github.com/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "This is close to perfect! Please address the suggested inline change.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "CHANGES_REQUESTED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-review",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review"
+    },
+    {
+      "name": "Update a pull request review",
+      "enabledForApps": true,
+      "method": "PUT",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The body text of the pull request review.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "This is close to perfect! Please address the suggested inline change. And add more about this."
+        }
+      ],
+      "description": "Update the review summary comment with new text.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "This is close to perfect! Please address the suggested inline change. And add more about this.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "CHANGES_REQUESTED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "update-review",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#update-a-pull-request-review"
+    },
+    {
+      "name": "Submit a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The body text of the pull request review",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+          "required": true,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "submit-review",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review"
+    },
+    {
+      "name": "Dismiss a pull request review",
+      "enabledForApps": true,
+      "method": "PUT",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "message",
+          "type": "string",
+          "description": "The message for the pull request review dismissal",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "description": "**Note:** To dismiss a pull request review on a [protected branch](https://developer.github.com/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "DISMISSED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "dismiss-review",
+      "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review"
+    }
+  ],
+  "rateLimit": [
+    {
+      "name": "Get your current rate limit status",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/rate_limit",
+      "previews": [],
+      "params": [],
+      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](https://developer.github.com/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](https://developer.github.com/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](https://developer.github.com/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "resources": {
+              "core": {
+                "limit": 5000,
+                "remaining": 4999,
+                "reset": 1372700873
+              },
+              "search": {
+                "limit": 30,
+                "remaining": 18,
+                "reset": 1372697452
+              },
+              "graphql": {
+                "limit": 5000,
+                "remaining": 4993,
+                "reset": 1372700389
+              }
+            },
+            "rate": {
+              "limit": 5000,
+              "remaining": 4999,
+              "reset": 1372700873
+            }
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/v3/rate_limit/#get-your-current-rate-limit-status"
     }
   ],
   "reactions": [
@@ -34765,229 +34765,6 @@
       "documentationUrl": "https://developer.github.com/v3/repos/contents/#get-archive-link"
     },
     {
-      "name": "List deploy keys",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-deploy-keys",
-      "documentationUrl": "https://developer.github.com/v3/repos/keys/#list-deploy-keys"
-    },
-    {
-      "name": "Get a deploy key",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-deploy-key",
-      "documentationUrl": "https://developer.github.com/v3/repos/keys/#get-a-deploy-key"
-    },
-    {
-      "name": "Add a new deploy key",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A name for the key.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The contents of the key.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "read_only",
-          "type": "boolean",
-          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA...",
-          "read_only": true
-        }
-      ],
-      "description": "Here's how you can create a read-only deploy key:\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "add-deploy-key",
-      "documentationUrl": "https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key"
-    },
-    {
-      "name": "Remove a deploy key",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-deploy-key",
-      "documentationUrl": "https://developer.github.com/v3/repos/keys/#remove-a-deploy-key"
-    },
-    {
       "name": "List deployments",
       "enabledForApps": true,
       "method": "GET",
@@ -36162,6 +35939,515 @@
       "documentationUrl": "https://developer.github.com/v3/repos/forks/#create-a-fork"
     },
     {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com/webhook",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Use `web` to create a webhook. This parameter only accepts the value `web`.",
+          "default": "web",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "add_events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Test a push hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "test-push-hook",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#test-a-push-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#delete-a-hook"
+    },
+    {
       "name": "List invitations for a repository",
       "enabledForApps": true,
       "method": "GET",
@@ -36743,6 +37029,229 @@
       ],
       "idName": "decline-invitation",
       "documentationUrl": "https://developer.github.com/v3/repos/invitations/#decline-a-repository-invitation"
+    },
+    {
+      "name": "List deploy keys",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-deploy-keys",
+      "documentationUrl": "https://developer.github.com/v3/repos/keys/#list-deploy-keys"
+    },
+    {
+      "name": "Get a deploy key",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-deploy-key",
+      "documentationUrl": "https://developer.github.com/v3/repos/keys/#get-a-deploy-key"
+    },
+    {
+      "name": "Add a new deploy key",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A name for the key.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The contents of the key.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "read_only",
+          "type": "boolean",
+          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA...",
+          "read_only": true
+        }
+      ],
+      "description": "Here's how you can create a read-only deploy key:\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "add-deploy-key",
+      "documentationUrl": "https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key"
+    },
+    {
+      "name": "Remove a deploy key",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-deploy-key",
+      "documentationUrl": "https://developer.github.com/v3/repos/keys/#remove-a-deploy-key"
     },
     {
       "name": "Perform a merge",
@@ -39333,101 +39842,78 @@
       ],
       "idName": "get-clones",
       "documentationUrl": "https://developer.github.com/v3/repos/traffic/#clones"
-    },
+    }
+  ],
+  "scim": [
     {
-      "name": "List hooks",
+      "name": "Get a list of provisioned identities",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
+      "path": "/scim/v2/organizations/:org/Users",
+      "previews": [
+        {
+          "name": "cloud-9",
+          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
+          "required": true
+        }
+      ],
       "params": [
         {
-          "name": "owner",
+          "name": "org",
           "type": "string",
           "required": true,
           "description": "",
           "location": "url"
         },
         {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
+          "name": "startIndex",
           "type": "integer",
+          "description": "Used for pagination: the index of the first result to return.",
           "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
           "location": "query"
         },
         {
-          "name": "page",
+          "name": "count",
           "type": "integer",
+          "description": "Used for pagination: the number of results to return.",
           "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
+          "location": "query"
+        },
+        {
+          "name": "filter",
+          "type": "string",
+          "description": "Filters results using the equals query parameter operator (`eq`). You can filter results that are equal to `id`, `userName`, `emails`, and `external_id`. For example, to search for an identity with the `userName` Octocat, you would use this query: `?filter=userName%20eq%20\\\"Octocat\\\"`",
+          "required": false,
           "location": "query"
         }
       ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com/webhook",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#list-hooks"
+      "description": "If you want to filter by a specific email address, you'd use the `email` query parameter and the `eq` operator:\n\n```\nGET /scim/v2/organizations/:org/Users?filter=emails\n```\n\nYour filter might look like this using cURL:\n\nRetrieves users that match the filter. In the example, we searched only for [octocat@github.com](mailto:octocat@github.com).\n\nRetrieves a paginated list of all provisioned organization members, including pending invitations.",
+      "idName": "list-provisioned-identities",
+      "documentationUrl": "https://developer.github.com/v3/scim/#get-a-list-of-provisioned-identities"
     },
     {
-      "name": "Get single hook",
+      "name": "Get provisioning details for a single user",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
+      "path": "/scim/v2/organizations/:org/Users/:external_identity_guid",
+      "previews": [
+        {
+          "name": "cloud-9",
+          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
+          "required": true
+        }
+      ],
       "params": [
         {
-          "name": "owner",
+          "name": "org",
           "type": "string",
           "required": true,
           "description": "",
           "location": "url"
         },
         {
-          "name": "repo",
+          "name": "external_identity_guid",
           "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
           "required": true,
           "description": "",
           "location": "url"
@@ -39441,124 +39927,50 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
+            "schemas": [
+              "urn:ietf:params:scim:schemas:core:2.0:User"
             ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
+            "id": "77563764-eb6-24-0598234-958243",
+            "externalId": "sdfoiausdofiua",
+            "userName": "hubot@example.com",
+            "name": {
+              "givenName": "hu",
+              "familyName": "bot"
             },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
+            "active": true,
+            "meta": {
+              "resourceType": "User",
+              "created": "2017-03-09T16:11:13-05:00",
+              "lastModified": "2017-03-09T16:11:13-05:00"
+            }
           }
         }
       ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#get-single-hook"
+      "idName": "get-provisioning-details-for-user",
+      "documentationUrl": "https://developer.github.com/v3/scim/#get-provisioning-details-for-a-single-user"
     },
     {
-      "name": "Create a hook",
+      "name": "Provision and invite users",
       "enabledForApps": true,
       "method": "POST",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
+      "path": "/scim/v2/organizations/:org/Users",
+      "previews": [
+        {
+          "name": "cloud-9",
+          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
+          "required": true
+        }
+      ],
       "params": [
         {
-          "name": "owner",
+          "name": "org",
           "type": "string",
           "required": true,
           "description": "",
           "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Use `web` to create a webhook. This parameter only accepts the value `web`.",
-          "default": "web",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
         }
       ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+      "description": "Provision organization membership for and send activation emails to a list of email addresses.",
       "responses": [
         {
           "headers": {
@@ -39566,131 +39978,118 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
+            "schemas": [
+              "urn:ietf:params:scim:schemas:core:2.0:User"
             ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
+            "id": "edefdfedf-050c-11e7-8d32",
+            "externalId": "a7d0f98382",
+            "userName": "mona.octocat@okta.example.com",
+            "name": {
+              "givenName": "Mona",
+              "familyName": "Octocat"
             },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
+            "active": true,
+            "meta": {
+              "resourceType": "User",
+              "created": "2017-03-09T16:11:13-05:00",
+              "lastModified": "2017-03-09T16:11:13-05:00"
+            }
           }
         }
       ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#create-a-hook"
+      "idName": "provision-and-invite-users",
+      "documentationUrl": "https://developer.github.com/v3/scim/#provision-and-invite-users"
     },
     {
-      "name": "Edit a hook",
+      "name": "Provision and invite users",
       "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
+      "method": "POST",
+      "path": "/scim/v2/organizations/:org/Users",
+      "previews": [
+        {
+          "name": "cloud-9",
+          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
+          "required": true
+        }
+      ],
       "params": [
         {
-          "name": "owner",
+          "name": "org",
           "type": "string",
           "required": true,
           "description": "",
           "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
         }
       ],
-      "requests": [
+      "description": "Provision organization membership for and send activation emails to a list of email addresses.",
+      "responses": [
         {
-          "active": true,
-          "add_events": [
-            "pull_request"
-          ]
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "schemas": [
+              "urn:ietf:params:scim:schemas:core:2.0:User"
+            ],
+            "id": "edefdfedf-050c-11e7-8d32",
+            "externalId": "a7d0f98382",
+            "userName": "mona.octocat@okta.example.com",
+            "name": {
+              "givenName": "Mona",
+              "familyName": "Octocat"
+            },
+            "active": true,
+            "meta": {
+              "resourceType": "User",
+              "created": "2017-03-09T16:11:13-05:00",
+              "lastModified": "2017-03-09T16:11:13-05:00"
+            }
+          }
         }
       ],
-      "description": "",
+      "idName": "provision-invite-users",
+      "documentationUrl": "https://developer.github.com/v3/scim/#provision-and-invite-users",
+      "deprecated": {
+        "date": "2018-12-27",
+        "message": "`idName` changed for \"Provision and invite users\". It now includes `-and-`",
+        "before": {
+          "idName": "provision-invite-users"
+        },
+        "after": {
+          "idName": "provision-and-invite-users"
+        }
+      }
+    },
+    {
+      "name": "Update a provisioned organization membership",
+      "enabledForApps": true,
+      "method": "PUT",
+      "path": "/scim/v2/organizations/:org/Users/:external_identity_guid",
+      "previews": [
+        {
+          "name": "cloud-9",
+          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "external_identity_guid",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Warning:** Setting `active: false` removes the user from the organization, deletes the external identity, and deletes the associated `:user_id`.",
       "responses": [
         {
           "headers": {
@@ -39698,134 +40097,109 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
+            "schemas": [
+              "urn:ietf:params:scim:schemas:core:2.0:User"
             ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
+            "id": "edefdfedf-050c-11e7-8d32",
+            "externalId": "a7d0f98382",
+            "userName": "mona.octocat@okta.example.com",
+            "name": {
+              "givenName": "Mona",
+              "familyName": "Octocat"
             },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
+            "active": true,
+            "meta": {
+              "resourceType": "User",
+              "created": "2017-03-09T16:11:13-05:00",
+              "lastModified": "2017-03-09T16:11:13-05:00"
+            }
           }
         }
       ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#edit-a-hook"
+      "idName": "update-provisioned-org-membership",
+      "documentationUrl": "https://developer.github.com/v3/scim/#update-a-provisioned-organization-membership"
     },
     {
-      "name": "Test a push hook",
+      "name": "Update a user attribute",
       "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-      "previews": [],
+      "method": "PATCH",
+      "path": "/scim/v2/organizations/:org/Users/:external_identity_guid",
+      "previews": [
+        {
+          "name": "cloud-9",
+          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
+          "required": true
+        }
+      ],
       "params": [
         {
-          "name": "owner",
+          "name": "org",
           "type": "string",
           "required": true,
           "description": "",
           "location": "url"
         },
         {
-          "name": "repo",
+          "name": "external_identity_guid",
           "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
           "required": true,
           "description": "",
           "location": "url"
         }
       ],
-      "description": "This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+      "description": "**Warning:** If you set `active:false` using the `replace` operation (as shown in the JSON example below), it removes the user from the organization, deletes the external identity, and deletes the associated `:user_id`.\n\n```\n{\n  \"Operations\":[{\n    \"op\":\"replace\",\n    \"value\":{\n      \"active\":false\n    }\n  }]\n}\n\n```",
       "responses": [
         {
           "headers": {
-            "status": "204 No Content",
+            "status": "200 OK",
             "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "schemas": [
+              "urn:ietf:params:scim:schemas:core:2.0:User"
+            ],
+            "id": "edefdfedf-050c-11e7-8d32",
+            "externalId": "a7d0f98382",
+            "userName": "mona.octocat@okta.example.com",
+            "name": {
+              "givenName": "Mona",
+              "familyName": "Octocat"
+            },
+            "active": true,
+            "meta": {
+              "resourceType": "User",
+              "created": "2017-03-09T16:11:13-05:00",
+              "lastModified": "2017-03-09T16:11:13-05:00"
+            }
           }
         }
       ],
-      "idName": "test-push-hook",
-      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#test-a-push-hook"
+      "idName": "update-user-attribute",
+      "documentationUrl": "https://developer.github.com/v3/scim/#update-a-user-attribute"
     },
     {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
+      "name": "Remove a user from the organization",
       "enabledForApps": true,
       "method": "DELETE",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
+      "path": "/scim/v2/organizations/:org/Users/:external_identity_guid",
+      "previews": [
+        {
+          "name": "cloud-9",
+          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
+          "required": true
+        }
+      ],
       "params": [
         {
-          "name": "owner",
+          "name": "org",
           "type": "string",
           "required": true,
           "description": "",
           "location": "url"
         },
         {
-          "name": "repo",
+          "name": "external_identity_guid",
           "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
           "required": true,
           "description": "",
           "location": "url"
@@ -39840,8 +40214,8 @@
           }
         }
       ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/v3/repos/hooks/#delete-a-hook"
+      "idName": "remove-user-from-org",
+      "documentationUrl": "https://developer.github.com/v3/scim/#remove-a-user-from-the-organization"
     }
   ],
   "search": [
@@ -41661,6 +42035,474 @@
       "documentationUrl": "https://developer.github.com/v3/teams/#remove-team-project"
     },
     {
+      "name": "List comments",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "direction",
+          "type": "string",
+          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "location": "query"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "author": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Do you like apples?",
+              "body_html": "<p>Do you like apples?</p>",
+              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+              "created_at": "2018-01-15T23:53:58Z",
+              "last_edited_at": null,
+              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+              "number": 1,
+              "updated_at": "2018-01-15T23:53:58Z",
+              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+              "reactions": {
+                "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+                "total_count": 5,
+                "+1": 3,
+                "-1": 1,
+                "laugh": 0,
+                "confused": 0,
+                "heart": 1,
+                "hooray": 0
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "list-discussion-comments",
+      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#list-comments"
+    },
+    {
+      "name": "Get a single comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "idName": "get-discussion-comment",
+      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment"
+    },
+    {
+      "name": "Create a comment",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like apples?"
+        }
+      ],
+      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)\" and \"[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)\" for details.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-discussion-comment",
+      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#create-a-comment"
+    },
+    {
+      "name": "Edit a comment",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like pineapples?"
+        }
+      ],
+      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like pineapples?",
+            "body_html": "<p>Do you like pineapples?</p>",
+            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": "2018-01-26T18:22:20Z",
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-26T18:22:20Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "idName": "edit-discussion-comment",
+      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment"
+    },
+    {
+      "name": "Delete a comment",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-discussion-comment",
+      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment"
+    },
+    {
       "name": "List discussions",
       "enabledForApps": true,
       "method": "GET",
@@ -42137,474 +42979,6 @@
       "documentationUrl": "https://developer.github.com/v3/teams/discussions/#delete-a-discussion"
     },
     {
-      "name": "List comments",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "direction",
-          "type": "string",
-          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-          "default": "desc",
-          "required": false,
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "location": "query"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "author": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Do you like apples?",
-              "body_html": "<p>Do you like apples?</p>",
-              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-              "created_at": "2018-01-15T23:53:58Z",
-              "last_edited_at": null,
-              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-              "number": 1,
-              "updated_at": "2018-01-15T23:53:58Z",
-              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-              "reactions": {
-                "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-                "total_count": 5,
-                "+1": 3,
-                "-1": 1,
-                "laugh": 0,
-                "confused": 0,
-                "heart": 1,
-                "hooray": 0
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "list-discussion-comments",
-      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#list-comments"
-    },
-    {
-      "name": "Get a single comment",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "idName": "get-discussion-comment",
-      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment"
-    },
-    {
-      "name": "Create a comment",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like apples?"
-        }
-      ],
-      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)\" and \"[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)\" for details.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-discussion-comment",
-      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#create-a-comment"
-    },
-    {
-      "name": "Edit a comment",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like pineapples?"
-        }
-      ],
-      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like pineapples?",
-            "body_html": "<p>Do you like pineapples?</p>",
-            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": "2018-01-26T18:22:20Z",
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-26T18:22:20Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "idName": "edit-discussion-comment",
-      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment"
-    },
-    {
-      "name": "Delete a comment",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-discussion-comment",
-      "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment"
-    },
-    {
       "name": "List team members",
       "enabledForApps": true,
       "method": "GET",
@@ -42999,380 +43373,6 @@
       ],
       "idName": "list-pending-invitations",
       "documentationUrl": "https://developer.github.com/v3/teams/members/#list-pending-team-invitations"
-    }
-  ],
-  "scim": [
-    {
-      "name": "Get a list of provisioned identities",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/scim/v2/organizations/:org/Users",
-      "previews": [
-        {
-          "name": "cloud-9",
-          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "startIndex",
-          "type": "integer",
-          "description": "Used for pagination: the index of the first result to return.",
-          "required": false,
-          "location": "query"
-        },
-        {
-          "name": "count",
-          "type": "integer",
-          "description": "Used for pagination: the number of results to return.",
-          "required": false,
-          "location": "query"
-        },
-        {
-          "name": "filter",
-          "type": "string",
-          "description": "Filters results using the equals query parameter operator (`eq`). You can filter results that are equal to `id`, `userName`, `emails`, and `external_id`. For example, to search for an identity with the `userName` Octocat, you would use this query: `?filter=userName%20eq%20\\\"Octocat\\\"`",
-          "required": false,
-          "location": "query"
-        }
-      ],
-      "description": "If you want to filter by a specific email address, you'd use the `email` query parameter and the `eq` operator:\n\n```\nGET /scim/v2/organizations/:org/Users?filter=emails\n```\n\nYour filter might look like this using cURL:\n\nRetrieves users that match the filter. In the example, we searched only for [octocat@github.com](mailto:octocat@github.com).\n\nRetrieves a paginated list of all provisioned organization members, including pending invitations.",
-      "idName": "list-provisioned-identities",
-      "documentationUrl": "https://developer.github.com/v3/scim/#get-a-list-of-provisioned-identities"
-    },
-    {
-      "name": "Get provisioning details for a single user",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/scim/v2/organizations/:org/Users/:external_identity_guid",
-      "previews": [
-        {
-          "name": "cloud-9",
-          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "external_identity_guid",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "schemas": [
-              "urn:ietf:params:scim:schemas:core:2.0:User"
-            ],
-            "id": "77563764-eb6-24-0598234-958243",
-            "externalId": "sdfoiausdofiua",
-            "userName": "hubot@example.com",
-            "name": {
-              "givenName": "hu",
-              "familyName": "bot"
-            },
-            "active": true,
-            "meta": {
-              "resourceType": "User",
-              "created": "2017-03-09T16:11:13-05:00",
-              "lastModified": "2017-03-09T16:11:13-05:00"
-            }
-          }
-        }
-      ],
-      "idName": "get-provisioning-details-for-user",
-      "documentationUrl": "https://developer.github.com/v3/scim/#get-provisioning-details-for-a-single-user"
-    },
-    {
-      "name": "Provision and invite users",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/scim/v2/organizations/:org/Users",
-      "previews": [
-        {
-          "name": "cloud-9",
-          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Provision organization membership for and send activation emails to a list of email addresses.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "schemas": [
-              "urn:ietf:params:scim:schemas:core:2.0:User"
-            ],
-            "id": "edefdfedf-050c-11e7-8d32",
-            "externalId": "a7d0f98382",
-            "userName": "mona.octocat@okta.example.com",
-            "name": {
-              "givenName": "Mona",
-              "familyName": "Octocat"
-            },
-            "active": true,
-            "meta": {
-              "resourceType": "User",
-              "created": "2017-03-09T16:11:13-05:00",
-              "lastModified": "2017-03-09T16:11:13-05:00"
-            }
-          }
-        }
-      ],
-      "idName": "provision-and-invite-users",
-      "documentationUrl": "https://developer.github.com/v3/scim/#provision-and-invite-users"
-    },
-    {
-      "name": "Provision and invite users",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/scim/v2/organizations/:org/Users",
-      "previews": [
-        {
-          "name": "cloud-9",
-          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Provision organization membership for and send activation emails to a list of email addresses.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "schemas": [
-              "urn:ietf:params:scim:schemas:core:2.0:User"
-            ],
-            "id": "edefdfedf-050c-11e7-8d32",
-            "externalId": "a7d0f98382",
-            "userName": "mona.octocat@okta.example.com",
-            "name": {
-              "givenName": "Mona",
-              "familyName": "Octocat"
-            },
-            "active": true,
-            "meta": {
-              "resourceType": "User",
-              "created": "2017-03-09T16:11:13-05:00",
-              "lastModified": "2017-03-09T16:11:13-05:00"
-            }
-          }
-        }
-      ],
-      "idName": "provision-invite-users",
-      "documentationUrl": "https://developer.github.com/v3/scim/#provision-and-invite-users",
-      "deprecated": {
-        "date": "2018-12-27",
-        "message": "`idName` changed for \"Provision and invite users\". It now includes `-and-`",
-        "before": {
-          "idName": "provision-invite-users"
-        },
-        "after": {
-          "idName": "provision-and-invite-users"
-        }
-      }
-    },
-    {
-      "name": "Update a provisioned organization membership",
-      "enabledForApps": true,
-      "method": "PUT",
-      "path": "/scim/v2/organizations/:org/Users/:external_identity_guid",
-      "previews": [
-        {
-          "name": "cloud-9",
-          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "external_identity_guid",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Warning:** Setting `active: false` removes the user from the organization, deletes the external identity, and deletes the associated `:user_id`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "schemas": [
-              "urn:ietf:params:scim:schemas:core:2.0:User"
-            ],
-            "id": "edefdfedf-050c-11e7-8d32",
-            "externalId": "a7d0f98382",
-            "userName": "mona.octocat@okta.example.com",
-            "name": {
-              "givenName": "Mona",
-              "familyName": "Octocat"
-            },
-            "active": true,
-            "meta": {
-              "resourceType": "User",
-              "created": "2017-03-09T16:11:13-05:00",
-              "lastModified": "2017-03-09T16:11:13-05:00"
-            }
-          }
-        }
-      ],
-      "idName": "update-provisioned-org-membership",
-      "documentationUrl": "https://developer.github.com/v3/scim/#update-a-provisioned-organization-membership"
-    },
-    {
-      "name": "Update a user attribute",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/scim/v2/organizations/:org/Users/:external_identity_guid",
-      "previews": [
-        {
-          "name": "cloud-9",
-          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "external_identity_guid",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Warning:** If you set `active:false` using the `replace` operation (as shown in the JSON example below), it removes the user from the organization, deletes the external identity, and deletes the associated `:user_id`.\n\n```\n{\n  \"Operations\":[{\n    \"op\":\"replace\",\n    \"value\":{\n      \"active\":false\n    }\n  }]\n}\n\n```",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "schemas": [
-              "urn:ietf:params:scim:schemas:core:2.0:User"
-            ],
-            "id": "edefdfedf-050c-11e7-8d32",
-            "externalId": "a7d0f98382",
-            "userName": "mona.octocat@okta.example.com",
-            "name": {
-              "givenName": "Mona",
-              "familyName": "Octocat"
-            },
-            "active": true,
-            "meta": {
-              "resourceType": "User",
-              "created": "2017-03-09T16:11:13-05:00",
-              "lastModified": "2017-03-09T16:11:13-05:00"
-            }
-          }
-        }
-      ],
-      "idName": "update-user-attribute",
-      "documentationUrl": "https://developer.github.com/v3/scim/#update-a-user-attribute"
-    },
-    {
-      "name": "Remove a user from the organization",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/scim/v2/organizations/:org/Users/:external_identity_guid",
-      "previews": [
-        {
-          "name": "cloud-9",
-          "description": "**Note:** The SCIM API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.cloud-9-preview+json+scim\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "external_identity_guid",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-user-from-org",
-      "documentationUrl": "https://developer.github.com/v3/scim/#remove-a-user-from-the-organization"
     }
   ],
   "users": [
@@ -44395,214 +44395,6 @@
       "documentationUrl": "https://developer.github.com/v3/users/followers/#unfollow-a-user"
     },
     {
-      "name": "List public keys for a user",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/users/:username/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA..."
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys-for-user",
-      "documentationUrl": "https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user"
-    },
-    {
-      "name": "List your public keys",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/user/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys",
-      "documentationUrl": "https://developer.github.com/v3/users/keys/#list-your-public-keys"
-    },
-    {
-      "name": "Get a single public key",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-public-key",
-      "documentationUrl": "https://developer.github.com/v3/users/keys/#get-a-single-public-key"
-    },
-    {
-      "name": "Create a public key",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA..."
-        }
-      ],
-      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "create-public-key",
-      "documentationUrl": "https://developer.github.com/v3/users/keys/#create-a-public-key"
-    },
-    {
-      "name": "Delete a public key",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-public-key",
-      "documentationUrl": "https://developer.github.com/v3/users/keys/#delete-a-public-key"
-    },
-    {
       "name": "List GPG keys for a user",
       "enabledForApps": true,
       "method": "GET",
@@ -44906,6 +44698,214 @@
       ],
       "idName": "delete-gpg-key",
       "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key"
+    },
+    {
+      "name": "List public keys for a user",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/users/:username/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA..."
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys-for-user",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user"
+    },
+    {
+      "name": "List your public keys",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/user/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#list-your-public-keys"
+    },
+    {
+      "name": "Get a single public key",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-public-key",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#get-a-single-public-key"
+    },
+    {
+      "name": "Create a public key",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA..."
+        }
+      ],
+      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "create-public-key",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#create-a-public-key"
+    },
+    {
+      "name": "Delete a public key",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-public-key",
+      "documentationUrl": "https://developer.github.com/v3/users/keys/#delete-a-public-key"
     }
   ]
 }

--- a/routes/api.github.com/licenses.json
+++ b/routes/api.github.com/licenses.json
@@ -64,6 +64,80 @@
     "documentationUrl": "https://developer.github.com/v3/licenses/#list-commonly-used-licenses"
   },
   {
+    "name": "List all licenses",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/licenses",
+    "previews": [],
+    "params": [],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "key": "mit",
+            "name": "MIT License",
+            "spdx_id": "MIT",
+            "url": "https://api.github.com/licenses/mit",
+            "node_id": "MDc6TGljZW5zZW1pdA=="
+          },
+          {
+            "key": "lgpl-3.0",
+            "name": "GNU Lesser General Public License v3.0",
+            "spdx_id": "LGPL-3.0",
+            "url": "https://api.github.com/licenses/lgpl-3.0"
+          },
+          {
+            "key": "mpl-2.0",
+            "name": "Mozilla Public License 2.0",
+            "spdx_id": "MPL-2.0",
+            "url": "https://api.github.com/licenses/mpl-2.0"
+          },
+          {
+            "key": "agpl-3.0",
+            "name": "GNU Affero General Public License v3.0",
+            "spdx_id": "AGPL-3.0",
+            "url": "https://api.github.com/licenses/agpl-3.0"
+          },
+          {
+            "key": "unlicense",
+            "name": "The Unlicense",
+            "spdx_id": "Unlicense",
+            "url": "https://api.github.com/licenses/unlicense"
+          },
+          {
+            "key": "apache-2.0",
+            "name": "Apache License 2.0",
+            "spdx_id": "Apache-2.0",
+            "url": "https://api.github.com/licenses/apache-2.0"
+          },
+          {
+            "key": "gpl-3.0",
+            "name": "GNU General Public License v3.0",
+            "spdx_id": "GPL-3.0",
+            "url": "https://api.github.com/licenses/gpl-3.0"
+          }
+        ]
+      }
+    ],
+    "idName": "list",
+    "documentationUrl": "https://developer.github.com/v3/licenses/#list-commonly-used-licenses",
+    "deprecated": {
+      "date": "2019-03-05",
+      "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+      "before": {
+        "idName": "list"
+      },
+      "after": {
+        "idName": "list-commonly-used"
+      }
+    }
+  },
+  {
     "name": "Get an individual license",
     "enabledForApps": true,
     "method": "GET",

--- a/routes/api.github.com/licenses/list.json
+++ b/routes/api.github.com/licenses/list.json
@@ -1,0 +1,74 @@
+{
+  "name": "List all licenses",
+  "enabledForApps": true,
+  "method": "GET",
+  "path": "/licenses",
+  "previews": [],
+  "params": [],
+  "description": "",
+  "responses": [
+    {
+      "headers": {
+        "status": "200 OK",
+        "content-type": "application/json; charset=utf-8"
+      },
+      "body": [
+        {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZW1pdA=="
+        },
+        {
+          "key": "lgpl-3.0",
+          "name": "GNU Lesser General Public License v3.0",
+          "spdx_id": "LGPL-3.0",
+          "url": "https://api.github.com/licenses/lgpl-3.0"
+        },
+        {
+          "key": "mpl-2.0",
+          "name": "Mozilla Public License 2.0",
+          "spdx_id": "MPL-2.0",
+          "url": "https://api.github.com/licenses/mpl-2.0"
+        },
+        {
+          "key": "agpl-3.0",
+          "name": "GNU Affero General Public License v3.0",
+          "spdx_id": "AGPL-3.0",
+          "url": "https://api.github.com/licenses/agpl-3.0"
+        },
+        {
+          "key": "unlicense",
+          "name": "The Unlicense",
+          "spdx_id": "Unlicense",
+          "url": "https://api.github.com/licenses/unlicense"
+        },
+        {
+          "key": "apache-2.0",
+          "name": "Apache License 2.0",
+          "spdx_id": "Apache-2.0",
+          "url": "https://api.github.com/licenses/apache-2.0"
+        },
+        {
+          "key": "gpl-3.0",
+          "name": "GNU General Public License v3.0",
+          "spdx_id": "GPL-3.0",
+          "url": "https://api.github.com/licenses/gpl-3.0"
+        }
+      ]
+    }
+  ],
+  "idName": "list",
+  "documentationUrl": "https://developer.github.com/v3/licenses/#list-commonly-used-licenses",
+  "deprecated": {
+    "date": "2019-03-05",
+    "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+    "before": {
+      "idName": "list"
+    },
+    "after": {
+      "idName": "list-commonly-used"
+    }
+  }
+}

--- a/routes/api.github.com/orgs.json
+++ b/routes/api.github.com/orgs.json
@@ -587,6 +587,412 @@
     "documentationUrl": "https://developer.github.com/v3/orgs/blocking/#unblock-a-user"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Must be passed as \"web\".",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Here's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#delete-a-hook"
+  },
+  {
     "name": "Members list",
     "enabledForApps": true,
     "method": "GET",
@@ -1673,411 +2079,5 @@
     ],
     "idName": "convert-member-to-outside-collaborator",
     "documentationUrl": "https://developer.github.com/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Must be passed as \"web\".",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Here's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/v3/orgs/hooks/#delete-a-hook"
   }
 ]

--- a/routes/api.github.com/pulls.json
+++ b/routes/api.github.com/pulls.json
@@ -3295,828 +3295,6 @@
     "documentationUrl": "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button"
   },
   {
-    "name": "List reviews on a pull request",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "The list of reviews returns in chronological order.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        ],
-        "description": "The list of reviews returns in chronological order."
-      }
-    ],
-    "idName": "list-reviews",
-    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-  },
-  {
-    "name": "Get a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "get-review",
-    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-a-single-review"
-  },
-  {
-    "name": "Delete a pending review",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "PENDING",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "delete-pending-review",
-    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review"
-  },
-  {
-    "name": "Get comments for a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-            "id": 10,
-            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-            "pull_request_review_id": 42,
-            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-            "path": "file1.txt",
-            "position": 1,
-            "original_position": 4,
-            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-            "in_reply_to_id": 8,
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Great stuff",
-            "created_at": "2011-04-14T16:00:49Z",
-            "updated_at": "2011-04-14T16:00:49Z",
-            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-            "_links": {
-              "self": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-              },
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-              }
-            }
-          }
-        ]
-      }
-    ],
-    "idName": "get-comments-for-review",
-    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review"
-  },
-  {
-    "name": "Create a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "commit_id",
-        "type": "string",
-        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-        "required": false,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      },
-      {
-        "name": "comments",
-        "type": "object[]",
-        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "comments[].path",
-        "type": "string",
-        "description": "The relative path to the file that necessitates a review comment.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].position",
-        "type": "integer",
-        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].body",
-        "type": "string",
-        "description": "Text of the review comment.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-        "body": "This is close to perfect! Please address the suggested inline change.",
-        "event": "REQUEST_CHANGES",
-        "comments": [
-          {
-            "path": "file.md",
-            "position": 6,
-            "body": "Please add more information here, and fix this typo."
-          }
-        ]
-      }
-    ],
-    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)\" and \"[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://developer.github.com/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "CHANGES_REQUESTED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-review",
-    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review"
-  },
-  {
-    "name": "Update a pull request review",
-    "enabledForApps": true,
-    "method": "PUT",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The body text of the pull request review.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "This is close to perfect! Please address the suggested inline change. And add more about this."
-      }
-    ],
-    "description": "Update the review summary comment with new text.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "This is close to perfect! Please address the suggested inline change. And add more about this.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "CHANGES_REQUESTED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "update-review",
-    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#update-a-pull-request-review"
-  },
-  {
-    "name": "Submit a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The body text of the pull request review",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-        "required": true,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "submit-review",
-    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review"
-  },
-  {
-    "name": "Dismiss a pull request review",
-    "enabledForApps": true,
-    "method": "PUT",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "message",
-        "type": "string",
-        "description": "The message for the pull request review dismissal",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "description": "**Note:** To dismiss a pull request review on a [protected branch](https://developer.github.com/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "DISMISSED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "dismiss-review",
-    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review"
-  },
-  {
     "name": "List comments on a pull request",
     "enabledForApps": true,
     "method": "GET",
@@ -5630,5 +4808,827 @@
     ],
     "idName": "delete-review-request",
     "documentationUrl": "https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request"
+  },
+  {
+    "name": "List reviews on a pull request",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "The list of reviews returns in chronological order.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        ],
+        "description": "The list of reviews returns in chronological order."
+      }
+    ],
+    "idName": "list-reviews",
+    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+  },
+  {
+    "name": "Get a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "get-review",
+    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-a-single-review"
+  },
+  {
+    "name": "Delete a pending review",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "PENDING",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "delete-pending-review",
+    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review"
+  },
+  {
+    "name": "Get comments for a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+            "id": 10,
+            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+            "pull_request_review_id": 42,
+            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+            "path": "file1.txt",
+            "position": 1,
+            "original_position": 4,
+            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+            "in_reply_to_id": 8,
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Great stuff",
+            "created_at": "2011-04-14T16:00:49Z",
+            "updated_at": "2011-04-14T16:00:49Z",
+            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+            "_links": {
+              "self": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+              },
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "idName": "get-comments-for-review",
+    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review"
+  },
+  {
+    "name": "Create a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "commit_id",
+        "type": "string",
+        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+        "required": false,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      },
+      {
+        "name": "comments",
+        "type": "object[]",
+        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "comments[].path",
+        "type": "string",
+        "description": "The relative path to the file that necessitates a review comment.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].position",
+        "type": "integer",
+        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].body",
+        "type": "string",
+        "description": "Text of the review comment.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+        "body": "This is close to perfect! Please address the suggested inline change.",
+        "event": "REQUEST_CHANGES",
+        "comments": [
+          {
+            "path": "file.md",
+            "position": 6,
+            "body": "Please add more information here, and fix this typo."
+          }
+        ]
+      }
+    ],
+    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)\" and \"[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://developer.github.com/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "CHANGES_REQUESTED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-review",
+    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review"
+  },
+  {
+    "name": "Update a pull request review",
+    "enabledForApps": true,
+    "method": "PUT",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The body text of the pull request review.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "This is close to perfect! Please address the suggested inline change. And add more about this."
+      }
+    ],
+    "description": "Update the review summary comment with new text.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "This is close to perfect! Please address the suggested inline change. And add more about this.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "CHANGES_REQUESTED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "update-review",
+    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#update-a-pull-request-review"
+  },
+  {
+    "name": "Submit a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The body text of the pull request review",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+        "required": true,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "submit-review",
+    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review"
+  },
+  {
+    "name": "Dismiss a pull request review",
+    "enabledForApps": true,
+    "method": "PUT",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "message",
+        "type": "string",
+        "description": "The message for the pull request review dismissal",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "description": "**Note:** To dismiss a pull request review on a [protected branch](https://developer.github.com/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "DISMISSED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "dismiss-review",
+    "documentationUrl": "https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review"
   }
 ]

--- a/routes/api.github.com/repos.json
+++ b/routes/api.github.com/repos.json
@@ -6581,229 +6581,6 @@
     "documentationUrl": "https://developer.github.com/v3/repos/contents/#get-archive-link"
   },
   {
-    "name": "List deploy keys",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-deploy-keys",
-    "documentationUrl": "https://developer.github.com/v3/repos/keys/#list-deploy-keys"
-  },
-  {
-    "name": "Get a deploy key",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-deploy-key",
-    "documentationUrl": "https://developer.github.com/v3/repos/keys/#get-a-deploy-key"
-  },
-  {
-    "name": "Add a new deploy key",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A name for the key.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The contents of the key.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "read_only",
-        "type": "boolean",
-        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA...",
-        "read_only": true
-      }
-    ],
-    "description": "Here's how you can create a read-only deploy key:\n\n",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "add-deploy-key",
-    "documentationUrl": "https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key"
-  },
-  {
-    "name": "Remove a deploy key",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "remove-deploy-key",
-    "documentationUrl": "https://developer.github.com/v3/repos/keys/#remove-a-deploy-key"
-  },
-  {
     "name": "List deployments",
     "enabledForApps": true,
     "method": "GET",
@@ -7978,6 +7755,515 @@
     "documentationUrl": "https://developer.github.com/v3/repos/forks/#create-a-fork"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Use `web` to create a webhook. This parameter only accepts the value `web`.",
+        "default": "web",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "add_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "remove_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "add_events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Test a push hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "test-push-hook",
+    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#test-a-push-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#delete-a-hook"
+  },
+  {
     "name": "List invitations for a repository",
     "enabledForApps": true,
     "method": "GET",
@@ -8559,6 +8845,229 @@
     ],
     "idName": "decline-invitation",
     "documentationUrl": "https://developer.github.com/v3/repos/invitations/#decline-a-repository-invitation"
+  },
+  {
+    "name": "List deploy keys",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-deploy-keys",
+    "documentationUrl": "https://developer.github.com/v3/repos/keys/#list-deploy-keys"
+  },
+  {
+    "name": "Get a deploy key",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-deploy-key",
+    "documentationUrl": "https://developer.github.com/v3/repos/keys/#get-a-deploy-key"
+  },
+  {
+    "name": "Add a new deploy key",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A name for the key.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The contents of the key.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "read_only",
+        "type": "boolean",
+        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA...",
+        "read_only": true
+      }
+    ],
+    "description": "Here's how you can create a read-only deploy key:\n\n",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "add-deploy-key",
+    "documentationUrl": "https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key"
+  },
+  {
+    "name": "Remove a deploy key",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "remove-deploy-key",
+    "documentationUrl": "https://developer.github.com/v3/repos/keys/#remove-a-deploy-key"
   },
   {
     "name": "Perform a merge",
@@ -11149,514 +11658,5 @@
     ],
     "idName": "get-clones",
     "documentationUrl": "https://developer.github.com/v3/repos/traffic/#clones"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Use `web` to create a webhook. This parameter only accepts the value `web`.",
-        "default": "web",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\nHere's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](https://developer.github.com/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](https://developer.github.com/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "add_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "remove_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "add_events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Test a push hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "test-push-hook",
-    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#test-a-push-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/v3/repos/hooks/#delete-a-hook"
   }
 ]

--- a/routes/api.github.com/teams.json
+++ b/routes/api.github.com/teams.json
@@ -1154,6 +1154,474 @@
     "documentationUrl": "https://developer.github.com/v3/teams/#remove-team-project"
   },
   {
+    "name": "List comments",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "direction",
+        "type": "string",
+        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+        "default": "desc",
+        "required": false,
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "location": "query"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        ]
+      }
+    ],
+    "idName": "list-discussion-comments",
+    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#list-comments"
+  },
+  {
+    "name": "Get a single comment",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "idName": "get-discussion-comment",
+    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment"
+  },
+  {
+    "name": "Create a comment",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like apples?"
+      }
+    ],
+    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)\" and \"[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)\" for details.",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-discussion-comment",
+    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#create-a-comment"
+  },
+  {
+    "name": "Edit a comment",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like pineapples?"
+      }
+    ],
+    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like pineapples?",
+          "body_html": "<p>Do you like pineapples?</p>",
+          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": "2018-01-26T18:22:20Z",
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-26T18:22:20Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "idName": "edit-discussion-comment",
+    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment"
+  },
+  {
+    "name": "Delete a comment",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-discussion-comment",
+    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment"
+  },
+  {
     "name": "List discussions",
     "enabledForApps": true,
     "method": "GET",
@@ -1628,474 +2096,6 @@
     ],
     "idName": "delete-discussion",
     "documentationUrl": "https://developer.github.com/v3/teams/discussions/#delete-a-discussion"
-  },
-  {
-    "name": "List comments",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "direction",
-        "type": "string",
-        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-        "default": "desc",
-        "required": false,
-        "enum": [
-          "asc",
-          "desc"
-        ],
-        "location": "query"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        ]
-      }
-    ],
-    "idName": "list-discussion-comments",
-    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#list-comments"
-  },
-  {
-    "name": "Get a single comment",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "idName": "get-discussion-comment",
-    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#get-a-single-comment"
-  },
-  {
-    "name": "Create a comment",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like apples?"
-      }
-    ],
-    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)\" and \"[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)\" for details.",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-discussion-comment",
-    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#create-a-comment"
-  },
-  {
-    "name": "Edit a comment",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like pineapples?"
-      }
-    ],
-    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like pineapples?",
-          "body_html": "<p>Do you like pineapples?</p>",
-          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": "2018-01-26T18:22:20Z",
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-26T18:22:20Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "idName": "edit-discussion-comment",
-    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#edit-a-comment"
-  },
-  {
-    "name": "Delete a comment",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-discussion-comment",
-    "documentationUrl": "https://developer.github.com/v3/teams/discussion_comments/#delete-a-comment"
   },
   {
     "name": "List team members",

--- a/routes/api.github.com/users.json
+++ b/routes/api.github.com/users.json
@@ -1018,214 +1018,6 @@
     "documentationUrl": "https://developer.github.com/v3/users/followers/#unfollow-a-user"
   },
   {
-    "name": "List public keys for a user",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/users/:username/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "username",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA..."
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys-for-user",
-    "documentationUrl": "https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user"
-  },
-  {
-    "name": "List your public keys",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys",
-    "documentationUrl": "https://developer.github.com/v3/users/keys/#list-your-public-keys"
-  },
-  {
-    "name": "Get a single public key",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-public-key",
-    "documentationUrl": "https://developer.github.com/v3/users/keys/#get-a-single-public-key"
-  },
-  {
-    "name": "Create a public key",
-    "enabledForApps": false,
-    "method": "POST",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA..."
-      }
-    ],
-    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "create-public-key",
-    "documentationUrl": "https://developer.github.com/v3/users/keys/#create-a-public-key"
-  },
-  {
-    "name": "Delete a public key",
-    "enabledForApps": false,
-    "method": "DELETE",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-public-key",
-    "documentationUrl": "https://developer.github.com/v3/users/keys/#delete-a-public-key"
-  },
-  {
     "name": "List GPG keys for a user",
     "enabledForApps": true,
     "method": "GET",
@@ -1529,5 +1321,213 @@
     ],
     "idName": "delete-gpg-key",
     "documentationUrl": "https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key"
+  },
+  {
+    "name": "List public keys for a user",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/users/:username/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "username",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA..."
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys-for-user",
+    "documentationUrl": "https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user"
+  },
+  {
+    "name": "List your public keys",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys",
+    "documentationUrl": "https://developer.github.com/v3/users/keys/#list-your-public-keys"
+  },
+  {
+    "name": "Get a single public key",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-public-key",
+    "documentationUrl": "https://developer.github.com/v3/users/keys/#get-a-single-public-key"
+  },
+  {
+    "name": "Create a public key",
+    "enabledForApps": false,
+    "method": "POST",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA..."
+      }
+    ],
+    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "create-public-key",
+    "documentationUrl": "https://developer.github.com/v3/users/keys/#create-a-public-key"
+  },
+  {
+    "name": "Delete a public key",
+    "enabledForApps": false,
+    "method": "DELETE",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-public-key",
+    "documentationUrl": "https://developer.github.com/v3/users/keys/#delete-a-public-key"
   }
 ]

--- a/routes/ghe-2.13/enterprise-admin.json
+++ b/routes/ghe-2.13/enterprise-admin.json
@@ -1219,111 +1219,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/management_console/#remove-an-authorized-ssh-key"
   },
   {
-    "name": "Create an organization",
-    "enabledForApps": false,
-    "method": "POST",
-    "path": "/admin/organizations",
-    "previews": [],
-    "params": [
-      {
-        "name": "login",
-        "type": "string",
-        "description": "The organization's username.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "admin",
-        "type": "string",
-        "description": "The login of the user who will manage this organization.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "profile_name",
-        "type": "string",
-        "description": "The organization's display name.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "login": "github",
-        "profile_name": "GitHub, Inc.",
-        "admin": "monalisaoctocat"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "login": "github",
-          "id": 1,
-          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-          "url": "https://api.github.com/orgs/github",
-          "repos_url": "https://api.github.com/orgs/github/repos",
-          "events_url": "https://api.github.com/orgs/github/events",
-          "hooks_url": "https://api.github.com/orgs/github/hooks",
-          "issues_url": "https://api.github.com/orgs/github/issues",
-          "members_url": "https://api.github.com/orgs/github/members{/member}",
-          "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-          "description": "A great organization"
-        }
-      }
-    ],
-    "idName": "create-org",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/#create-an-organization"
-  },
-  {
-    "name": "Rename an organization",
-    "enabledForApps": false,
-    "method": "PATCH",
-    "path": "/admin/organizations/:org",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "login",
-        "type": "string",
-        "description": "The organization's new name.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "login": "the-new-octocats"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "202 Accepted",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "message": "Job queued to rename organization. It may take a few minutes to complete.",
-          "url": "https://<hostname>/api/v3/organizations/1"
-        }
-      }
-    ],
-    "idName": "rename-org",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/#rename-an-organization"
-  },
-  {
     "name": "List pre-receive hooks for organization",
     "enabledForApps": true,
     "method": "GET",
@@ -1456,6 +1351,111 @@
     "description": "Removes any overrides for this hook at the org level for this org.",
     "idName": "remove-enforcement-overrides-for-pre-receive-hook-for-org",
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/org_pre_receive_hooks/#remove-enforcement-overrides-for-a-pre-receive-hook"
+  },
+  {
+    "name": "Create an organization",
+    "enabledForApps": false,
+    "method": "POST",
+    "path": "/admin/organizations",
+    "previews": [],
+    "params": [
+      {
+        "name": "login",
+        "type": "string",
+        "description": "The organization's username.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "admin",
+        "type": "string",
+        "description": "The login of the user who will manage this organization.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "profile_name",
+        "type": "string",
+        "description": "The organization's display name.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "login": "github",
+        "profile_name": "GitHub, Inc.",
+        "admin": "monalisaoctocat"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "login": "github",
+          "id": 1,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+          "url": "https://api.github.com/orgs/github",
+          "repos_url": "https://api.github.com/orgs/github/repos",
+          "events_url": "https://api.github.com/orgs/github/events",
+          "hooks_url": "https://api.github.com/orgs/github/hooks",
+          "issues_url": "https://api.github.com/orgs/github/issues",
+          "members_url": "https://api.github.com/orgs/github/members{/member}",
+          "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+          "description": "A great organization"
+        }
+      }
+    ],
+    "idName": "create-org",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/#create-an-organization"
+  },
+  {
+    "name": "Rename an organization",
+    "enabledForApps": false,
+    "method": "PATCH",
+    "path": "/admin/organizations/:org",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "login",
+        "type": "string",
+        "description": "The organization's new name.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "login": "the-new-octocats"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "202 Accepted",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "message": "Job queued to rename organization. It may take a few minutes to complete.",
+          "url": "https://<hostname>/api/v3/organizations/1"
+        }
+      }
+    ],
+    "idName": "rename-org",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/#rename-an-organization"
   },
   {
     "name": "Get a single pre-receive environment",

--- a/routes/ghe-2.13/index.json
+++ b/routes/ghe-2.13/index.json
@@ -14490,6 +14490,80 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/licenses/#list-commonly-used-licenses"
     },
     {
+      "name": "List all licenses",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/licenses",
+      "previews": [],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "mit",
+              "name": "MIT License",
+              "spdx_id": "MIT",
+              "url": "https://api.github.com/licenses/mit",
+              "node_id": "MDc6TGljZW5zZW1pdA=="
+            },
+            {
+              "key": "lgpl-3.0",
+              "name": "GNU Lesser General Public License v3.0",
+              "spdx_id": "LGPL-3.0",
+              "url": "https://api.github.com/licenses/lgpl-3.0"
+            },
+            {
+              "key": "mpl-2.0",
+              "name": "Mozilla Public License 2.0",
+              "spdx_id": "MPL-2.0",
+              "url": "https://api.github.com/licenses/mpl-2.0"
+            },
+            {
+              "key": "agpl-3.0",
+              "name": "GNU Affero General Public License v3.0",
+              "spdx_id": "AGPL-3.0",
+              "url": "https://api.github.com/licenses/agpl-3.0"
+            },
+            {
+              "key": "unlicense",
+              "name": "The Unlicense",
+              "spdx_id": "Unlicense",
+              "url": "https://api.github.com/licenses/unlicense"
+            },
+            {
+              "key": "apache-2.0",
+              "name": "Apache License 2.0",
+              "spdx_id": "Apache-2.0",
+              "url": "https://api.github.com/licenses/apache-2.0"
+            },
+            {
+              "key": "gpl-3.0",
+              "name": "GNU General Public License v3.0",
+              "spdx_id": "GPL-3.0",
+              "url": "https://api.github.com/licenses/gpl-3.0"
+            }
+          ]
+        }
+      ],
+      "idName": "list",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/licenses/#list-commonly-used-licenses",
+      "deprecated": {
+        "date": "2019-03-05",
+        "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+        "before": {
+          "idName": "list"
+        },
+        "after": {
+          "idName": "list-commonly-used"
+        }
+      }
+    },
+    {
       "name": "Get an individual license",
       "enabledForApps": true,
       "method": "GET",

--- a/routes/ghe-2.13/index.json
+++ b/routes/ghe-2.13/index.json
@@ -1,860 +1,4 @@
 {
-  "oauthAuthorizations": [
-    {
-      "name": "List your grants",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/enterprise/2.13/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/applications/grants/1",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "created_at": "2011-09-06T17:26:27Z",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "scopes": [
-                "public_repo"
-              ]
-            }
-          ]
-        }
-      ],
-      "idName": "list-grants",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#list-your-grants"
-    },
-    {
-      "name": "Get a single grant",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/applications/grants/1",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "created_at": "2011-09-06T17:26:27Z",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "scopes": [
-              "public_repo"
-            ]
-          }
-        }
-      ],
-      "idName": "get-grant",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-a-single-grant"
-    },
-    {
-      "name": "Delete a grant",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-grant",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#delete-a-grant"
-    },
-    {
-      "name": "List your authorizations",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/authorizations/1",
-              "scopes": [
-                "public_repo"
-              ],
-              "token": "",
-              "token_last_eight": "12345678",
-              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "note": "optional note",
-              "note_url": "http://optional/note/url",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z",
-              "fingerprint": "jklmnop12345678"
-            }
-          ]
-        }
-      ],
-      "idName": "list-authorizations",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#list-your-authorizations"
-    },
-    {
-      "name": "Get a single authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "get-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-a-single-authorization"
-    },
-    {
-      "name": "Create a new authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_id",
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "If you need a small number of personal access tokens, implementing the [web flow](/enterprise/2.13/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": ""
-          }
-        }
-      ],
-      "idName": "create-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#create-a-new-authorization"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/enterprise/2.13/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-and-fingerprint",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-fingerprint",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
-      "deprecated": {
-        "date": "2018-12-27",
-        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
-        "before": {
-          "idName": "get-or-create-authorization-for-app-fingerprint"
-        },
-        "after": {
-          "idName": "get-or-create-authorization-for-app-and-fingerprint"
-        }
-      }
-    },
-    {
-      "name": "Update an existing authorization",
-      "enabledForApps": false,
-      "method": "PATCH",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "Replaces the authorization scopes with these.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to add to this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to remove from this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "add_scopes": [
-            "repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "You can only send one of these scope keys at a time.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "update-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#update-an-existing-authorization"
-    },
-    {
-      "name": "Delete an authorization",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#delete-an-authorization"
-    },
-    {
-      "name": "Check an authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "check-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#check-an-authorization"
-    },
-    {
-      "name": "Reset an authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "reset-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#reset-an-authorization"
-    },
-    {
-      "name": "Revoke an authorization for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-authorization-for-application",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
-    },
-    {
-      "name": "Revoke a grant for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/grants/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-grant-for-application",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
-    }
-  ],
   "activity": [
     {
       "name": "List public events",
@@ -2963,6 +2107,1175 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/activity/watching/#stop-watching-a-repository-legacy"
     }
   ],
+  "apps": [
+    {
+      "name": "Get a single GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/apps/:app_slug",
+      "previews": [],
+      "params": [
+        {
+          "name": "app_slug",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-by-slug",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#get-a-single-github-app"
+    },
+    {
+      "name": "Get the authenticated GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-authenticated",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#get-the-authenticated-github-app"
+    },
+    {
+      "name": "Find installations",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "account": {
+                "login": "github",
+                "id": 1,
+                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                "url": "https://api.github.com/orgs/github",
+                "repos_url": "https://api.github.com/orgs/github/repos",
+                "events_url": "https://api.github.com/orgs/github/events",
+                "hooks_url": "https://api.github.com/orgs/github/hooks",
+                "issues_url": "https://api.github.com/orgs/github/issues",
+                "members_url": "https://api.github.com/orgs/github/members{/member}",
+                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "description": "A great organization"
+              },
+              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+              "repositories_url": "https://api.github.com/installation/repositories",
+              "html_url": "https://github.com/organizations/github/settings/installations/1",
+              "app_id": 1,
+              "target_id": 1,
+              "target_type": "Organization",
+              "permissions": {
+                "metadata": "read",
+                "contents": "read",
+                "issues": "write",
+                "single_file": "write"
+              },
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "single_file_name": "config.yml",
+              "repository_selection": "selected"
+            }
+          ],
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#find-installations"
+    },
+    {
+      "name": "Get a single installation",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations/:installation_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "You must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "metadata": "read",
+              "contents": "read",
+              "issues": "write",
+              "single_file": "write"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "single_file_name": "config.yml",
+            "repository_selection": "selected"
+          }
+        }
+      ],
+      "idName": "get-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#get-a-single-installation"
+    },
+    {
+      "name": "List installations for user",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.13/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 2,
+            "installations": [
+              {
+                "id": 1,
+                "account": {
+                  "login": "github",
+                  "id": 1,
+                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                  "url": "https://api.github.com/orgs/github",
+                  "repos_url": "https://api.github.com/orgs/github/repos",
+                  "events_url": "https://api.github.com/orgs/github/events",
+                  "hooks_url": "https://api.github.com/orgs/github/hooks",
+                  "issues_url": "https://api.github.com/orgs/github/issues",
+                  "members_url": "https://api.github.com/orgs/github/members{/member}",
+                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "description": "A great organization"
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              },
+              {
+                "id": 3,
+                "account": {
+                  "login": "octocat",
+                  "id": 2,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              }
+            ]
+          },
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#list-installations-for-user"
+    },
+    {
+      "name": "Create a new installation token",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/installations/:installation_id/access_tokens",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "token": "v1.1f699f1069f60xxx",
+            "expires_at": "2016-07-11T22:14:10Z"
+          }
+        }
+      ],
+      "idName": "create-installation-token",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#create-a-new-installation-token"
+    },
+    {
+      "name": "Find organization installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/orgs/:org/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-org-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#find-organization-installation"
+    },
+    {
+      "name": "Find repository installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-repo-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#find-repository-installation"
+    },
+    {
+      "name": "Find user installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/users/:username/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 3,
+            "account": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "repository_selection": "selected",
+            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/3",
+            "app_id": 2,
+            "target_id": 1,
+            "target_type": "User",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "label"
+            ],
+            "created_at": "2018-02-22T20:51:14Z",
+            "updated_at": "2018-02-22T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-user-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#find-user-installation"
+    },
+    {
+      "name": "List repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/installation/repositories",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0
+              }
+            ]
+          }
+        }
+      ],
+      "idName": "list-repos",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/installations/#list-repositories"
+    },
+    {
+      "name": "List repositories accessible to the user for an installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations/:installation_id/repositories",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        },
+        {
+          "name": "mercy",
+          "description": "**Note:** The `topics` property for repositories on GitHub Enterprise is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.13/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "permissions": {
+                  "admin": false,
+                  "push": false,
+                  "pull": true
+                },
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0
+              }
+            ]
+          },
+          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+        }
+      ],
+      "idName": "list-installation-repos-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
+    },
+    {
+      "name": "Add repository to installation",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.13/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.13/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "add-repo-to-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/installations/#add-repository-to-installation"
+    },
+    {
+      "name": "Remove repository from installation",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.13/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.13/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-repo-from-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/installations/#remove-repository-from-installation"
+    }
+  ],
+  "codesOfConduct": [
+    {
+      "name": "List all codes of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "citizen_code_of_conduct",
+              "name": "Citizen Code of Conduct",
+              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
+            },
+            {
+              "key": "contributor_covenant",
+              "name": "Contributor Covenant",
+              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
+            }
+          ]
+        }
+      ],
+      "idName": "list-conduct-codes",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/codes_of_conduct/#list-all-codes-of-conduct"
+    },
+    {
+      "name": "Get an individual code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct/:key",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-conduct-code",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
+    },
+    {
+      "name": "Get the contents of a repository's code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/community/code_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-for-repo",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
+    }
+  ],
+  "emojis": [
+    {
+      "name": "Get",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/emojis",
+      "previews": [],
+      "params": [],
+      "description": "Lists all the emojis available to use on GitHub Enterprise.\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/emojis/#emojis"
+    }
+  ],
   "enterpriseAdmin": [
     {
       "name": "Get statistics",
@@ -4184,111 +4497,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/management_console/#remove-an-authorized-ssh-key"
     },
     {
-      "name": "Create an organization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/admin/organizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "login",
-          "type": "string",
-          "description": "The organization's username.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "admin",
-          "type": "string",
-          "description": "The login of the user who will manage this organization.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "profile_name",
-          "type": "string",
-          "description": "The organization's display name.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "login": "github",
-          "profile_name": "GitHub, Inc.",
-          "admin": "monalisaoctocat"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "login": "github",
-            "id": 1,
-            "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-            "url": "https://api.github.com/orgs/github",
-            "repos_url": "https://api.github.com/orgs/github/repos",
-            "events_url": "https://api.github.com/orgs/github/events",
-            "hooks_url": "https://api.github.com/orgs/github/hooks",
-            "issues_url": "https://api.github.com/orgs/github/issues",
-            "members_url": "https://api.github.com/orgs/github/members{/member}",
-            "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "description": "A great organization"
-          }
-        }
-      ],
-      "idName": "create-org",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/#create-an-organization"
-    },
-    {
-      "name": "Rename an organization",
-      "enabledForApps": false,
-      "method": "PATCH",
-      "path": "/admin/organizations/:org",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "login",
-          "type": "string",
-          "description": "The organization's new name.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "login": "the-new-octocats"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "202 Accepted",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "message": "Job queued to rename organization. It may take a few minutes to complete.",
-            "url": "https://<hostname>/api/v3/organizations/1"
-          }
-        }
-      ],
-      "idName": "rename-org",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/#rename-an-organization"
-    },
-    {
       "name": "List pre-receive hooks for organization",
       "enabledForApps": true,
       "method": "GET",
@@ -4421,6 +4629,111 @@
       "description": "Removes any overrides for this hook at the org level for this org.",
       "idName": "remove-enforcement-overrides-for-pre-receive-hook-for-org",
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/org_pre_receive_hooks/#remove-enforcement-overrides-for-a-pre-receive-hook"
+    },
+    {
+      "name": "Create an organization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/admin/organizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "login",
+          "type": "string",
+          "description": "The organization's username.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "admin",
+          "type": "string",
+          "description": "The login of the user who will manage this organization.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "profile_name",
+          "type": "string",
+          "description": "The organization's display name.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "login": "github",
+          "profile_name": "GitHub, Inc.",
+          "admin": "monalisaoctocat"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "login": "github",
+            "id": 1,
+            "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+            "url": "https://api.github.com/orgs/github",
+            "repos_url": "https://api.github.com/orgs/github/repos",
+            "events_url": "https://api.github.com/orgs/github/events",
+            "hooks_url": "https://api.github.com/orgs/github/hooks",
+            "issues_url": "https://api.github.com/orgs/github/issues",
+            "members_url": "https://api.github.com/orgs/github/members{/member}",
+            "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "description": "A great organization"
+          }
+        }
+      ],
+      "idName": "create-org",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/#create-an-organization"
+    },
+    {
+      "name": "Rename an organization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "path": "/admin/organizations/:org",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "login",
+          "type": "string",
+          "description": "The organization's new name.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "login": "the-new-octocats"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "202 Accepted",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "message": "Job queued to rename organization. It may take a few minutes to complete.",
+            "url": "https://<hostname>/api/v3/organizations/1"
+          }
+        }
+      ],
+      "idName": "rename-org",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/enterprise-admin/orgs/#rename-an-organization"
     },
     {
       "name": "Get a single pre-receive environment",
@@ -8118,138 +8431,15 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/git/trees/#create-a-tree"
     }
   ],
-  "apps": [
+  "gitignore": [
     {
-      "name": "Get a single GitHub App",
+      "name": "Listing available templates",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/apps/:app_slug",
+      "path": "/gitignore/templates",
       "previews": [],
-      "params": [
-        {
-          "name": "app_slug",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
-        }
-      ],
-      "idName": "get-by-slug",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#get-a-single-github-app"
-    },
-    {
-      "name": "Get the authenticated GitHub App",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
       "params": [],
-      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
-        }
-      ],
-      "idName": "get-authenticated",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#get-the-authenticated-github-app"
-    },
-    {
-      "name": "Find installations",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "description": "List all templates available to pass as an option when [creating a repository](/enterprise/2.13/v3/repos/#create).",
       "responses": [
         {
           "headers": {
@@ -8257,529 +8447,35 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": [
-            {
-              "id": 1,
-              "account": {
-                "login": "github",
-                "id": 1,
-                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                "url": "https://api.github.com/orgs/github",
-                "repos_url": "https://api.github.com/orgs/github/repos",
-                "events_url": "https://api.github.com/orgs/github/events",
-                "hooks_url": "https://api.github.com/orgs/github/hooks",
-                "issues_url": "https://api.github.com/orgs/github/issues",
-                "members_url": "https://api.github.com/orgs/github/members{/member}",
-                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "description": "A great organization"
-              },
-              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-              "repositories_url": "https://api.github.com/installation/repositories",
-              "html_url": "https://github.com/organizations/github/settings/installations/1",
-              "app_id": 1,
-              "target_id": 1,
-              "target_type": "Organization",
-              "permissions": {
-                "metadata": "read",
-                "contents": "read",
-                "issues": "write",
-                "single_file": "write"
-              },
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "single_file_name": "config.yml",
-              "repository_selection": "selected"
-            }
-          ],
-          "description": "The permissions the installation has are included under the `permissions` key."
+            "Actionscript",
+            "Android",
+            "AppceleratorTitanium",
+            "Autotools",
+            "Bancha",
+            "C",
+            "C++"
+          ]
         }
       ],
-      "idName": "list-installations",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#find-installations"
+      "idName": "list-templates",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/gitignore/#listing-available-templates"
     },
     {
-      "name": "Get a single installation",
+      "name": "Get a single template",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/app/installations/:installation_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "You must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "metadata": "read",
-              "contents": "read",
-              "issues": "write",
-              "single_file": "write"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "single_file_name": "config.yml",
-            "repository_selection": "selected"
-          }
-        }
-      ],
-      "idName": "get-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#get-a-single-installation"
-    },
-    {
-      "name": "List installations for user",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.13/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "total_count": 2,
-            "installations": [
-              {
-                "id": 1,
-                "account": {
-                  "login": "github",
-                  "id": 1,
-                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                  "url": "https://api.github.com/orgs/github",
-                  "repos_url": "https://api.github.com/orgs/github/repos",
-                  "events_url": "https://api.github.com/orgs/github/events",
-                  "hooks_url": "https://api.github.com/orgs/github/hooks",
-                  "issues_url": "https://api.github.com/orgs/github/issues",
-                  "members_url": "https://api.github.com/orgs/github/members{/member}",
-                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "description": "A great organization"
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              },
-              {
-                "id": 3,
-                "account": {
-                  "login": "octocat",
-                  "id": 2,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              }
-            ]
-          },
-          "description": "The permissions the installation has are included under the `permissions` key."
-        }
-      ],
-      "idName": "list-installations-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#list-installations-for-user"
-    },
-    {
-      "name": "Create a new installation token",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/installations/:installation_id/access_tokens",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "token": "v1.1f699f1069f60xxx",
-            "expires_at": "2016-07-11T22:14:10Z"
-          }
-        }
-      ],
-      "idName": "create-installation-token",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#create-a-new-installation-token"
-    },
-    {
-      "name": "Find organization installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/orgs/:org/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-org-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#find-organization-installation"
-    },
-    {
-      "name": "Find repository installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-repo-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#find-repository-installation"
-    },
-    {
-      "name": "Find user installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/users/:username/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 3,
-            "account": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "repository_selection": "selected",
-            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/3",
-            "app_id": 2,
-            "target_id": 1,
-            "target_type": "User",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "label"
-            ],
-            "created_at": "2018-02-22T20:51:14Z",
-            "updated_at": "2018-02-22T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-user-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/#find-user-installation"
-    },
-    {
-      "name": "List repositories",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/installation/repositories",
+      "path": "/gitignore/templates/:name",
       "previews": [],
       "params": [
         {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
         }
       ],
-      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](/enterprise/2.13/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/enterprise/2.13/v3/media/) to get the raw contents.\n\n",
       "responses": [
         {
           "headers": {
@@ -8787,359 +8483,20 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0
-              }
-            ]
+            "name": "C",
+            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
           }
-        }
-      ],
-      "idName": "list-repos",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/installations/#list-repositories"
-    },
-    {
-      "name": "List repositories accessible to the user for an installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations/:installation_id/repositories",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
         },
-        {
-          "name": "mercy",
-          "description": "**Note:** The `topics` property for repositories on GitHub Enterprise is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.13/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
-      "responses": [
         {
           "headers": {
             "status": "200 OK",
             "content-type": "application/json; charset=utf-8"
           },
-          "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "permissions": {
-                  "admin": false,
-                  "push": false,
-                  "pull": true
-                },
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0
-              }
-            ]
-          },
-          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+          "description": "Use the raw [media type](/enterprise/2.13/v3/media/) to get the raw contents."
         }
       ],
-      "idName": "list-installation-repos-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
-    },
-    {
-      "name": "Add repository to installation",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.13/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.13/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "add-repo-to-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/installations/#add-repository-to-installation"
-    },
-    {
-      "name": "Remove repository from installation",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.13/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.13/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-repo-from-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/apps/installations/#remove-repository-from-installation"
+      "idName": "get-template",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/gitignore/#get-a-single-template"
     }
   ],
   "issues": [
@@ -14211,219 +13568,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/issues/timeline/#list-events-for-an-issue"
     }
   ],
-  "codesOfConduct": [
-    {
-      "name": "List all codes of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/codes_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "key": "citizen_code_of_conduct",
-              "name": "Citizen Code of Conduct",
-              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
-            },
-            {
-              "key": "contributor_covenant",
-              "name": "Contributor Covenant",
-              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
-            }
-          ]
-        }
-      ],
-      "idName": "list-conduct-codes",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/codes_of_conduct/#list-all-codes-of-conduct"
-    },
-    {
-      "name": "Get an individual code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/codes_of_conduct/:key",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "key",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-conduct-code",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
-    },
-    {
-      "name": "Get the contents of a repository's code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/community/code_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-for-repo",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
-    }
-  ],
-  "emojis": [
-    {
-      "name": "Get",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/emojis",
-      "previews": [],
-      "params": [],
-      "description": "Lists all the emojis available to use on GitHub Enterprise.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/emojis/#emojis"
-    }
-  ],
-  "gitignore": [
-    {
-      "name": "Listing available templates",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates",
-      "previews": [],
-      "params": [],
-      "description": "List all templates available to pass as an option when [creating a repository](/enterprise/2.13/v3/repos/#create).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            "Actionscript",
-            "Android",
-            "AppceleratorTitanium",
-            "Autotools",
-            "Bancha",
-            "C",
-            "C++"
-          ]
-        }
-      ],
-      "idName": "list-templates",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/gitignore/#listing-available-templates"
-    },
-    {
-      "name": "Get a single template",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates/:name",
-      "previews": [],
-      "params": [
-        {
-          "name": "name",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/enterprise/2.13/v3/media/) to get the raw contents.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "name": "C",
-            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
-          }
-        },
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "description": "Use the raw [media type](/enterprise/2.13/v3/media/) to get the raw contents."
-        }
-      ],
-      "idName": "get-template",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/gitignore/#get-a-single-template"
-    }
-  ],
   "licenses": [
     {
       "name": "List commonly used licenses",
@@ -14784,15 +13928,75 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/meta/#meta"
     }
   ],
-  "rateLimit": [
+  "oauthAuthorizations": [
     {
-      "name": "Get your current rate limit status",
-      "enabledForApps": true,
+      "name": "List your grants",
+      "enabledForApps": false,
       "method": "GET",
-      "path": "/rate_limit",
+      "path": "/applications/grants",
       "previews": [],
-      "params": [],
-      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](/enterprise/2.13/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/enterprise/2.13/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](/enterprise/2.13/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/enterprise/2.13/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](/enterprise/2.13/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/enterprise/2.13/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/applications/grants/1",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "created_at": "2011-09-06T17:26:27Z",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "scopes": [
+                "public_repo"
+              ]
+            }
+          ]
+        }
+      ],
+      "idName": "list-grants",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#list-your-grants"
+    },
+    {
+      "name": "Get a single grant",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
       "responses": [
         {
           "headers": {
@@ -14800,33 +14004,784 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "resources": {
-              "core": {
-                "limit": 5000,
-                "remaining": 4999,
-                "reset": 1372700873
-              },
-              "search": {
-                "limit": 30,
-                "remaining": 18,
-                "reset": 1372697452
-              },
-              "graphql": {
-                "limit": 5000,
-                "remaining": 4993,
-                "reset": 1372700389
-              }
+            "id": 1,
+            "url": "https://api.github.com/applications/grants/1",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
             },
-            "rate": {
-              "limit": 5000,
-              "remaining": 4999,
-              "reset": 1372700873
+            "created_at": "2011-09-06T17:26:27Z",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "scopes": [
+              "public_repo"
+            ]
+          }
+        }
+      ],
+      "idName": "get-grant",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-a-single-grant"
+    },
+    {
+      "name": "Delete a grant",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-grant",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#delete-a-grant"
+    },
+    {
+      "name": "List your authorizations",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/authorizations/1",
+              "scopes": [
+                "public_repo"
+              ],
+              "token": "",
+              "token_last_eight": "12345678",
+              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "note": "optional note",
+              "note_url": "http://optional/note/url",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z",
+              "fingerprint": "jklmnop12345678"
+            }
+          ]
+        }
+      ],
+      "idName": "list-authorizations",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#list-your-authorizations"
+    },
+    {
+      "name": "Get a single authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "get-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-a-single-authorization"
+    },
+    {
+      "name": "Create a new authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_id",
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "If you need a small number of personal access tokens, implementing the [web flow](/enterprise/2.13/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": ""
+          }
+        }
+      ],
+      "idName": "create-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#create-a-new-authorization"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/enterprise/2.13/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-and-fingerprint",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-fingerprint",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
+      "deprecated": {
+        "date": "2018-12-27",
+        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
+        "before": {
+          "idName": "get-or-create-authorization-for-app-fingerprint"
+        },
+        "after": {
+          "idName": "get-or-create-authorization-for-app-and-fingerprint"
+        }
+      }
+    },
+    {
+      "name": "Update an existing authorization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "Replaces the authorization scopes with these.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to add to this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to remove from this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "add_scopes": [
+            "repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "You can only send one of these scope keys at a time.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "update-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#update-an-existing-authorization"
+    },
+    {
+      "name": "Delete an authorization",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#delete-an-authorization"
+    },
+    {
+      "name": "Check an authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
             }
           }
         }
       ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/rate_limit/#get-your-current-rate-limit-status"
+      "idName": "check-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#check-an-authorization"
+    },
+    {
+      "name": "Reset an authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            }
+          }
+        }
+      ],
+      "idName": "reset-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#reset-an-authorization"
+    },
+    {
+      "name": "Revoke an authorization for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-authorization-for-application",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
+    },
+    {
+      "name": "Revoke a grant for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/grants/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/enterprise/2.13/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-grant-for-application",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
     }
   ],
   "orgs": [
@@ -15230,6 +15185,412 @@
       ],
       "idName": "edit",
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/#edit-an-organization"
+    },
+    {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/orgs/octocat/hooks/1",
+              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Must be passed as \"web\".",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Here's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This will trigger a [ping event](/enterprise/2.13/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#delete-a-hook"
     },
     {
       "name": "Members list",
@@ -16108,412 +16469,6 @@
       ],
       "idName": "convert-member-to-outside-collaborator",
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-    },
-    {
-      "name": "List hooks",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/orgs/octocat/hooks/1",
-              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#list-hooks"
-    },
-    {
-      "name": "Get single hook",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#get-single-hook"
-    },
-    {
-      "name": "Create a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Must be passed as \"web\".",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Here's how you can create a hook that posts payloads in JSON format:",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#create-a-hook"
-    },
-    {
-      "name": "Edit a hook",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "active": true,
-          "events": [
-            "pull_request"
-          ]
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#edit-a-hook"
-    },
-    {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This will trigger a [ping event](/enterprise/2.13/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#delete-a-hook"
     }
   ],
   "projects": [
@@ -20961,731 +20916,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/#merge-a-pull-request-merge-button"
     },
     {
-      "name": "List reviews on a pull request",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "The list of reviews returns in chronological order.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 80,
-              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Here is the body for the review.",
-              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-              "state": "APPROVED",
-              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-              "_links": {
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-                }
-              }
-            }
-          ],
-          "description": "The list of reviews returns in chronological order."
-        }
-      ],
-      "idName": "list-reviews",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-    },
-    {
-      "name": "Get a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "get-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#get-a-single-review"
-    },
-    {
-      "name": "Delete a pending review",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "PENDING",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "delete-pending-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#delete-a-pending-review"
-    },
-    {
-      "name": "Get comments for a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-              "id": 10,
-              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-              "pull_request_review_id": 42,
-              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-              "path": "file1.txt",
-              "position": 1,
-              "original_position": 4,
-              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-              "in_reply_to_id": 8,
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Great stuff",
-              "created_at": "2011-04-14T16:00:49Z",
-              "updated_at": "2011-04-14T16:00:49Z",
-              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-              "_links": {
-                "self": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-                },
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "get-comments-for-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#get-comments-for-a-single-review"
-    },
-    {
-      "name": "Create a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "commit_id",
-          "type": "string",
-          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.13/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-          "required": false,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        },
-        {
-          "name": "comments",
-          "type": "object[]",
-          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "comments[].path",
-          "type": "string",
-          "description": "The relative path to the file that necessitates a review comment.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].position",
-          "type": "integer",
-          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].body",
-          "type": "string",
-          "description": "Text of the review comment.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "event": "REQUEST_CHANGES",
-          "comments": [
-            {
-              "path": "file.md",
-              "position": 6,
-              "body": "Please add more information here, and fix this typo."
-            }
-          ]
-        }
-      ],
-      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.13/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.13/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.13/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "This is close to perfect! Please address the suggested inline change.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "CHANGES_REQUESTED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#create-a-pull-request-review"
-    },
-    {
-      "name": "Submit a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The body text of the pull request review",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-          "required": true,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "submit-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#submit-a-pull-request-review"
-    },
-    {
-      "name": "Dismiss a pull request review",
-      "enabledForApps": true,
-      "method": "PUT",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "message",
-          "type": "string",
-          "description": "The message for the pull request review dismissal",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.13/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "DISMISSED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "dismiss-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#dismiss-a-pull-request-review"
-    },
-    {
       "name": "List comments on a pull request",
       "enabledForApps": true,
       "method": "GET",
@@ -23180,6 +22410,776 @@
       ],
       "idName": "delete-review-request",
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/review_requests/#delete-a-review-request"
+    },
+    {
+      "name": "List reviews on a pull request",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "The list of reviews returns in chronological order.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 80,
+              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Here is the body for the review.",
+              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+              "state": "APPROVED",
+              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+              "_links": {
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+                }
+              }
+            }
+          ],
+          "description": "The list of reviews returns in chronological order."
+        }
+      ],
+      "idName": "list-reviews",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+    },
+    {
+      "name": "Get a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "get-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#get-a-single-review"
+    },
+    {
+      "name": "Delete a pending review",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "PENDING",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "delete-pending-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#delete-a-pending-review"
+    },
+    {
+      "name": "Get comments for a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+              "id": 10,
+              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+              "pull_request_review_id": 42,
+              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+              "path": "file1.txt",
+              "position": 1,
+              "original_position": 4,
+              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+              "in_reply_to_id": 8,
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Great stuff",
+              "created_at": "2011-04-14T16:00:49Z",
+              "updated_at": "2011-04-14T16:00:49Z",
+              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+              "_links": {
+                "self": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+                },
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "get-comments-for-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#get-comments-for-a-single-review"
+    },
+    {
+      "name": "Create a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "commit_id",
+          "type": "string",
+          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.13/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+          "required": false,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        },
+        {
+          "name": "comments",
+          "type": "object[]",
+          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "comments[].path",
+          "type": "string",
+          "description": "The relative path to the file that necessitates a review comment.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].position",
+          "type": "integer",
+          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].body",
+          "type": "string",
+          "description": "Text of the review comment.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "event": "REQUEST_CHANGES",
+          "comments": [
+            {
+              "path": "file.md",
+              "position": 6,
+              "body": "Please add more information here, and fix this typo."
+            }
+          ]
+        }
+      ],
+      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.13/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.13/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.13/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "This is close to perfect! Please address the suggested inline change.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "CHANGES_REQUESTED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#create-a-pull-request-review"
+    },
+    {
+      "name": "Submit a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The body text of the pull request review",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+          "required": true,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "submit-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#submit-a-pull-request-review"
+    },
+    {
+      "name": "Dismiss a pull request review",
+      "enabledForApps": true,
+      "method": "PUT",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "message",
+          "type": "string",
+          "description": "The message for the pull request review dismissal",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.13/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "DISMISSED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "dismiss-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#dismiss-a-pull-request-review"
+    }
+  ],
+  "rateLimit": [
+    {
+      "name": "Get your current rate limit status",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/rate_limit",
+      "previews": [],
+      "params": [],
+      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](/enterprise/2.13/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/enterprise/2.13/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](/enterprise/2.13/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/enterprise/2.13/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](/enterprise/2.13/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "resources": {
+              "core": {
+                "limit": 5000,
+                "remaining": 4999,
+                "reset": 1372700873
+              },
+              "search": {
+                "limit": 30,
+                "remaining": 18,
+                "reset": 1372697452
+              },
+              "graphql": {
+                "limit": 5000,
+                "remaining": 4993,
+                "reset": 1372700389
+              }
+            },
+            "rate": {
+              "limit": 5000,
+              "remaining": 4999,
+              "reset": 1372700873
+            }
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/rate_limit/#get-your-current-rate-limit-status"
     }
   ],
   "reactions": [
@@ -30465,229 +30465,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/contents/#get-archive-link"
     },
     {
-      "name": "List deploy keys",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-deploy-keys",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#list-deploy-keys"
-    },
-    {
-      "name": "Get a deploy key",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#get-a-deploy-key"
-    },
-    {
-      "name": "Add a new deploy key",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A name for the key.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The contents of the key.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "read_only",
-          "type": "boolean",
-          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA...",
-          "read_only": true
-        }
-      ],
-      "description": "Here's how you can create a read-only deploy key:\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "add-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#add-a-new-deploy-key"
-    },
-    {
-      "name": "Remove a deploy key",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#remove-a-deploy-key"
-    },
-    {
       "name": "List deployments",
       "enabledForApps": true,
       "method": "GET",
@@ -31818,6 +31595,514 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/forks/#create-a-fork"
     },
     {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com/webhook",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) for details.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "add_events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Test a push hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "test-push-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#test-a-push-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.13/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#delete-a-hook"
+    },
+    {
       "name": "List invitations for a repository",
       "enabledForApps": true,
       "method": "GET",
@@ -32399,6 +32684,229 @@
       ],
       "idName": "decline-invitation",
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/invitations/#decline-a-repository-invitation"
+    },
+    {
+      "name": "List deploy keys",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-deploy-keys",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#list-deploy-keys"
+    },
+    {
+      "name": "Get a deploy key",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#get-a-deploy-key"
+    },
+    {
+      "name": "Add a new deploy key",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A name for the key.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The contents of the key.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "read_only",
+          "type": "boolean",
+          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA...",
+          "read_only": true
+        }
+      ],
+      "description": "Here's how you can create a read-only deploy key:\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "add-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#add-a-new-deploy-key"
+    },
+    {
+      "name": "Remove a deploy key",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#remove-a-deploy-key"
     },
     {
       "name": "Perform a merge",
@@ -34536,514 +35044,6 @@
       ],
       "idName": "get-combined-status-for-ref",
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref"
-    },
-    {
-      "name": "List hooks",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com/webhook",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#list-hooks"
-    },
-    {
-      "name": "Get single hook",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#get-single-hook"
-    },
-    {
-      "name": "Create a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) for details.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#create-a-hook"
-    },
-    {
-      "name": "Edit a hook",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "active": true,
-          "add_events": [
-            "pull_request"
-          ]
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#edit-a-hook"
-    },
-    {
-      "name": "Test a push hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "test-push-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#test-a-push-hook"
-    },
-    {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.13/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#delete-a-hook"
     }
   ],
   "search": [
@@ -36597,6 +36597,414 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/#list-user-teams"
     },
     {
+      "name": "List comments",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "direction",
+          "type": "string",
+          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "location": "query"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "author": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Do you like apples?",
+              "body_html": "<p>Do you like apples?</p>",
+              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+              "created_at": "2018-01-15T23:53:58Z",
+              "last_edited_at": null,
+              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+              "number": 1,
+              "updated_at": "2018-01-15T23:53:58Z",
+              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
+            }
+          ]
+        }
+      ],
+      "idName": "list-discussion-comments",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#list-comments"
+    },
+    {
+      "name": "Get a single comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
+          }
+        }
+      ],
+      "idName": "get-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#get-a-single-comment"
+    },
+    {
+      "name": "Create a comment",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like apples?"
+        }
+      ],
+      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.13/v3/#abuse-rate-limits)\" for details.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#create-a-comment"
+    },
+    {
+      "name": "Edit a comment",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like pineapples?"
+        }
+      ],
+      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like pineapples?",
+            "body_html": "<p>Do you like pineapples?</p>",
+            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": "2018-01-26T18:22:20Z",
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-26T18:22:20Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
+          }
+        }
+      ],
+      "idName": "edit-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#edit-a-comment"
+    },
+    {
+      "name": "Delete a comment",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#delete-a-comment"
+    },
+    {
       "name": "List discussions",
       "enabledForApps": true,
       "method": "GET",
@@ -37011,414 +37419,6 @@
       ],
       "idName": "delete-discussion",
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussions/#delete-a-discussion"
-    },
-    {
-      "name": "List comments",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "direction",
-          "type": "string",
-          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-          "default": "desc",
-          "required": false,
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "location": "query"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "author": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Do you like apples?",
-              "body_html": "<p>Do you like apples?</p>",
-              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-              "created_at": "2018-01-15T23:53:58Z",
-              "last_edited_at": null,
-              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-              "number": 1,
-              "updated_at": "2018-01-15T23:53:58Z",
-              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
-            }
-          ]
-        }
-      ],
-      "idName": "list-discussion-comments",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#list-comments"
-    },
-    {
-      "name": "Get a single comment",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
-          }
-        }
-      ],
-      "idName": "get-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#get-a-single-comment"
-    },
-    {
-      "name": "Create a comment",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like apples?"
-        }
-      ],
-      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.13/v3/#abuse-rate-limits)\" for details.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#create-a-comment"
-    },
-    {
-      "name": "Edit a comment",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like pineapples?"
-        }
-      ],
-      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like pineapples?",
-            "body_html": "<p>Do you like pineapples?</p>",
-            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": "2018-01-26T18:22:20Z",
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-26T18:22:20Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
-          }
-        }
-      ],
-      "idName": "edit-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#edit-a-comment"
-    },
-    {
-      "name": "Delete a comment",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#delete-a-comment"
     },
     {
       "name": "List team members",
@@ -38504,214 +38504,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/followers/#unfollow-a-user"
     },
     {
-      "name": "List public keys for a user",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/users/:username/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA..."
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys-for-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#list-public-keys-for-a-user"
-    },
-    {
-      "name": "List your public keys",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/user/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#list-your-public-keys"
-    },
-    {
-      "name": "Get a single public key",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#get-a-single-public-key"
-    },
-    {
-      "name": "Create a public key",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA..."
-        }
-      ],
-      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "create-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#create-a-public-key"
-    },
-    {
-      "name": "Delete a public key",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#delete-a-public-key"
-    },
-    {
       "name": "List GPG keys for a user",
       "enabledForApps": true,
       "method": "GET",
@@ -39015,6 +38807,214 @@
       ],
       "idName": "delete-gpg-key",
       "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/gpg_keys/#delete-a-gpg-key"
+    },
+    {
+      "name": "List public keys for a user",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/users/:username/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA..."
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys-for-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#list-public-keys-for-a-user"
+    },
+    {
+      "name": "List your public keys",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/user/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#list-your-public-keys"
+    },
+    {
+      "name": "Get a single public key",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#get-a-single-public-key"
+    },
+    {
+      "name": "Create a public key",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA..."
+        }
+      ],
+      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "create-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#create-a-public-key"
+    },
+    {
+      "name": "Delete a public key",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#delete-a-public-key"
     }
   ]
 }

--- a/routes/ghe-2.13/licenses.json
+++ b/routes/ghe-2.13/licenses.json
@@ -64,6 +64,80 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/licenses/#list-commonly-used-licenses"
   },
   {
+    "name": "List all licenses",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/licenses",
+    "previews": [],
+    "params": [],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "key": "mit",
+            "name": "MIT License",
+            "spdx_id": "MIT",
+            "url": "https://api.github.com/licenses/mit",
+            "node_id": "MDc6TGljZW5zZW1pdA=="
+          },
+          {
+            "key": "lgpl-3.0",
+            "name": "GNU Lesser General Public License v3.0",
+            "spdx_id": "LGPL-3.0",
+            "url": "https://api.github.com/licenses/lgpl-3.0"
+          },
+          {
+            "key": "mpl-2.0",
+            "name": "Mozilla Public License 2.0",
+            "spdx_id": "MPL-2.0",
+            "url": "https://api.github.com/licenses/mpl-2.0"
+          },
+          {
+            "key": "agpl-3.0",
+            "name": "GNU Affero General Public License v3.0",
+            "spdx_id": "AGPL-3.0",
+            "url": "https://api.github.com/licenses/agpl-3.0"
+          },
+          {
+            "key": "unlicense",
+            "name": "The Unlicense",
+            "spdx_id": "Unlicense",
+            "url": "https://api.github.com/licenses/unlicense"
+          },
+          {
+            "key": "apache-2.0",
+            "name": "Apache License 2.0",
+            "spdx_id": "Apache-2.0",
+            "url": "https://api.github.com/licenses/apache-2.0"
+          },
+          {
+            "key": "gpl-3.0",
+            "name": "GNU General Public License v3.0",
+            "spdx_id": "GPL-3.0",
+            "url": "https://api.github.com/licenses/gpl-3.0"
+          }
+        ]
+      }
+    ],
+    "idName": "list",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/licenses/#list-commonly-used-licenses",
+    "deprecated": {
+      "date": "2019-03-05",
+      "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+      "before": {
+        "idName": "list"
+      },
+      "after": {
+        "idName": "list-commonly-used"
+      }
+    }
+  },
+  {
     "name": "Get an individual license",
     "enabledForApps": true,
     "method": "GET",

--- a/routes/ghe-2.13/licenses/list.json
+++ b/routes/ghe-2.13/licenses/list.json
@@ -1,0 +1,74 @@
+{
+  "name": "List all licenses",
+  "enabledForApps": true,
+  "method": "GET",
+  "path": "/licenses",
+  "previews": [],
+  "params": [],
+  "description": "",
+  "responses": [
+    {
+      "headers": {
+        "status": "200 OK",
+        "content-type": "application/json; charset=utf-8"
+      },
+      "body": [
+        {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZW1pdA=="
+        },
+        {
+          "key": "lgpl-3.0",
+          "name": "GNU Lesser General Public License v3.0",
+          "spdx_id": "LGPL-3.0",
+          "url": "https://api.github.com/licenses/lgpl-3.0"
+        },
+        {
+          "key": "mpl-2.0",
+          "name": "Mozilla Public License 2.0",
+          "spdx_id": "MPL-2.0",
+          "url": "https://api.github.com/licenses/mpl-2.0"
+        },
+        {
+          "key": "agpl-3.0",
+          "name": "GNU Affero General Public License v3.0",
+          "spdx_id": "AGPL-3.0",
+          "url": "https://api.github.com/licenses/agpl-3.0"
+        },
+        {
+          "key": "unlicense",
+          "name": "The Unlicense",
+          "spdx_id": "Unlicense",
+          "url": "https://api.github.com/licenses/unlicense"
+        },
+        {
+          "key": "apache-2.0",
+          "name": "Apache License 2.0",
+          "spdx_id": "Apache-2.0",
+          "url": "https://api.github.com/licenses/apache-2.0"
+        },
+        {
+          "key": "gpl-3.0",
+          "name": "GNU General Public License v3.0",
+          "spdx_id": "GPL-3.0",
+          "url": "https://api.github.com/licenses/gpl-3.0"
+        }
+      ]
+    }
+  ],
+  "idName": "list",
+  "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/licenses/#list-commonly-used-licenses",
+  "deprecated": {
+    "date": "2019-03-05",
+    "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+    "before": {
+      "idName": "list"
+    },
+    "after": {
+      "idName": "list-commonly-used"
+    }
+  }
+}

--- a/routes/ghe-2.13/orgs.json
+++ b/routes/ghe-2.13/orgs.json
@@ -401,6 +401,412 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/#edit-an-organization"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Must be passed as \"web\".",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Here's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "This will trigger a [ping event](/enterprise/2.13/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#delete-a-hook"
+  },
+  {
     "name": "Members list",
     "enabledForApps": true,
     "method": "GET",
@@ -1277,411 +1683,5 @@
     ],
     "idName": "convert-member-to-outside-collaborator",
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Must be passed as \"web\".",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Here's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "This will trigger a [ping event](/enterprise/2.13/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/orgs/hooks/#delete-a-hook"
   }
 ]

--- a/routes/ghe-2.13/pulls.json
+++ b/routes/ghe-2.13/pulls.json
@@ -3265,731 +3265,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/#merge-a-pull-request-merge-button"
   },
   {
-    "name": "List reviews on a pull request",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "The list of reviews returns in chronological order.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        ],
-        "description": "The list of reviews returns in chronological order."
-      }
-    ],
-    "idName": "list-reviews",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-  },
-  {
-    "name": "Get a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "get-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#get-a-single-review"
-  },
-  {
-    "name": "Delete a pending review",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "PENDING",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "delete-pending-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#delete-a-pending-review"
-  },
-  {
-    "name": "Get comments for a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-            "id": 10,
-            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-            "pull_request_review_id": 42,
-            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-            "path": "file1.txt",
-            "position": 1,
-            "original_position": 4,
-            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-            "in_reply_to_id": 8,
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Great stuff",
-            "created_at": "2011-04-14T16:00:49Z",
-            "updated_at": "2011-04-14T16:00:49Z",
-            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-            "_links": {
-              "self": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-              },
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-              }
-            }
-          }
-        ]
-      }
-    ],
-    "idName": "get-comments-for-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#get-comments-for-a-single-review"
-  },
-  {
-    "name": "Create a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "commit_id",
-        "type": "string",
-        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.13/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-        "required": false,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      },
-      {
-        "name": "comments",
-        "type": "object[]",
-        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "comments[].path",
-        "type": "string",
-        "description": "The relative path to the file that necessitates a review comment.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].position",
-        "type": "integer",
-        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].body",
-        "type": "string",
-        "description": "Text of the review comment.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-        "body": "This is close to perfect! Please address the suggested inline change.",
-        "event": "REQUEST_CHANGES",
-        "comments": [
-          {
-            "path": "file.md",
-            "position": 6,
-            "body": "Please add more information here, and fix this typo."
-          }
-        ]
-      }
-    ],
-    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.13/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.13/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.13/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "CHANGES_REQUESTED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#create-a-pull-request-review"
-  },
-  {
-    "name": "Submit a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The body text of the pull request review",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-        "required": true,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "submit-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#submit-a-pull-request-review"
-  },
-  {
-    "name": "Dismiss a pull request review",
-    "enabledForApps": true,
-    "method": "PUT",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "message",
-        "type": "string",
-        "description": "The message for the pull request review dismissal",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.13/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "DISMISSED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "dismiss-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#dismiss-a-pull-request-review"
-  },
-  {
     "name": "List comments on a pull request",
     "enabledForApps": true,
     "method": "GET",
@@ -5484,5 +4759,730 @@
     ],
     "idName": "delete-review-request",
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/review_requests/#delete-a-review-request"
+  },
+  {
+    "name": "List reviews on a pull request",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "The list of reviews returns in chronological order.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        ],
+        "description": "The list of reviews returns in chronological order."
+      }
+    ],
+    "idName": "list-reviews",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+  },
+  {
+    "name": "Get a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "get-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#get-a-single-review"
+  },
+  {
+    "name": "Delete a pending review",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "PENDING",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "delete-pending-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#delete-a-pending-review"
+  },
+  {
+    "name": "Get comments for a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+            "id": 10,
+            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+            "pull_request_review_id": 42,
+            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+            "path": "file1.txt",
+            "position": 1,
+            "original_position": 4,
+            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+            "in_reply_to_id": 8,
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Great stuff",
+            "created_at": "2011-04-14T16:00:49Z",
+            "updated_at": "2011-04-14T16:00:49Z",
+            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+            "_links": {
+              "self": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+              },
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "idName": "get-comments-for-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#get-comments-for-a-single-review"
+  },
+  {
+    "name": "Create a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "commit_id",
+        "type": "string",
+        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.13/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+        "required": false,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      },
+      {
+        "name": "comments",
+        "type": "object[]",
+        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "comments[].path",
+        "type": "string",
+        "description": "The relative path to the file that necessitates a review comment.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].position",
+        "type": "integer",
+        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].body",
+        "type": "string",
+        "description": "Text of the review comment.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+        "body": "This is close to perfect! Please address the suggested inline change.",
+        "event": "REQUEST_CHANGES",
+        "comments": [
+          {
+            "path": "file.md",
+            "position": 6,
+            "body": "Please add more information here, and fix this typo."
+          }
+        ]
+      }
+    ],
+    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.13/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.13/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.13/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "CHANGES_REQUESTED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#create-a-pull-request-review"
+  },
+  {
+    "name": "Submit a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The body text of the pull request review",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+        "required": true,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "submit-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#submit-a-pull-request-review"
+  },
+  {
+    "name": "Dismiss a pull request review",
+    "enabledForApps": true,
+    "method": "PUT",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "message",
+        "type": "string",
+        "description": "The message for the pull request review dismissal",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.13/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "DISMISSED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "dismiss-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/pulls/reviews/#dismiss-a-pull-request-review"
   }
 ]

--- a/routes/ghe-2.13/repos.json
+++ b/routes/ghe-2.13/repos.json
@@ -6450,229 +6450,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/contents/#get-archive-link"
   },
   {
-    "name": "List deploy keys",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-deploy-keys",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#list-deploy-keys"
-  },
-  {
-    "name": "Get a deploy key",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#get-a-deploy-key"
-  },
-  {
-    "name": "Add a new deploy key",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A name for the key.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The contents of the key.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "read_only",
-        "type": "boolean",
-        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA...",
-        "read_only": true
-      }
-    ],
-    "description": "Here's how you can create a read-only deploy key:\n\n",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "add-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#add-a-new-deploy-key"
-  },
-  {
-    "name": "Remove a deploy key",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "remove-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#remove-a-deploy-key"
-  },
-  {
     "name": "List deployments",
     "enabledForApps": true,
     "method": "GET",
@@ -7803,6 +7580,514 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/forks/#create-a-fork"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) for details.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "add_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "remove_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "add_events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Test a push hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "test-push-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#test-a-push-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.13/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#delete-a-hook"
+  },
+  {
     "name": "List invitations for a repository",
     "enabledForApps": true,
     "method": "GET",
@@ -8384,6 +8669,229 @@
     ],
     "idName": "decline-invitation",
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/invitations/#decline-a-repository-invitation"
+  },
+  {
+    "name": "List deploy keys",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-deploy-keys",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#list-deploy-keys"
+  },
+  {
+    "name": "Get a deploy key",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#get-a-deploy-key"
+  },
+  {
+    "name": "Add a new deploy key",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A name for the key.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The contents of the key.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "read_only",
+        "type": "boolean",
+        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA...",
+        "read_only": true
+      }
+    ],
+    "description": "Here's how you can create a read-only deploy key:\n\n",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "add-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#add-a-new-deploy-key"
+  },
+  {
+    "name": "Remove a deploy key",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "remove-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/keys/#remove-a-deploy-key"
   },
   {
     "name": "Perform a merge",
@@ -10521,513 +11029,5 @@
     ],
     "idName": "get-combined-status-for-ref",
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) for details.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.13/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.13/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "add_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "remove_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "add_events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Test a push hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "test-push-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#test-a-push-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.13/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.13/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/repos/hooks/#delete-a-hook"
   }
 ]

--- a/routes/ghe-2.13/teams.json
+++ b/routes/ghe-2.13/teams.json
@@ -888,6 +888,414 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/#list-user-teams"
   },
   {
+    "name": "List comments",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "direction",
+        "type": "string",
+        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+        "default": "desc",
+        "required": false,
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "location": "query"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
+          }
+        ]
+      }
+    ],
+    "idName": "list-discussion-comments",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#list-comments"
+  },
+  {
+    "name": "Get a single comment",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
+        }
+      }
+    ],
+    "idName": "get-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#get-a-single-comment"
+  },
+  {
+    "name": "Create a comment",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like apples?"
+      }
+    ],
+    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.13/v3/#abuse-rate-limits)\" for details.",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#create-a-comment"
+  },
+  {
+    "name": "Edit a comment",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like pineapples?"
+      }
+    ],
+    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like pineapples?",
+          "body_html": "<p>Do you like pineapples?</p>",
+          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": "2018-01-26T18:22:20Z",
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-26T18:22:20Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
+        }
+      }
+    ],
+    "idName": "edit-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#edit-a-comment"
+  },
+  {
+    "name": "Delete a comment",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#delete-a-comment"
+  },
+  {
     "name": "List discussions",
     "enabledForApps": true,
     "method": "GET",
@@ -1302,414 +1710,6 @@
     ],
     "idName": "delete-discussion",
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussions/#delete-a-discussion"
-  },
-  {
-    "name": "List comments",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "direction",
-        "type": "string",
-        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-        "default": "desc",
-        "required": false,
-        "enum": [
-          "asc",
-          "desc"
-        ],
-        "location": "query"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
-          }
-        ]
-      }
-    ],
-    "idName": "list-discussion-comments",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#list-comments"
-  },
-  {
-    "name": "Get a single comment",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
-        }
-      }
-    ],
-    "idName": "get-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#get-a-single-comment"
-  },
-  {
-    "name": "Create a comment",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like apples?"
-      }
-    ],
-    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.13/v3/#abuse-rate-limits)\" for details.",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#create-a-comment"
-  },
-  {
-    "name": "Edit a comment",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like pineapples?"
-      }
-    ],
-    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like pineapples?",
-          "body_html": "<p>Do you like pineapples?</p>",
-          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": "2018-01-26T18:22:20Z",
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-26T18:22:20Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1"
-        }
-      }
-    ],
-    "idName": "edit-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#edit-a-comment"
-  },
-  {
-    "name": "Delete a comment",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.13/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/teams/discussion_comments/#delete-a-comment"
   },
   {
     "name": "List team members",

--- a/routes/ghe-2.13/users.json
+++ b/routes/ghe-2.13/users.json
@@ -765,214 +765,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/followers/#unfollow-a-user"
   },
   {
-    "name": "List public keys for a user",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/users/:username/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "username",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA..."
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys-for-user",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#list-public-keys-for-a-user"
-  },
-  {
-    "name": "List your public keys",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#list-your-public-keys"
-  },
-  {
-    "name": "Get a single public key",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#get-a-single-public-key"
-  },
-  {
-    "name": "Create a public key",
-    "enabledForApps": false,
-    "method": "POST",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA..."
-      }
-    ],
-    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "create-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#create-a-public-key"
-  },
-  {
-    "name": "Delete a public key",
-    "enabledForApps": false,
-    "method": "DELETE",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#delete-a-public-key"
-  },
-  {
     "name": "List GPG keys for a user",
     "enabledForApps": true,
     "method": "GET",
@@ -1276,5 +1068,213 @@
     ],
     "idName": "delete-gpg-key",
     "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/gpg_keys/#delete-a-gpg-key"
+  },
+  {
+    "name": "List public keys for a user",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/users/:username/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "username",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA..."
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys-for-user",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#list-public-keys-for-a-user"
+  },
+  {
+    "name": "List your public keys",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#list-your-public-keys"
+  },
+  {
+    "name": "Get a single public key",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#get-a-single-public-key"
+  },
+  {
+    "name": "Create a public key",
+    "enabledForApps": false,
+    "method": "POST",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA..."
+      }
+    ],
+    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "create-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#create-a-public-key"
+  },
+  {
+    "name": "Delete a public key",
+    "enabledForApps": false,
+    "method": "DELETE",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.13/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.13/v3/users/keys/#delete-a-public-key"
   }
 ]

--- a/routes/ghe-2.14/enterprise-admin.json
+++ b/routes/ghe-2.14/enterprise-admin.json
@@ -1219,111 +1219,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/management_console/#remove-an-authorized-ssh-key"
   },
   {
-    "name": "Create an organization",
-    "enabledForApps": false,
-    "method": "POST",
-    "path": "/admin/organizations",
-    "previews": [],
-    "params": [
-      {
-        "name": "login",
-        "type": "string",
-        "description": "The organization's username.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "admin",
-        "type": "string",
-        "description": "The login of the user who will manage this organization.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "profile_name",
-        "type": "string",
-        "description": "The organization's display name.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "login": "github",
-        "profile_name": "GitHub, Inc.",
-        "admin": "monalisaoctocat"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "login": "github",
-          "id": 1,
-          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-          "url": "https://api.github.com/orgs/github",
-          "repos_url": "https://api.github.com/orgs/github/repos",
-          "events_url": "https://api.github.com/orgs/github/events",
-          "hooks_url": "https://api.github.com/orgs/github/hooks",
-          "issues_url": "https://api.github.com/orgs/github/issues",
-          "members_url": "https://api.github.com/orgs/github/members{/member}",
-          "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-          "description": "A great organization"
-        }
-      }
-    ],
-    "idName": "create-org",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#create-an-organization"
-  },
-  {
-    "name": "Rename an organization",
-    "enabledForApps": false,
-    "method": "PATCH",
-    "path": "/admin/organizations/:org",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "login",
-        "type": "string",
-        "description": "The organization's new name.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "login": "the-new-octocats"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "202 Accepted",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "message": "Job queued to rename organization. It may take a few minutes to complete.",
-          "url": "https://<hostname>/api/v3/organizations/1"
-        }
-      }
-    ],
-    "idName": "rename-org",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#rename-an-organization"
-  },
-  {
     "name": "List pre-receive hooks for organization",
     "enabledForApps": true,
     "method": "GET",
@@ -1456,6 +1351,111 @@
     "description": "Removes any overrides for this hook at the org level for this org.",
     "idName": "remove-enforcement-overrides-for-pre-receive-hook-for-org",
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/org_pre_receive_hooks/#remove-enforcement-overrides-for-a-pre-receive-hook"
+  },
+  {
+    "name": "Create an organization",
+    "enabledForApps": false,
+    "method": "POST",
+    "path": "/admin/organizations",
+    "previews": [],
+    "params": [
+      {
+        "name": "login",
+        "type": "string",
+        "description": "The organization's username.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "admin",
+        "type": "string",
+        "description": "The login of the user who will manage this organization.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "profile_name",
+        "type": "string",
+        "description": "The organization's display name.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "login": "github",
+        "profile_name": "GitHub, Inc.",
+        "admin": "monalisaoctocat"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "login": "github",
+          "id": 1,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+          "url": "https://api.github.com/orgs/github",
+          "repos_url": "https://api.github.com/orgs/github/repos",
+          "events_url": "https://api.github.com/orgs/github/events",
+          "hooks_url": "https://api.github.com/orgs/github/hooks",
+          "issues_url": "https://api.github.com/orgs/github/issues",
+          "members_url": "https://api.github.com/orgs/github/members{/member}",
+          "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+          "description": "A great organization"
+        }
+      }
+    ],
+    "idName": "create-org",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#create-an-organization"
+  },
+  {
+    "name": "Rename an organization",
+    "enabledForApps": false,
+    "method": "PATCH",
+    "path": "/admin/organizations/:org",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "login",
+        "type": "string",
+        "description": "The organization's new name.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "login": "the-new-octocats"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "202 Accepted",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "message": "Job queued to rename organization. It may take a few minutes to complete.",
+          "url": "https://<hostname>/api/v3/organizations/1"
+        }
+      }
+    ],
+    "idName": "rename-org",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#rename-an-organization"
   },
   {
     "name": "Get a single pre-receive environment",

--- a/routes/ghe-2.14/index.json
+++ b/routes/ghe-2.14/index.json
@@ -1,860 +1,4 @@
 {
-  "oauthAuthorizations": [
-    {
-      "name": "List your grants",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/enterprise/2.14/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/applications/grants/1",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "created_at": "2011-09-06T17:26:27Z",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "scopes": [
-                "public_repo"
-              ]
-            }
-          ]
-        }
-      ],
-      "idName": "list-grants",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#list-your-grants"
-    },
-    {
-      "name": "Get a single grant",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/applications/grants/1",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "created_at": "2011-09-06T17:26:27Z",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "scopes": [
-              "public_repo"
-            ]
-          }
-        }
-      ],
-      "idName": "get-grant",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-a-single-grant"
-    },
-    {
-      "name": "Delete a grant",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-grant",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#delete-a-grant"
-    },
-    {
-      "name": "List your authorizations",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/authorizations/1",
-              "scopes": [
-                "public_repo"
-              ],
-              "token": "",
-              "token_last_eight": "12345678",
-              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "note": "optional note",
-              "note_url": "http://optional/note/url",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z",
-              "fingerprint": "jklmnop12345678"
-            }
-          ]
-        }
-      ],
-      "idName": "list-authorizations",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#list-your-authorizations"
-    },
-    {
-      "name": "Get a single authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "get-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-a-single-authorization"
-    },
-    {
-      "name": "Create a new authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_id",
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "If you need a small number of personal access tokens, implementing the [web flow](/enterprise/2.14/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": ""
-          }
-        }
-      ],
-      "idName": "create-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#create-a-new-authorization"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/enterprise/2.14/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-and-fingerprint",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-fingerprint",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
-      "deprecated": {
-        "date": "2018-12-27",
-        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
-        "before": {
-          "idName": "get-or-create-authorization-for-app-fingerprint"
-        },
-        "after": {
-          "idName": "get-or-create-authorization-for-app-and-fingerprint"
-        }
-      }
-    },
-    {
-      "name": "Update an existing authorization",
-      "enabledForApps": false,
-      "method": "PATCH",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "Replaces the authorization scopes with these.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to add to this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to remove from this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "add_scopes": [
-            "repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "You can only send one of these scope keys at a time.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "update-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#update-an-existing-authorization"
-    },
-    {
-      "name": "Delete an authorization",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#delete-an-authorization"
-    },
-    {
-      "name": "Check an authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "check-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#check-an-authorization"
-    },
-    {
-      "name": "Reset an authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "reset-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#reset-an-authorization"
-    },
-    {
-      "name": "Revoke an authorization for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-authorization-for-application",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
-    },
-    {
-      "name": "Revoke a grant for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/grants/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-grant-for-application",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
-    }
-  ],
   "activity": [
     {
       "name": "List public events",
@@ -2967,6 +2111,1032 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/activity/watching/#stop-watching-a-repository-legacy"
     }
   ],
+  "apps": [
+    {
+      "name": "Get a single GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/apps/:app_slug",
+      "previews": [],
+      "params": [
+        {
+          "name": "app_slug",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-by-slug",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#get-a-single-github-app"
+    },
+    {
+      "name": "Get the authenticated GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-authenticated",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#get-the-authenticated-github-app"
+    },
+    {
+      "name": "Find installations",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "account": {
+                "login": "github",
+                "id": 1,
+                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                "url": "https://api.github.com/orgs/github",
+                "repos_url": "https://api.github.com/orgs/github/repos",
+                "events_url": "https://api.github.com/orgs/github/events",
+                "hooks_url": "https://api.github.com/orgs/github/hooks",
+                "issues_url": "https://api.github.com/orgs/github/issues",
+                "members_url": "https://api.github.com/orgs/github/members{/member}",
+                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "description": "A great organization"
+              },
+              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+              "repositories_url": "https://api.github.com/installation/repositories",
+              "html_url": "https://github.com/organizations/github/settings/installations/1",
+              "app_id": 1,
+              "target_id": 1,
+              "target_type": "Organization",
+              "permissions": {
+                "metadata": "read",
+                "contents": "read",
+                "issues": "write",
+                "single_file": "write"
+              },
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "single_file_name": "config.yml",
+              "repository_selection": "selected"
+            }
+          ],
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#find-installations"
+    },
+    {
+      "name": "Get a single installation",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations/:installation_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "You must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "metadata": "read",
+              "contents": "read",
+              "issues": "write",
+              "single_file": "write"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "single_file_name": "config.yml",
+            "repository_selection": "selected"
+          }
+        }
+      ],
+      "idName": "get-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#get-a-single-installation"
+    },
+    {
+      "name": "List installations for user",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.14/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 2,
+            "installations": [
+              {
+                "id": 1,
+                "account": {
+                  "login": "github",
+                  "id": 1,
+                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                  "url": "https://api.github.com/orgs/github",
+                  "repos_url": "https://api.github.com/orgs/github/repos",
+                  "events_url": "https://api.github.com/orgs/github/events",
+                  "hooks_url": "https://api.github.com/orgs/github/hooks",
+                  "issues_url": "https://api.github.com/orgs/github/issues",
+                  "members_url": "https://api.github.com/orgs/github/members{/member}",
+                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "description": "A great organization"
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              },
+              {
+                "id": 3,
+                "account": {
+                  "login": "octocat",
+                  "id": 2,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              }
+            ]
+          },
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#list-installations-for-user"
+    },
+    {
+      "name": "Create a new installation token",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/installations/:installation_id/access_tokens",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "token": "v1.1f699f1069f60xxx",
+            "expires_at": "2016-07-11T22:14:10Z"
+          }
+        }
+      ],
+      "idName": "create-installation-token",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#create-a-new-installation-token"
+    },
+    {
+      "name": "Find organization installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/orgs/:org/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-org-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#find-organization-installation"
+    },
+    {
+      "name": "Find repository installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-repo-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#find-repository-installation"
+    },
+    {
+      "name": "Find user installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/users/:username/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 3,
+            "account": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "repository_selection": "selected",
+            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/3",
+            "app_id": 2,
+            "target_id": 1,
+            "target_type": "User",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "label"
+            ],
+            "created_at": "2018-02-22T20:51:14Z",
+            "updated_at": "2018-02-22T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-user-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#find-user-installation"
+    },
+    {
+      "name": "List repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/installation/repositories",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0,
+                "anonymous_access_enabled": false
+              }
+            ]
+          }
+        }
+      ],
+      "idName": "list-repos",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/installations/#list-repositories"
+    },
+    {
+      "name": "List repositories accessible to the user for an installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations/:installation_id/repositories",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        },
+        {
+          "name": "mercy",
+          "description": "**Note:** The `topics` property for repositories on GitHub Enterprise is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.14/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "permissions": {
+                  "admin": false,
+                  "push": false,
+                  "pull": true
+                },
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0,
+                "anonymous_access_enabled": false
+              }
+            ]
+          },
+          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+        }
+      ],
+      "idName": "list-installation-repos-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
+    },
+    {
+      "name": "Add repository to installation",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.14/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.14/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "add-repo-to-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/installations/#add-repository-to-installation"
+    },
+    {
+      "name": "Remove repository from installation",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.14/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.14/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-repo-from-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/installations/#remove-repository-from-installation"
+    }
+  ],
   "checks": [
     {
       "name": "Create a check run",
@@ -5076,6 +5246,151 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/checks/suites/#request-check-suites"
     }
   ],
+  "codesOfConduct": [
+    {
+      "name": "List all codes of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "citizen_code_of_conduct",
+              "name": "Citizen Code of Conduct",
+              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
+            },
+            {
+              "key": "contributor_covenant",
+              "name": "Contributor Covenant",
+              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
+            }
+          ]
+        }
+      ],
+      "idName": "list-conduct-codes",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/codes_of_conduct/#list-all-codes-of-conduct"
+    },
+    {
+      "name": "Get an individual code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct/:key",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-conduct-code",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
+    },
+    {
+      "name": "Get the contents of a repository's code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/community/code_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-for-repo",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
+    }
+  ],
+  "emojis": [
+    {
+      "name": "Get",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/emojis",
+      "previews": [],
+      "params": [],
+      "description": "Lists all the emojis available to use on GitHub Enterprise.\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/emojis/#emojis"
+    }
+  ],
   "enterpriseAdmin": [
     {
       "name": "Get statistics",
@@ -6297,111 +6612,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/management_console/#remove-an-authorized-ssh-key"
     },
     {
-      "name": "Create an organization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/admin/organizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "login",
-          "type": "string",
-          "description": "The organization's username.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "admin",
-          "type": "string",
-          "description": "The login of the user who will manage this organization.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "profile_name",
-          "type": "string",
-          "description": "The organization's display name.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "login": "github",
-          "profile_name": "GitHub, Inc.",
-          "admin": "monalisaoctocat"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "login": "github",
-            "id": 1,
-            "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-            "url": "https://api.github.com/orgs/github",
-            "repos_url": "https://api.github.com/orgs/github/repos",
-            "events_url": "https://api.github.com/orgs/github/events",
-            "hooks_url": "https://api.github.com/orgs/github/hooks",
-            "issues_url": "https://api.github.com/orgs/github/issues",
-            "members_url": "https://api.github.com/orgs/github/members{/member}",
-            "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "description": "A great organization"
-          }
-        }
-      ],
-      "idName": "create-org",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#create-an-organization"
-    },
-    {
-      "name": "Rename an organization",
-      "enabledForApps": false,
-      "method": "PATCH",
-      "path": "/admin/organizations/:org",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "login",
-          "type": "string",
-          "description": "The organization's new name.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "login": "the-new-octocats"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "202 Accepted",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "message": "Job queued to rename organization. It may take a few minutes to complete.",
-            "url": "https://<hostname>/api/v3/organizations/1"
-          }
-        }
-      ],
-      "idName": "rename-org",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#rename-an-organization"
-    },
-    {
       "name": "List pre-receive hooks for organization",
       "enabledForApps": true,
       "method": "GET",
@@ -6534,6 +6744,111 @@
       "description": "Removes any overrides for this hook at the org level for this org.",
       "idName": "remove-enforcement-overrides-for-pre-receive-hook-for-org",
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/org_pre_receive_hooks/#remove-enforcement-overrides-for-a-pre-receive-hook"
+    },
+    {
+      "name": "Create an organization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/admin/organizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "login",
+          "type": "string",
+          "description": "The organization's username.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "admin",
+          "type": "string",
+          "description": "The login of the user who will manage this organization.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "profile_name",
+          "type": "string",
+          "description": "The organization's display name.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "login": "github",
+          "profile_name": "GitHub, Inc.",
+          "admin": "monalisaoctocat"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "login": "github",
+            "id": 1,
+            "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+            "url": "https://api.github.com/orgs/github",
+            "repos_url": "https://api.github.com/orgs/github/repos",
+            "events_url": "https://api.github.com/orgs/github/events",
+            "hooks_url": "https://api.github.com/orgs/github/hooks",
+            "issues_url": "https://api.github.com/orgs/github/issues",
+            "members_url": "https://api.github.com/orgs/github/members{/member}",
+            "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "description": "A great organization"
+          }
+        }
+      ],
+      "idName": "create-org",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#create-an-organization"
+    },
+    {
+      "name": "Rename an organization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "path": "/admin/organizations/:org",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "login",
+          "type": "string",
+          "description": "The organization's new name.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "login": "the-new-octocats"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "202 Accepted",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "message": "Job queued to rename organization. It may take a few minutes to complete.",
+            "url": "https://<hostname>/api/v3/organizations/1"
+          }
+        }
+      ],
+      "idName": "rename-org",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/enterprise-admin/orgs/#rename-an-organization"
     },
     {
       "name": "Get a single pre-receive environment",
@@ -10245,138 +10560,15 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/git/trees/#create-a-tree"
     }
   ],
-  "apps": [
+  "gitignore": [
     {
-      "name": "Get a single GitHub App",
+      "name": "Listing available templates",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/apps/:app_slug",
+      "path": "/gitignore/templates",
       "previews": [],
-      "params": [
-        {
-          "name": "app_slug",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
-        }
-      ],
-      "idName": "get-by-slug",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#get-a-single-github-app"
-    },
-    {
-      "name": "Get the authenticated GitHub App",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
       "params": [],
-      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
-        }
-      ],
-      "idName": "get-authenticated",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#get-the-authenticated-github-app"
-    },
-    {
-      "name": "Find installations",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "description": "List all templates available to pass as an option when [creating a repository](/enterprise/2.14/v3/repos/#create).",
       "responses": [
         {
           "headers": {
@@ -10384,529 +10576,35 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": [
-            {
-              "id": 1,
-              "account": {
-                "login": "github",
-                "id": 1,
-                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                "url": "https://api.github.com/orgs/github",
-                "repos_url": "https://api.github.com/orgs/github/repos",
-                "events_url": "https://api.github.com/orgs/github/events",
-                "hooks_url": "https://api.github.com/orgs/github/hooks",
-                "issues_url": "https://api.github.com/orgs/github/issues",
-                "members_url": "https://api.github.com/orgs/github/members{/member}",
-                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "description": "A great organization"
-              },
-              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-              "repositories_url": "https://api.github.com/installation/repositories",
-              "html_url": "https://github.com/organizations/github/settings/installations/1",
-              "app_id": 1,
-              "target_id": 1,
-              "target_type": "Organization",
-              "permissions": {
-                "metadata": "read",
-                "contents": "read",
-                "issues": "write",
-                "single_file": "write"
-              },
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "single_file_name": "config.yml",
-              "repository_selection": "selected"
-            }
-          ],
-          "description": "The permissions the installation has are included under the `permissions` key."
+            "Actionscript",
+            "Android",
+            "AppceleratorTitanium",
+            "Autotools",
+            "Bancha",
+            "C",
+            "C++"
+          ]
         }
       ],
-      "idName": "list-installations",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#find-installations"
+      "idName": "list-templates",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/gitignore/#listing-available-templates"
     },
     {
-      "name": "Get a single installation",
+      "name": "Get a single template",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/app/installations/:installation_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "You must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "metadata": "read",
-              "contents": "read",
-              "issues": "write",
-              "single_file": "write"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "single_file_name": "config.yml",
-            "repository_selection": "selected"
-          }
-        }
-      ],
-      "idName": "get-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#get-a-single-installation"
-    },
-    {
-      "name": "List installations for user",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.14/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "total_count": 2,
-            "installations": [
-              {
-                "id": 1,
-                "account": {
-                  "login": "github",
-                  "id": 1,
-                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                  "url": "https://api.github.com/orgs/github",
-                  "repos_url": "https://api.github.com/orgs/github/repos",
-                  "events_url": "https://api.github.com/orgs/github/events",
-                  "hooks_url": "https://api.github.com/orgs/github/hooks",
-                  "issues_url": "https://api.github.com/orgs/github/issues",
-                  "members_url": "https://api.github.com/orgs/github/members{/member}",
-                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "description": "A great organization"
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              },
-              {
-                "id": 3,
-                "account": {
-                  "login": "octocat",
-                  "id": 2,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              }
-            ]
-          },
-          "description": "The permissions the installation has are included under the `permissions` key."
-        }
-      ],
-      "idName": "list-installations-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#list-installations-for-user"
-    },
-    {
-      "name": "Create a new installation token",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/installations/:installation_id/access_tokens",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "token": "v1.1f699f1069f60xxx",
-            "expires_at": "2016-07-11T22:14:10Z"
-          }
-        }
-      ],
-      "idName": "create-installation-token",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#create-a-new-installation-token"
-    },
-    {
-      "name": "Find organization installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/orgs/:org/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-org-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#find-organization-installation"
-    },
-    {
-      "name": "Find repository installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-repo-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#find-repository-installation"
-    },
-    {
-      "name": "Find user installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/users/:username/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 3,
-            "account": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "repository_selection": "selected",
-            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/3",
-            "app_id": 2,
-            "target_id": 1,
-            "target_type": "User",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "label"
-            ],
-            "created_at": "2018-02-22T20:51:14Z",
-            "updated_at": "2018-02-22T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-user-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/#find-user-installation"
-    },
-    {
-      "name": "List repositories",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/installation/repositories",
+      "path": "/gitignore/templates/:name",
       "previews": [],
       "params": [
         {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
         }
       ],
-      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](/enterprise/2.14/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/enterprise/2.14/v3/media/) to get the raw contents.\n\n",
       "responses": [
         {
           "headers": {
@@ -10914,361 +10612,20 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0,
-                "anonymous_access_enabled": false
-              }
-            ]
+            "name": "C",
+            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
           }
-        }
-      ],
-      "idName": "list-repos",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/installations/#list-repositories"
-    },
-    {
-      "name": "List repositories accessible to the user for an installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations/:installation_id/repositories",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
         },
-        {
-          "name": "mercy",
-          "description": "**Note:** The `topics` property for repositories on GitHub Enterprise is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.14/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
-      "responses": [
         {
           "headers": {
             "status": "200 OK",
             "content-type": "application/json; charset=utf-8"
           },
-          "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "permissions": {
-                  "admin": false,
-                  "push": false,
-                  "pull": true
-                },
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0,
-                "anonymous_access_enabled": false
-              }
-            ]
-          },
-          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+          "description": "Use the raw [media type](/enterprise/2.14/v3/media/) to get the raw contents."
         }
       ],
-      "idName": "list-installation-repos-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
-    },
-    {
-      "name": "Add repository to installation",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.14/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.14/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "add-repo-to-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/installations/#add-repository-to-installation"
-    },
-    {
-      "name": "Remove repository from installation",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.14/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.14/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-repo-from-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/apps/installations/#remove-repository-from-installation"
+      "idName": "get-template",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/gitignore/#get-a-single-template"
     }
   ],
   "issues": [
@@ -16340,219 +15697,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/issues/timeline/#list-events-for-an-issue"
     }
   ],
-  "codesOfConduct": [
-    {
-      "name": "List all codes of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/codes_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "key": "citizen_code_of_conduct",
-              "name": "Citizen Code of Conduct",
-              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
-            },
-            {
-              "key": "contributor_covenant",
-              "name": "Contributor Covenant",
-              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
-            }
-          ]
-        }
-      ],
-      "idName": "list-conduct-codes",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/codes_of_conduct/#list-all-codes-of-conduct"
-    },
-    {
-      "name": "Get an individual code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/codes_of_conduct/:key",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "key",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-conduct-code",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
-    },
-    {
-      "name": "Get the contents of a repository's code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/community/code_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-for-repo",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
-    }
-  ],
-  "emojis": [
-    {
-      "name": "Get",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/emojis",
-      "previews": [],
-      "params": [],
-      "description": "Lists all the emojis available to use on GitHub Enterprise.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/emojis/#emojis"
-    }
-  ],
-  "gitignore": [
-    {
-      "name": "Listing available templates",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates",
-      "previews": [],
-      "params": [],
-      "description": "List all templates available to pass as an option when [creating a repository](/enterprise/2.14/v3/repos/#create).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            "Actionscript",
-            "Android",
-            "AppceleratorTitanium",
-            "Autotools",
-            "Bancha",
-            "C",
-            "C++"
-          ]
-        }
-      ],
-      "idName": "list-templates",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/gitignore/#listing-available-templates"
-    },
-    {
-      "name": "Get a single template",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates/:name",
-      "previews": [],
-      "params": [
-        {
-          "name": "name",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/enterprise/2.14/v3/media/) to get the raw contents.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "name": "C",
-            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
-          }
-        },
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "description": "Use the raw [media type](/enterprise/2.14/v3/media/) to get the raw contents."
-        }
-      ],
-      "idName": "get-template",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/gitignore/#get-a-single-template"
-    }
-  ],
   "licenses": [
     {
       "name": "List commonly used licenses",
@@ -16913,15 +16057,75 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/meta/#meta"
     }
   ],
-  "rateLimit": [
+  "oauthAuthorizations": [
     {
-      "name": "Get your current rate limit status",
-      "enabledForApps": true,
+      "name": "List your grants",
+      "enabledForApps": false,
       "method": "GET",
-      "path": "/rate_limit",
+      "path": "/applications/grants",
       "previews": [],
-      "params": [],
-      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](/enterprise/2.14/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/enterprise/2.14/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](/enterprise/2.14/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/enterprise/2.14/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](/enterprise/2.14/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/enterprise/2.14/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/applications/grants/1",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "created_at": "2011-09-06T17:26:27Z",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "scopes": [
+                "public_repo"
+              ]
+            }
+          ]
+        }
+      ],
+      "idName": "list-grants",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#list-your-grants"
+    },
+    {
+      "name": "Get a single grant",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
       "responses": [
         {
           "headers": {
@@ -16929,33 +16133,784 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "resources": {
-              "core": {
-                "limit": 5000,
-                "remaining": 4999,
-                "reset": 1372700873
-              },
-              "search": {
-                "limit": 30,
-                "remaining": 18,
-                "reset": 1372697452
-              },
-              "graphql": {
-                "limit": 5000,
-                "remaining": 4993,
-                "reset": 1372700389
-              }
+            "id": 1,
+            "url": "https://api.github.com/applications/grants/1",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
             },
-            "rate": {
-              "limit": 5000,
-              "remaining": 4999,
-              "reset": 1372700873
+            "created_at": "2011-09-06T17:26:27Z",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "scopes": [
+              "public_repo"
+            ]
+          }
+        }
+      ],
+      "idName": "get-grant",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-a-single-grant"
+    },
+    {
+      "name": "Delete a grant",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-grant",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#delete-a-grant"
+    },
+    {
+      "name": "List your authorizations",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/authorizations/1",
+              "scopes": [
+                "public_repo"
+              ],
+              "token": "",
+              "token_last_eight": "12345678",
+              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "note": "optional note",
+              "note_url": "http://optional/note/url",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z",
+              "fingerprint": "jklmnop12345678"
+            }
+          ]
+        }
+      ],
+      "idName": "list-authorizations",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#list-your-authorizations"
+    },
+    {
+      "name": "Get a single authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "get-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-a-single-authorization"
+    },
+    {
+      "name": "Create a new authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_id",
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "If you need a small number of personal access tokens, implementing the [web flow](/enterprise/2.14/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": ""
+          }
+        }
+      ],
+      "idName": "create-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#create-a-new-authorization"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/enterprise/2.14/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-and-fingerprint",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-fingerprint",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
+      "deprecated": {
+        "date": "2018-12-27",
+        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
+        "before": {
+          "idName": "get-or-create-authorization-for-app-fingerprint"
+        },
+        "after": {
+          "idName": "get-or-create-authorization-for-app-and-fingerprint"
+        }
+      }
+    },
+    {
+      "name": "Update an existing authorization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "Replaces the authorization scopes with these.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to add to this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to remove from this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "add_scopes": [
+            "repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "You can only send one of these scope keys at a time.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "update-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#update-an-existing-authorization"
+    },
+    {
+      "name": "Delete an authorization",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#delete-an-authorization"
+    },
+    {
+      "name": "Check an authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
             }
           }
         }
       ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/rate_limit/#get-your-current-rate-limit-status"
+      "idName": "check-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#check-an-authorization"
+    },
+    {
+      "name": "Reset an authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            }
+          }
+        }
+      ],
+      "idName": "reset-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#reset-an-authorization"
+    },
+    {
+      "name": "Revoke an authorization for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-authorization-for-application",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
+    },
+    {
+      "name": "Revoke a grant for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/grants/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/enterprise/2.14/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-grant-for-application",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
     }
   ],
   "orgs": [
@@ -17359,6 +17314,412 @@
       ],
       "idName": "edit",
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/#edit-an-organization"
+    },
+    {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/orgs/octocat/hooks/1",
+              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Must be passed as \"web\".",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Here's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This will trigger a [ping event](/enterprise/2.14/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#delete-a-hook"
     },
     {
       "name": "Members list",
@@ -18237,412 +18598,6 @@
       ],
       "idName": "convert-member-to-outside-collaborator",
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-    },
-    {
-      "name": "List hooks",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/orgs/octocat/hooks/1",
-              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#list-hooks"
-    },
-    {
-      "name": "Get single hook",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#get-single-hook"
-    },
-    {
-      "name": "Create a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Must be passed as \"web\".",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Here's how you can create a hook that posts payloads in JSON format:",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#create-a-hook"
-    },
-    {
-      "name": "Edit a hook",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "active": true,
-          "events": [
-            "pull_request"
-          ]
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#edit-a-hook"
-    },
-    {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This will trigger a [ping event](/enterprise/2.14/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#delete-a-hook"
     }
   ],
   "projects": [
@@ -23354,731 +23309,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/#merge-a-pull-request-merge-button"
     },
     {
-      "name": "List reviews on a pull request",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "The list of reviews returns in chronological order.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 80,
-              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Here is the body for the review.",
-              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-              "state": "APPROVED",
-              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-              "_links": {
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-                }
-              }
-            }
-          ],
-          "description": "The list of reviews returns in chronological order."
-        }
-      ],
-      "idName": "list-reviews",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-    },
-    {
-      "name": "Get a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "get-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#get-a-single-review"
-    },
-    {
-      "name": "Delete a pending review",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "PENDING",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "delete-pending-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#delete-a-pending-review"
-    },
-    {
-      "name": "Get comments for a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-              "id": 10,
-              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-              "pull_request_review_id": 42,
-              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-              "path": "file1.txt",
-              "position": 1,
-              "original_position": 4,
-              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-              "in_reply_to_id": 8,
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Great stuff",
-              "created_at": "2011-04-14T16:00:49Z",
-              "updated_at": "2011-04-14T16:00:49Z",
-              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-              "_links": {
-                "self": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-                },
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "get-comments-for-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#get-comments-for-a-single-review"
-    },
-    {
-      "name": "Create a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "commit_id",
-          "type": "string",
-          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.14/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-          "required": false,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        },
-        {
-          "name": "comments",
-          "type": "object[]",
-          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "comments[].path",
-          "type": "string",
-          "description": "The relative path to the file that necessitates a review comment.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].position",
-          "type": "integer",
-          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].body",
-          "type": "string",
-          "description": "Text of the review comment.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "event": "REQUEST_CHANGES",
-          "comments": [
-            {
-              "path": "file.md",
-              "position": 6,
-              "body": "Please add more information here, and fix this typo."
-            }
-          ]
-        }
-      ],
-      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.14/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.14/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.14/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "This is close to perfect! Please address the suggested inline change.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "CHANGES_REQUESTED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#create-a-pull-request-review"
-    },
-    {
-      "name": "Submit a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The body text of the pull request review",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-          "required": true,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "submit-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#submit-a-pull-request-review"
-    },
-    {
-      "name": "Dismiss a pull request review",
-      "enabledForApps": true,
-      "method": "PUT",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "message",
-          "type": "string",
-          "description": "The message for the pull request review dismissal",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.14/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "DISMISSED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "dismiss-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#dismiss-a-pull-request-review"
-    },
-    {
       "name": "List comments on a pull request",
       "enabledForApps": true,
       "method": "GET",
@@ -25575,6 +24805,776 @@
       ],
       "idName": "delete-review-request",
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/review_requests/#delete-a-review-request"
+    },
+    {
+      "name": "List reviews on a pull request",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "The list of reviews returns in chronological order.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 80,
+              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Here is the body for the review.",
+              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+              "state": "APPROVED",
+              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+              "_links": {
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+                }
+              }
+            }
+          ],
+          "description": "The list of reviews returns in chronological order."
+        }
+      ],
+      "idName": "list-reviews",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+    },
+    {
+      "name": "Get a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "get-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#get-a-single-review"
+    },
+    {
+      "name": "Delete a pending review",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "PENDING",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "delete-pending-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#delete-a-pending-review"
+    },
+    {
+      "name": "Get comments for a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+              "id": 10,
+              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+              "pull_request_review_id": 42,
+              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+              "path": "file1.txt",
+              "position": 1,
+              "original_position": 4,
+              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+              "in_reply_to_id": 8,
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Great stuff",
+              "created_at": "2011-04-14T16:00:49Z",
+              "updated_at": "2011-04-14T16:00:49Z",
+              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+              "_links": {
+                "self": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+                },
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "get-comments-for-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#get-comments-for-a-single-review"
+    },
+    {
+      "name": "Create a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "commit_id",
+          "type": "string",
+          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.14/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+          "required": false,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        },
+        {
+          "name": "comments",
+          "type": "object[]",
+          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "comments[].path",
+          "type": "string",
+          "description": "The relative path to the file that necessitates a review comment.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].position",
+          "type": "integer",
+          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].body",
+          "type": "string",
+          "description": "Text of the review comment.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "event": "REQUEST_CHANGES",
+          "comments": [
+            {
+              "path": "file.md",
+              "position": 6,
+              "body": "Please add more information here, and fix this typo."
+            }
+          ]
+        }
+      ],
+      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.14/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.14/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.14/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "This is close to perfect! Please address the suggested inline change.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "CHANGES_REQUESTED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#create-a-pull-request-review"
+    },
+    {
+      "name": "Submit a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The body text of the pull request review",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+          "required": true,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "submit-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#submit-a-pull-request-review"
+    },
+    {
+      "name": "Dismiss a pull request review",
+      "enabledForApps": true,
+      "method": "PUT",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "message",
+          "type": "string",
+          "description": "The message for the pull request review dismissal",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.14/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "DISMISSED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "dismiss-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#dismiss-a-pull-request-review"
+    }
+  ],
+  "rateLimit": [
+    {
+      "name": "Get your current rate limit status",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/rate_limit",
+      "previews": [],
+      "params": [],
+      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](/enterprise/2.14/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/enterprise/2.14/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](/enterprise/2.14/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/enterprise/2.14/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](/enterprise/2.14/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "resources": {
+              "core": {
+                "limit": 5000,
+                "remaining": 4999,
+                "reset": 1372700873
+              },
+              "search": {
+                "limit": 30,
+                "remaining": 18,
+                "reset": 1372697452
+              },
+              "graphql": {
+                "limit": 5000,
+                "remaining": 4993,
+                "reset": 1372700389
+              }
+            },
+            "rate": {
+              "limit": 5000,
+              "remaining": 4999,
+              "reset": 1372700873
+            }
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/rate_limit/#get-your-current-rate-limit-status"
     }
   ],
   "reactions": [
@@ -33336,229 +33336,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/contents/#get-archive-link"
     },
     {
-      "name": "List deploy keys",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-deploy-keys",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#list-deploy-keys"
-    },
-    {
-      "name": "Get a deploy key",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#get-a-deploy-key"
-    },
-    {
-      "name": "Add a new deploy key",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A name for the key.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The contents of the key.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "read_only",
-          "type": "boolean",
-          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA...",
-          "read_only": true
-        }
-      ],
-      "description": "Here's how you can create a read-only deploy key:\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "add-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#add-a-new-deploy-key"
-    },
-    {
-      "name": "Remove a deploy key",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#remove-a-deploy-key"
-    },
-    {
       "name": "List deployments",
       "enabledForApps": true,
       "method": "GET",
@@ -34691,6 +34468,514 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/forks/#create-a-fork"
     },
     {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com/webhook",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) for details.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "add_events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Test a push hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "test-push-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#test-a-push-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.14/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#delete-a-hook"
+    },
+    {
       "name": "List invitations for a repository",
       "enabledForApps": true,
       "method": "GET",
@@ -35272,6 +35557,229 @@
       ],
       "idName": "decline-invitation",
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/invitations/#decline-a-repository-invitation"
+    },
+    {
+      "name": "List deploy keys",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-deploy-keys",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#list-deploy-keys"
+    },
+    {
+      "name": "Get a deploy key",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#get-a-deploy-key"
+    },
+    {
+      "name": "Add a new deploy key",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A name for the key.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The contents of the key.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "read_only",
+          "type": "boolean",
+          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA...",
+          "read_only": true
+        }
+      ],
+      "description": "Here's how you can create a read-only deploy key:\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "add-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#add-a-new-deploy-key"
+    },
+    {
+      "name": "Remove a deploy key",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#remove-a-deploy-key"
     },
     {
       "name": "Perform a merge",
@@ -37409,514 +37917,6 @@
       ],
       "idName": "get-combined-status-for-ref",
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref"
-    },
-    {
-      "name": "List hooks",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com/webhook",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#list-hooks"
-    },
-    {
-      "name": "Get single hook",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#get-single-hook"
-    },
-    {
-      "name": "Create a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) for details.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#create-a-hook"
-    },
-    {
-      "name": "Edit a hook",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "active": true,
-          "add_events": [
-            "pull_request"
-          ]
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#edit-a-hook"
-    },
-    {
-      "name": "Test a push hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "test-push-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#test-a-push-hook"
-    },
-    {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.14/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#delete-a-hook"
     }
   ],
   "search": [
@@ -39745,6 +39745,474 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/#remove-team-project"
     },
     {
+      "name": "List comments",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "direction",
+          "type": "string",
+          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "location": "query"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "author": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Do you like apples?",
+              "body_html": "<p>Do you like apples?</p>",
+              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+              "created_at": "2018-01-15T23:53:58Z",
+              "last_edited_at": null,
+              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+              "number": 1,
+              "updated_at": "2018-01-15T23:53:58Z",
+              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+              "reactions": {
+                "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+                "total_count": 5,
+                "+1": 3,
+                "-1": 1,
+                "laugh": 0,
+                "confused": 0,
+                "heart": 1,
+                "hooray": 0
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "list-discussion-comments",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#list-comments"
+    },
+    {
+      "name": "Get a single comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "idName": "get-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#get-a-single-comment"
+    },
+    {
+      "name": "Create a comment",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like apples?"
+        }
+      ],
+      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.14/v3/#abuse-rate-limits)\" for details.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#create-a-comment"
+    },
+    {
+      "name": "Edit a comment",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like pineapples?"
+        }
+      ],
+      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like pineapples?",
+            "body_html": "<p>Do you like pineapples?</p>",
+            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": "2018-01-26T18:22:20Z",
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-26T18:22:20Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "idName": "edit-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#edit-a-comment"
+    },
+    {
+      "name": "Delete a comment",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#delete-a-comment"
+    },
+    {
       "name": "List discussions",
       "enabledForApps": true,
       "method": "GET",
@@ -40219,474 +40687,6 @@
       ],
       "idName": "delete-discussion",
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussions/#delete-a-discussion"
-    },
-    {
-      "name": "List comments",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "direction",
-          "type": "string",
-          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-          "default": "desc",
-          "required": false,
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "location": "query"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "author": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Do you like apples?",
-              "body_html": "<p>Do you like apples?</p>",
-              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-              "created_at": "2018-01-15T23:53:58Z",
-              "last_edited_at": null,
-              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-              "number": 1,
-              "updated_at": "2018-01-15T23:53:58Z",
-              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-              "reactions": {
-                "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-                "total_count": 5,
-                "+1": 3,
-                "-1": 1,
-                "laugh": 0,
-                "confused": 0,
-                "heart": 1,
-                "hooray": 0
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "list-discussion-comments",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#list-comments"
-    },
-    {
-      "name": "Get a single comment",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "idName": "get-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#get-a-single-comment"
-    },
-    {
-      "name": "Create a comment",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like apples?"
-        }
-      ],
-      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.14/v3/#abuse-rate-limits)\" for details.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#create-a-comment"
-    },
-    {
-      "name": "Edit a comment",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like pineapples?"
-        }
-      ],
-      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like pineapples?",
-            "body_html": "<p>Do you like pineapples?</p>",
-            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": "2018-01-26T18:22:20Z",
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-26T18:22:20Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "idName": "edit-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#edit-a-comment"
-    },
-    {
-      "name": "Delete a comment",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#delete-a-comment"
     },
     {
       "name": "List team members",
@@ -41828,214 +41828,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/followers/#unfollow-a-user"
     },
     {
-      "name": "List public keys for a user",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/users/:username/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA..."
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys-for-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#list-public-keys-for-a-user"
-    },
-    {
-      "name": "List your public keys",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/user/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#list-your-public-keys"
-    },
-    {
-      "name": "Get a single public key",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#get-a-single-public-key"
-    },
-    {
-      "name": "Create a public key",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA..."
-        }
-      ],
-      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "create-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#create-a-public-key"
-    },
-    {
-      "name": "Delete a public key",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#delete-a-public-key"
-    },
-    {
       "name": "List GPG keys for a user",
       "enabledForApps": true,
       "method": "GET",
@@ -42339,6 +42131,214 @@
       ],
       "idName": "delete-gpg-key",
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/gpg_keys/#delete-a-gpg-key"
+    },
+    {
+      "name": "List public keys for a user",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/users/:username/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA..."
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys-for-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#list-public-keys-for-a-user"
+    },
+    {
+      "name": "List your public keys",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/user/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#list-your-public-keys"
+    },
+    {
+      "name": "Get a single public key",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#get-a-single-public-key"
+    },
+    {
+      "name": "Create a public key",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA..."
+        }
+      ],
+      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "create-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#create-a-public-key"
+    },
+    {
+      "name": "Delete a public key",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#delete-a-public-key"
     }
   ]
 }

--- a/routes/ghe-2.14/index.json
+++ b/routes/ghe-2.14/index.json
@@ -16619,6 +16619,80 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/licenses/#list-commonly-used-licenses"
     },
     {
+      "name": "List all licenses",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/licenses",
+      "previews": [],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "mit",
+              "name": "MIT License",
+              "spdx_id": "MIT",
+              "url": "https://api.github.com/licenses/mit",
+              "node_id": "MDc6TGljZW5zZW1pdA=="
+            },
+            {
+              "key": "lgpl-3.0",
+              "name": "GNU Lesser General Public License v3.0",
+              "spdx_id": "LGPL-3.0",
+              "url": "https://api.github.com/licenses/lgpl-3.0"
+            },
+            {
+              "key": "mpl-2.0",
+              "name": "Mozilla Public License 2.0",
+              "spdx_id": "MPL-2.0",
+              "url": "https://api.github.com/licenses/mpl-2.0"
+            },
+            {
+              "key": "agpl-3.0",
+              "name": "GNU Affero General Public License v3.0",
+              "spdx_id": "AGPL-3.0",
+              "url": "https://api.github.com/licenses/agpl-3.0"
+            },
+            {
+              "key": "unlicense",
+              "name": "The Unlicense",
+              "spdx_id": "Unlicense",
+              "url": "https://api.github.com/licenses/unlicense"
+            },
+            {
+              "key": "apache-2.0",
+              "name": "Apache License 2.0",
+              "spdx_id": "Apache-2.0",
+              "url": "https://api.github.com/licenses/apache-2.0"
+            },
+            {
+              "key": "gpl-3.0",
+              "name": "GNU General Public License v3.0",
+              "spdx_id": "GPL-3.0",
+              "url": "https://api.github.com/licenses/gpl-3.0"
+            }
+          ]
+        }
+      ],
+      "idName": "list",
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/licenses/#list-commonly-used-licenses",
+      "deprecated": {
+        "date": "2019-03-05",
+        "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+        "before": {
+          "idName": "list"
+        },
+        "after": {
+          "idName": "list-commonly-used"
+        }
+      }
+    },
+    {
       "name": "Get an individual license",
       "enabledForApps": true,
       "method": "GET",

--- a/routes/ghe-2.14/licenses.json
+++ b/routes/ghe-2.14/licenses.json
@@ -64,6 +64,80 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/licenses/#list-commonly-used-licenses"
   },
   {
+    "name": "List all licenses",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/licenses",
+    "previews": [],
+    "params": [],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "key": "mit",
+            "name": "MIT License",
+            "spdx_id": "MIT",
+            "url": "https://api.github.com/licenses/mit",
+            "node_id": "MDc6TGljZW5zZW1pdA=="
+          },
+          {
+            "key": "lgpl-3.0",
+            "name": "GNU Lesser General Public License v3.0",
+            "spdx_id": "LGPL-3.0",
+            "url": "https://api.github.com/licenses/lgpl-3.0"
+          },
+          {
+            "key": "mpl-2.0",
+            "name": "Mozilla Public License 2.0",
+            "spdx_id": "MPL-2.0",
+            "url": "https://api.github.com/licenses/mpl-2.0"
+          },
+          {
+            "key": "agpl-3.0",
+            "name": "GNU Affero General Public License v3.0",
+            "spdx_id": "AGPL-3.0",
+            "url": "https://api.github.com/licenses/agpl-3.0"
+          },
+          {
+            "key": "unlicense",
+            "name": "The Unlicense",
+            "spdx_id": "Unlicense",
+            "url": "https://api.github.com/licenses/unlicense"
+          },
+          {
+            "key": "apache-2.0",
+            "name": "Apache License 2.0",
+            "spdx_id": "Apache-2.0",
+            "url": "https://api.github.com/licenses/apache-2.0"
+          },
+          {
+            "key": "gpl-3.0",
+            "name": "GNU General Public License v3.0",
+            "spdx_id": "GPL-3.0",
+            "url": "https://api.github.com/licenses/gpl-3.0"
+          }
+        ]
+      }
+    ],
+    "idName": "list",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/licenses/#list-commonly-used-licenses",
+    "deprecated": {
+      "date": "2019-03-05",
+      "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+      "before": {
+        "idName": "list"
+      },
+      "after": {
+        "idName": "list-commonly-used"
+      }
+    }
+  },
+  {
     "name": "Get an individual license",
     "enabledForApps": true,
     "method": "GET",

--- a/routes/ghe-2.14/licenses/list.json
+++ b/routes/ghe-2.14/licenses/list.json
@@ -1,0 +1,74 @@
+{
+  "name": "List all licenses",
+  "enabledForApps": true,
+  "method": "GET",
+  "path": "/licenses",
+  "previews": [],
+  "params": [],
+  "description": "",
+  "responses": [
+    {
+      "headers": {
+        "status": "200 OK",
+        "content-type": "application/json; charset=utf-8"
+      },
+      "body": [
+        {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZW1pdA=="
+        },
+        {
+          "key": "lgpl-3.0",
+          "name": "GNU Lesser General Public License v3.0",
+          "spdx_id": "LGPL-3.0",
+          "url": "https://api.github.com/licenses/lgpl-3.0"
+        },
+        {
+          "key": "mpl-2.0",
+          "name": "Mozilla Public License 2.0",
+          "spdx_id": "MPL-2.0",
+          "url": "https://api.github.com/licenses/mpl-2.0"
+        },
+        {
+          "key": "agpl-3.0",
+          "name": "GNU Affero General Public License v3.0",
+          "spdx_id": "AGPL-3.0",
+          "url": "https://api.github.com/licenses/agpl-3.0"
+        },
+        {
+          "key": "unlicense",
+          "name": "The Unlicense",
+          "spdx_id": "Unlicense",
+          "url": "https://api.github.com/licenses/unlicense"
+        },
+        {
+          "key": "apache-2.0",
+          "name": "Apache License 2.0",
+          "spdx_id": "Apache-2.0",
+          "url": "https://api.github.com/licenses/apache-2.0"
+        },
+        {
+          "key": "gpl-3.0",
+          "name": "GNU General Public License v3.0",
+          "spdx_id": "GPL-3.0",
+          "url": "https://api.github.com/licenses/gpl-3.0"
+        }
+      ]
+    }
+  ],
+  "idName": "list",
+  "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/licenses/#list-commonly-used-licenses",
+  "deprecated": {
+    "date": "2019-03-05",
+    "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+    "before": {
+      "idName": "list"
+    },
+    "after": {
+      "idName": "list-commonly-used"
+    }
+  }
+}

--- a/routes/ghe-2.14/orgs.json
+++ b/routes/ghe-2.14/orgs.json
@@ -401,6 +401,412 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/#edit-an-organization"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Must be passed as \"web\".",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Here's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "This will trigger a [ping event](/enterprise/2.14/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#delete-a-hook"
+  },
+  {
     "name": "Members list",
     "enabledForApps": true,
     "method": "GET",
@@ -1277,411 +1683,5 @@
     ],
     "idName": "convert-member-to-outside-collaborator",
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Must be passed as \"web\".",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Here's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "This will trigger a [ping event](/enterprise/2.14/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/orgs/hooks/#delete-a-hook"
   }
 ]

--- a/routes/ghe-2.14/pulls.json
+++ b/routes/ghe-2.14/pulls.json
@@ -3275,731 +3275,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/#merge-a-pull-request-merge-button"
   },
   {
-    "name": "List reviews on a pull request",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "The list of reviews returns in chronological order.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        ],
-        "description": "The list of reviews returns in chronological order."
-      }
-    ],
-    "idName": "list-reviews",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-  },
-  {
-    "name": "Get a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "get-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#get-a-single-review"
-  },
-  {
-    "name": "Delete a pending review",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "PENDING",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "delete-pending-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#delete-a-pending-review"
-  },
-  {
-    "name": "Get comments for a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-            "id": 10,
-            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-            "pull_request_review_id": 42,
-            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-            "path": "file1.txt",
-            "position": 1,
-            "original_position": 4,
-            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-            "in_reply_to_id": 8,
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Great stuff",
-            "created_at": "2011-04-14T16:00:49Z",
-            "updated_at": "2011-04-14T16:00:49Z",
-            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-            "_links": {
-              "self": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-              },
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-              }
-            }
-          }
-        ]
-      }
-    ],
-    "idName": "get-comments-for-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#get-comments-for-a-single-review"
-  },
-  {
-    "name": "Create a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "commit_id",
-        "type": "string",
-        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.14/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-        "required": false,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      },
-      {
-        "name": "comments",
-        "type": "object[]",
-        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "comments[].path",
-        "type": "string",
-        "description": "The relative path to the file that necessitates a review comment.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].position",
-        "type": "integer",
-        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].body",
-        "type": "string",
-        "description": "Text of the review comment.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-        "body": "This is close to perfect! Please address the suggested inline change.",
-        "event": "REQUEST_CHANGES",
-        "comments": [
-          {
-            "path": "file.md",
-            "position": 6,
-            "body": "Please add more information here, and fix this typo."
-          }
-        ]
-      }
-    ],
-    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.14/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.14/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.14/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "CHANGES_REQUESTED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#create-a-pull-request-review"
-  },
-  {
-    "name": "Submit a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The body text of the pull request review",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-        "required": true,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "submit-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#submit-a-pull-request-review"
-  },
-  {
-    "name": "Dismiss a pull request review",
-    "enabledForApps": true,
-    "method": "PUT",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "message",
-        "type": "string",
-        "description": "The message for the pull request review dismissal",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.14/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "DISMISSED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "dismiss-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#dismiss-a-pull-request-review"
-  },
-  {
     "name": "List comments on a pull request",
     "enabledForApps": true,
     "method": "GET",
@@ -5496,5 +4771,730 @@
     ],
     "idName": "delete-review-request",
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/review_requests/#delete-a-review-request"
+  },
+  {
+    "name": "List reviews on a pull request",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "The list of reviews returns in chronological order.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        ],
+        "description": "The list of reviews returns in chronological order."
+      }
+    ],
+    "idName": "list-reviews",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+  },
+  {
+    "name": "Get a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "get-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#get-a-single-review"
+  },
+  {
+    "name": "Delete a pending review",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "PENDING",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "delete-pending-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#delete-a-pending-review"
+  },
+  {
+    "name": "Get comments for a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+            "id": 10,
+            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+            "pull_request_review_id": 42,
+            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+            "path": "file1.txt",
+            "position": 1,
+            "original_position": 4,
+            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+            "in_reply_to_id": 8,
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Great stuff",
+            "created_at": "2011-04-14T16:00:49Z",
+            "updated_at": "2011-04-14T16:00:49Z",
+            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+            "_links": {
+              "self": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+              },
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "idName": "get-comments-for-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#get-comments-for-a-single-review"
+  },
+  {
+    "name": "Create a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "commit_id",
+        "type": "string",
+        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.14/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+        "required": false,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      },
+      {
+        "name": "comments",
+        "type": "object[]",
+        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "comments[].path",
+        "type": "string",
+        "description": "The relative path to the file that necessitates a review comment.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].position",
+        "type": "integer",
+        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].body",
+        "type": "string",
+        "description": "Text of the review comment.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+        "body": "This is close to perfect! Please address the suggested inline change.",
+        "event": "REQUEST_CHANGES",
+        "comments": [
+          {
+            "path": "file.md",
+            "position": 6,
+            "body": "Please add more information here, and fix this typo."
+          }
+        ]
+      }
+    ],
+    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.14/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.14/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.14/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "CHANGES_REQUESTED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#create-a-pull-request-review"
+  },
+  {
+    "name": "Submit a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The body text of the pull request review",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+        "required": true,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "submit-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#submit-a-pull-request-review"
+  },
+  {
+    "name": "Dismiss a pull request review",
+    "enabledForApps": true,
+    "method": "PUT",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "message",
+        "type": "string",
+        "description": "The message for the pull request review dismissal",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.14/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "DISMISSED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "dismiss-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/pulls/reviews/#dismiss-a-pull-request-review"
   }
 ]

--- a/routes/ghe-2.14/repos.json
+++ b/routes/ghe-2.14/repos.json
@@ -6517,229 +6517,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/contents/#get-archive-link"
   },
   {
-    "name": "List deploy keys",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-deploy-keys",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#list-deploy-keys"
-  },
-  {
-    "name": "Get a deploy key",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#get-a-deploy-key"
-  },
-  {
-    "name": "Add a new deploy key",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A name for the key.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The contents of the key.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "read_only",
-        "type": "boolean",
-        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA...",
-        "read_only": true
-      }
-    ],
-    "description": "Here's how you can create a read-only deploy key:\n\n",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "add-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#add-a-new-deploy-key"
-  },
-  {
-    "name": "Remove a deploy key",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "remove-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#remove-a-deploy-key"
-  },
-  {
     "name": "List deployments",
     "enabledForApps": true,
     "method": "GET",
@@ -7872,6 +7649,514 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/forks/#create-a-fork"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) for details.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "add_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "remove_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "add_events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Test a push hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "test-push-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#test-a-push-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.14/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#delete-a-hook"
+  },
+  {
     "name": "List invitations for a repository",
     "enabledForApps": true,
     "method": "GET",
@@ -8453,6 +8738,229 @@
     ],
     "idName": "decline-invitation",
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/invitations/#decline-a-repository-invitation"
+  },
+  {
+    "name": "List deploy keys",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-deploy-keys",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#list-deploy-keys"
+  },
+  {
+    "name": "Get a deploy key",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#get-a-deploy-key"
+  },
+  {
+    "name": "Add a new deploy key",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A name for the key.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The contents of the key.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "read_only",
+        "type": "boolean",
+        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA...",
+        "read_only": true
+      }
+    ],
+    "description": "Here's how you can create a read-only deploy key:\n\n",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "add-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#add-a-new-deploy-key"
+  },
+  {
+    "name": "Remove a deploy key",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "remove-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/keys/#remove-a-deploy-key"
   },
   {
     "name": "Perform a merge",
@@ -10590,513 +11098,5 @@
     ],
     "idName": "get-combined-status-for-ref",
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) for details.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.14/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.14/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "add_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "remove_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "add_events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Test a push hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "test-push-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#test-a-push-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.14/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.14/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/hooks/#delete-a-hook"
   }
 ]

--- a/routes/ghe-2.14/teams.json
+++ b/routes/ghe-2.14/teams.json
@@ -1163,6 +1163,474 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/#remove-team-project"
   },
   {
+    "name": "List comments",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "direction",
+        "type": "string",
+        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+        "default": "desc",
+        "required": false,
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "location": "query"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        ]
+      }
+    ],
+    "idName": "list-discussion-comments",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#list-comments"
+  },
+  {
+    "name": "Get a single comment",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "idName": "get-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#get-a-single-comment"
+  },
+  {
+    "name": "Create a comment",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like apples?"
+      }
+    ],
+    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.14/v3/#abuse-rate-limits)\" for details.",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#create-a-comment"
+  },
+  {
+    "name": "Edit a comment",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like pineapples?"
+      }
+    ],
+    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like pineapples?",
+          "body_html": "<p>Do you like pineapples?</p>",
+          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": "2018-01-26T18:22:20Z",
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-26T18:22:20Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "idName": "edit-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#edit-a-comment"
+  },
+  {
+    "name": "Delete a comment",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#delete-a-comment"
+  },
+  {
     "name": "List discussions",
     "enabledForApps": true,
     "method": "GET",
@@ -1637,474 +2105,6 @@
     ],
     "idName": "delete-discussion",
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussions/#delete-a-discussion"
-  },
-  {
-    "name": "List comments",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "direction",
-        "type": "string",
-        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-        "default": "desc",
-        "required": false,
-        "enum": [
-          "asc",
-          "desc"
-        ],
-        "location": "query"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        ]
-      }
-    ],
-    "idName": "list-discussion-comments",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#list-comments"
-  },
-  {
-    "name": "Get a single comment",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "idName": "get-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#get-a-single-comment"
-  },
-  {
-    "name": "Create a comment",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like apples?"
-      }
-    ],
-    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.14/v3/#abuse-rate-limits)\" for details.",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#create-a-comment"
-  },
-  {
-    "name": "Edit a comment",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.14/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.14/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like pineapples?"
-      }
-    ],
-    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like pineapples?",
-          "body_html": "<p>Do you like pineapples?</p>",
-          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": "2018-01-26T18:22:20Z",
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-26T18:22:20Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "idName": "edit-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#edit-a-comment"
-  },
-  {
-    "name": "Delete a comment",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/teams/discussion_comments/#delete-a-comment"
   },
   {
     "name": "List team members",

--- a/routes/ghe-2.14/users.json
+++ b/routes/ghe-2.14/users.json
@@ -821,214 +821,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/followers/#unfollow-a-user"
   },
   {
-    "name": "List public keys for a user",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/users/:username/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "username",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA..."
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys-for-user",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#list-public-keys-for-a-user"
-  },
-  {
-    "name": "List your public keys",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#list-your-public-keys"
-  },
-  {
-    "name": "Get a single public key",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#get-a-single-public-key"
-  },
-  {
-    "name": "Create a public key",
-    "enabledForApps": false,
-    "method": "POST",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA..."
-      }
-    ],
-    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "create-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#create-a-public-key"
-  },
-  {
-    "name": "Delete a public key",
-    "enabledForApps": false,
-    "method": "DELETE",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#delete-a-public-key"
-  },
-  {
     "name": "List GPG keys for a user",
     "enabledForApps": true,
     "method": "GET",
@@ -1332,5 +1124,213 @@
     ],
     "idName": "delete-gpg-key",
     "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/gpg_keys/#delete-a-gpg-key"
+  },
+  {
+    "name": "List public keys for a user",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/users/:username/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "username",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA..."
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys-for-user",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#list-public-keys-for-a-user"
+  },
+  {
+    "name": "List your public keys",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#list-your-public-keys"
+  },
+  {
+    "name": "Get a single public key",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#get-a-single-public-key"
+  },
+  {
+    "name": "Create a public key",
+    "enabledForApps": false,
+    "method": "POST",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA..."
+      }
+    ],
+    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "create-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#create-a-public-key"
+  },
+  {
+    "name": "Delete a public key",
+    "enabledForApps": false,
+    "method": "DELETE",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.14/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/users/keys/#delete-a-public-key"
   }
 ]

--- a/routes/ghe-2.15/enterprise-admin.json
+++ b/routes/ghe-2.15/enterprise-admin.json
@@ -1219,111 +1219,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/management_console/#remove-an-authorized-ssh-key"
   },
   {
-    "name": "Create an organization",
-    "enabledForApps": false,
-    "method": "POST",
-    "path": "/admin/organizations",
-    "previews": [],
-    "params": [
-      {
-        "name": "login",
-        "type": "string",
-        "description": "The organization's username.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "admin",
-        "type": "string",
-        "description": "The login of the user who will manage this organization.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "profile_name",
-        "type": "string",
-        "description": "The organization's display name.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "login": "github",
-        "profile_name": "GitHub, Inc.",
-        "admin": "monalisaoctocat"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "login": "github",
-          "id": 1,
-          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-          "url": "https://api.github.com/orgs/github",
-          "repos_url": "https://api.github.com/orgs/github/repos",
-          "events_url": "https://api.github.com/orgs/github/events",
-          "hooks_url": "https://api.github.com/orgs/github/hooks",
-          "issues_url": "https://api.github.com/orgs/github/issues",
-          "members_url": "https://api.github.com/orgs/github/members{/member}",
-          "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-          "description": "A great organization"
-        }
-      }
-    ],
-    "idName": "create-org",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/#create-an-organization"
-  },
-  {
-    "name": "Rename an organization",
-    "enabledForApps": false,
-    "method": "PATCH",
-    "path": "/admin/organizations/:org",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "login",
-        "type": "string",
-        "description": "The organization's new name.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "login": "the-new-octocats"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "202 Accepted",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "message": "Job queued to rename organization. It may take a few minutes to complete.",
-          "url": "https://<hostname>/api/v3/organizations/1"
-        }
-      }
-    ],
-    "idName": "rename-org",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/#rename-an-organization"
-  },
-  {
     "name": "List pre-receive hooks for organization",
     "enabledForApps": true,
     "method": "GET",
@@ -1456,6 +1351,111 @@
     "description": "Removes any overrides for this hook at the org level for this org.",
     "idName": "remove-enforcement-overrides-for-pre-receive-hook-for-org",
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/org_pre_receive_hooks/#remove-enforcement-overrides-for-a-pre-receive-hook"
+  },
+  {
+    "name": "Create an organization",
+    "enabledForApps": false,
+    "method": "POST",
+    "path": "/admin/organizations",
+    "previews": [],
+    "params": [
+      {
+        "name": "login",
+        "type": "string",
+        "description": "The organization's username.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "admin",
+        "type": "string",
+        "description": "The login of the user who will manage this organization.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "profile_name",
+        "type": "string",
+        "description": "The organization's display name.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "login": "github",
+        "profile_name": "GitHub, Inc.",
+        "admin": "monalisaoctocat"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "login": "github",
+          "id": 1,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+          "url": "https://api.github.com/orgs/github",
+          "repos_url": "https://api.github.com/orgs/github/repos",
+          "events_url": "https://api.github.com/orgs/github/events",
+          "hooks_url": "https://api.github.com/orgs/github/hooks",
+          "issues_url": "https://api.github.com/orgs/github/issues",
+          "members_url": "https://api.github.com/orgs/github/members{/member}",
+          "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+          "description": "A great organization"
+        }
+      }
+    ],
+    "idName": "create-org",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/#create-an-organization"
+  },
+  {
+    "name": "Rename an organization",
+    "enabledForApps": false,
+    "method": "PATCH",
+    "path": "/admin/organizations/:org",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "login",
+        "type": "string",
+        "description": "The organization's new name.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "login": "the-new-octocats"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "202 Accepted",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "message": "Job queued to rename organization. It may take a few minutes to complete.",
+          "url": "https://<hostname>/api/v3/organizations/1"
+        }
+      }
+    ],
+    "idName": "rename-org",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/#rename-an-organization"
   },
   {
     "name": "Get a single pre-receive environment",

--- a/routes/ghe-2.15/index.json
+++ b/routes/ghe-2.15/index.json
@@ -1,860 +1,4 @@
 {
-  "oauthAuthorizations": [
-    {
-      "name": "List your grants",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/enterprise/2.15/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/applications/grants/1",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "created_at": "2011-09-06T17:26:27Z",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "scopes": [
-                "public_repo"
-              ]
-            }
-          ]
-        }
-      ],
-      "idName": "list-grants",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#list-your-grants"
-    },
-    {
-      "name": "Get a single grant",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/applications/grants/1",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "created_at": "2011-09-06T17:26:27Z",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "scopes": [
-              "public_repo"
-            ]
-          }
-        }
-      ],
-      "idName": "get-grant",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-a-single-grant"
-    },
-    {
-      "name": "Delete a grant",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-grant",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#delete-a-grant"
-    },
-    {
-      "name": "List your authorizations",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/authorizations/1",
-              "scopes": [
-                "public_repo"
-              ],
-              "token": "",
-              "token_last_eight": "12345678",
-              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "note": "optional note",
-              "note_url": "http://optional/note/url",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z",
-              "fingerprint": "jklmnop12345678"
-            }
-          ]
-        }
-      ],
-      "idName": "list-authorizations",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#list-your-authorizations"
-    },
-    {
-      "name": "Get a single authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "get-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-a-single-authorization"
-    },
-    {
-      "name": "Create a new authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_id",
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "If you need a small number of personal access tokens, implementing the [web flow](/enterprise/2.15/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": ""
-          }
-        }
-      ],
-      "idName": "create-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#create-a-new-authorization"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/enterprise/2.15/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-and-fingerprint",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-fingerprint",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
-      "deprecated": {
-        "date": "2018-12-27",
-        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
-        "before": {
-          "idName": "get-or-create-authorization-for-app-fingerprint"
-        },
-        "after": {
-          "idName": "get-or-create-authorization-for-app-and-fingerprint"
-        }
-      }
-    },
-    {
-      "name": "Update an existing authorization",
-      "enabledForApps": false,
-      "method": "PATCH",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "Replaces the authorization scopes with these.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to add to this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to remove from this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "add_scopes": [
-            "repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "You can only send one of these scope keys at a time.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "update-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#update-an-existing-authorization"
-    },
-    {
-      "name": "Delete an authorization",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#delete-an-authorization"
-    },
-    {
-      "name": "Check an authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "check-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#check-an-authorization"
-    },
-    {
-      "name": "Reset an authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "reset-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#reset-an-authorization"
-    },
-    {
-      "name": "Revoke an authorization for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-authorization-for-application",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
-    },
-    {
-      "name": "Revoke a grant for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/grants/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-grant-for-application",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
-    }
-  ],
   "activity": [
     {
       "name": "List public events",
@@ -2965,6 +2109,1032 @@
       ],
       "idName": "stop-watching-repo-legacy",
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/activity/watching/#stop-watching-a-repository-legacy"
+    }
+  ],
+  "apps": [
+    {
+      "name": "Get a single GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/apps/:app_slug",
+      "previews": [],
+      "params": [
+        {
+          "name": "app_slug",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-by-slug",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#get-a-single-github-app"
+    },
+    {
+      "name": "Get the authenticated GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-authenticated",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#get-the-authenticated-github-app"
+    },
+    {
+      "name": "Find installations",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "account": {
+                "login": "github",
+                "id": 1,
+                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                "url": "https://api.github.com/orgs/github",
+                "repos_url": "https://api.github.com/orgs/github/repos",
+                "events_url": "https://api.github.com/orgs/github/events",
+                "hooks_url": "https://api.github.com/orgs/github/hooks",
+                "issues_url": "https://api.github.com/orgs/github/issues",
+                "members_url": "https://api.github.com/orgs/github/members{/member}",
+                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "description": "A great organization"
+              },
+              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+              "repositories_url": "https://api.github.com/installation/repositories",
+              "html_url": "https://github.com/organizations/github/settings/installations/1",
+              "app_id": 1,
+              "target_id": 1,
+              "target_type": "Organization",
+              "permissions": {
+                "metadata": "read",
+                "contents": "read",
+                "issues": "write",
+                "single_file": "write"
+              },
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "single_file_name": "config.yml",
+              "repository_selection": "selected"
+            }
+          ],
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#find-installations"
+    },
+    {
+      "name": "Get a single installation",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations/:installation_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "You must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "metadata": "read",
+              "contents": "read",
+              "issues": "write",
+              "single_file": "write"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "single_file_name": "config.yml",
+            "repository_selection": "selected"
+          }
+        }
+      ],
+      "idName": "get-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#get-a-single-installation"
+    },
+    {
+      "name": "List installations for user",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.15/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 2,
+            "installations": [
+              {
+                "id": 1,
+                "account": {
+                  "login": "github",
+                  "id": 1,
+                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                  "url": "https://api.github.com/orgs/github",
+                  "repos_url": "https://api.github.com/orgs/github/repos",
+                  "events_url": "https://api.github.com/orgs/github/events",
+                  "hooks_url": "https://api.github.com/orgs/github/hooks",
+                  "issues_url": "https://api.github.com/orgs/github/issues",
+                  "members_url": "https://api.github.com/orgs/github/members{/member}",
+                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "description": "A great organization"
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              },
+              {
+                "id": 3,
+                "account": {
+                  "login": "octocat",
+                  "id": 2,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              }
+            ]
+          },
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#list-installations-for-user"
+    },
+    {
+      "name": "Create a new installation token",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/app/installations/:installation_id/access_tokens",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "token": "v1.1f699f1069f60xxx",
+            "expires_at": "2016-07-11T22:14:10Z"
+          }
+        }
+      ],
+      "idName": "create-installation-token",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#create-a-new-installation-token"
+    },
+    {
+      "name": "Find organization installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/orgs/:org/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-org-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#find-organization-installation"
+    },
+    {
+      "name": "Find repository installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-repo-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#find-repository-installation"
+    },
+    {
+      "name": "Find user installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/users/:username/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 3,
+            "account": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "repository_selection": "selected",
+            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/3",
+            "app_id": 2,
+            "target_id": 1,
+            "target_type": "User",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "label"
+            ],
+            "created_at": "2018-02-22T20:51:14Z",
+            "updated_at": "2018-02-22T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-user-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#find-user-installation"
+    },
+    {
+      "name": "List repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/installation/repositories",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0,
+                "anonymous_access_enabled": false
+              }
+            ]
+          }
+        }
+      ],
+      "idName": "list-repos",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/installations/#list-repositories"
+    },
+    {
+      "name": "List repositories accessible to the user for an installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations/:installation_id/repositories",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        },
+        {
+          "name": "mercy",
+          "description": "**Note:** The `topics` property for repositories on GitHub Enterprise is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.15/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "permissions": {
+                  "admin": false,
+                  "push": false,
+                  "pull": true
+                },
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0,
+                "anonymous_access_enabled": false
+              }
+            ]
+          },
+          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+        }
+      ],
+      "idName": "list-installation-repos-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
+    },
+    {
+      "name": "Add repository to installation",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.15/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.15/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "add-repo-to-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/installations/#add-repository-to-installation"
+    },
+    {
+      "name": "Remove repository from installation",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.15/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.15/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-repo-from-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/installations/#remove-repository-from-installation"
     }
   ],
   "checks": [
@@ -5094,6 +5264,151 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/checks/suites/#rerequest-check-suite"
     }
   ],
+  "codesOfConduct": [
+    {
+      "name": "List all codes of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "citizen_code_of_conduct",
+              "name": "Citizen Code of Conduct",
+              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
+            },
+            {
+              "key": "contributor_covenant",
+              "name": "Contributor Covenant",
+              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
+            }
+          ]
+        }
+      ],
+      "idName": "list-conduct-codes",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/codes_of_conduct/#list-all-codes-of-conduct"
+    },
+    {
+      "name": "Get an individual code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct/:key",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-conduct-code",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
+    },
+    {
+      "name": "Get the contents of a repository's code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/community/code_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-for-repo",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
+    }
+  ],
+  "emojis": [
+    {
+      "name": "Get",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/emojis",
+      "previews": [],
+      "params": [],
+      "description": "Lists all the emojis available to use on GitHub Enterprise.\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/emojis/#emojis"
+    }
+  ],
   "enterpriseAdmin": [
     {
       "name": "Get statistics",
@@ -6315,111 +6630,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/management_console/#remove-an-authorized-ssh-key"
     },
     {
-      "name": "Create an organization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/admin/organizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "login",
-          "type": "string",
-          "description": "The organization's username.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "admin",
-          "type": "string",
-          "description": "The login of the user who will manage this organization.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "profile_name",
-          "type": "string",
-          "description": "The organization's display name.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "login": "github",
-          "profile_name": "GitHub, Inc.",
-          "admin": "monalisaoctocat"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "login": "github",
-            "id": 1,
-            "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-            "url": "https://api.github.com/orgs/github",
-            "repos_url": "https://api.github.com/orgs/github/repos",
-            "events_url": "https://api.github.com/orgs/github/events",
-            "hooks_url": "https://api.github.com/orgs/github/hooks",
-            "issues_url": "https://api.github.com/orgs/github/issues",
-            "members_url": "https://api.github.com/orgs/github/members{/member}",
-            "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "description": "A great organization"
-          }
-        }
-      ],
-      "idName": "create-org",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/#create-an-organization"
-    },
-    {
-      "name": "Rename an organization",
-      "enabledForApps": false,
-      "method": "PATCH",
-      "path": "/admin/organizations/:org",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "login",
-          "type": "string",
-          "description": "The organization's new name.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "login": "the-new-octocats"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "202 Accepted",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "message": "Job queued to rename organization. It may take a few minutes to complete.",
-            "url": "https://<hostname>/api/v3/organizations/1"
-          }
-        }
-      ],
-      "idName": "rename-org",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/#rename-an-organization"
-    },
-    {
       "name": "List pre-receive hooks for organization",
       "enabledForApps": true,
       "method": "GET",
@@ -6552,6 +6762,111 @@
       "description": "Removes any overrides for this hook at the org level for this org.",
       "idName": "remove-enforcement-overrides-for-pre-receive-hook-for-org",
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/org_pre_receive_hooks/#remove-enforcement-overrides-for-a-pre-receive-hook"
+    },
+    {
+      "name": "Create an organization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/admin/organizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "login",
+          "type": "string",
+          "description": "The organization's username.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "admin",
+          "type": "string",
+          "description": "The login of the user who will manage this organization.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "profile_name",
+          "type": "string",
+          "description": "The organization's display name.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "login": "github",
+          "profile_name": "GitHub, Inc.",
+          "admin": "monalisaoctocat"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "login": "github",
+            "id": 1,
+            "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+            "url": "https://api.github.com/orgs/github",
+            "repos_url": "https://api.github.com/orgs/github/repos",
+            "events_url": "https://api.github.com/orgs/github/events",
+            "hooks_url": "https://api.github.com/orgs/github/hooks",
+            "issues_url": "https://api.github.com/orgs/github/issues",
+            "members_url": "https://api.github.com/orgs/github/members{/member}",
+            "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "description": "A great organization"
+          }
+        }
+      ],
+      "idName": "create-org",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/#create-an-organization"
+    },
+    {
+      "name": "Rename an organization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "path": "/admin/organizations/:org",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "login",
+          "type": "string",
+          "description": "The organization's new name.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "login": "the-new-octocats"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "202 Accepted",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "message": "Job queued to rename organization. It may take a few minutes to complete.",
+            "url": "https://<hostname>/api/v3/organizations/1"
+          }
+        }
+      ],
+      "idName": "rename-org",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/enterprise-admin/orgs/#rename-an-organization"
     },
     {
       "name": "Get a single pre-receive environment",
@@ -10263,138 +10578,15 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/git/trees/#create-a-tree"
     }
   ],
-  "apps": [
+  "gitignore": [
     {
-      "name": "Get a single GitHub App",
+      "name": "Listing available templates",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/apps/:app_slug",
+      "path": "/gitignore/templates",
       "previews": [],
-      "params": [
-        {
-          "name": "app_slug",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
-        }
-      ],
-      "idName": "get-by-slug",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#get-a-single-github-app"
-    },
-    {
-      "name": "Get the authenticated GitHub App",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
       "params": [],
-      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
-        }
-      ],
-      "idName": "get-authenticated",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#get-the-authenticated-github-app"
-    },
-    {
-      "name": "Find installations",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "description": "List all templates available to pass as an option when [creating a repository](/enterprise/2.15/v3/repos/#create).",
       "responses": [
         {
           "headers": {
@@ -10402,529 +10594,35 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": [
-            {
-              "id": 1,
-              "account": {
-                "login": "github",
-                "id": 1,
-                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                "url": "https://api.github.com/orgs/github",
-                "repos_url": "https://api.github.com/orgs/github/repos",
-                "events_url": "https://api.github.com/orgs/github/events",
-                "hooks_url": "https://api.github.com/orgs/github/hooks",
-                "issues_url": "https://api.github.com/orgs/github/issues",
-                "members_url": "https://api.github.com/orgs/github/members{/member}",
-                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "description": "A great organization"
-              },
-              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-              "repositories_url": "https://api.github.com/installation/repositories",
-              "html_url": "https://github.com/organizations/github/settings/installations/1",
-              "app_id": 1,
-              "target_id": 1,
-              "target_type": "Organization",
-              "permissions": {
-                "metadata": "read",
-                "contents": "read",
-                "issues": "write",
-                "single_file": "write"
-              },
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "single_file_name": "config.yml",
-              "repository_selection": "selected"
-            }
-          ],
-          "description": "The permissions the installation has are included under the `permissions` key."
+            "Actionscript",
+            "Android",
+            "AppceleratorTitanium",
+            "Autotools",
+            "Bancha",
+            "C",
+            "C++"
+          ]
         }
       ],
-      "idName": "list-installations",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#find-installations"
+      "idName": "list-templates",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/gitignore/#listing-available-templates"
     },
     {
-      "name": "Get a single installation",
+      "name": "Get a single template",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/app/installations/:installation_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "You must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "metadata": "read",
-              "contents": "read",
-              "issues": "write",
-              "single_file": "write"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "single_file_name": "config.yml",
-            "repository_selection": "selected"
-          }
-        }
-      ],
-      "idName": "get-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#get-a-single-installation"
-    },
-    {
-      "name": "List installations for user",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.15/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "total_count": 2,
-            "installations": [
-              {
-                "id": 1,
-                "account": {
-                  "login": "github",
-                  "id": 1,
-                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                  "url": "https://api.github.com/orgs/github",
-                  "repos_url": "https://api.github.com/orgs/github/repos",
-                  "events_url": "https://api.github.com/orgs/github/events",
-                  "hooks_url": "https://api.github.com/orgs/github/hooks",
-                  "issues_url": "https://api.github.com/orgs/github/issues",
-                  "members_url": "https://api.github.com/orgs/github/members{/member}",
-                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "description": "A great organization"
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              },
-              {
-                "id": 3,
-                "account": {
-                  "login": "octocat",
-                  "id": 2,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              }
-            ]
-          },
-          "description": "The permissions the installation has are included under the `permissions` key."
-        }
-      ],
-      "idName": "list-installations-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#list-installations-for-user"
-    },
-    {
-      "name": "Create a new installation token",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/app/installations/:installation_id/access_tokens",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "token": "v1.1f699f1069f60xxx",
-            "expires_at": "2016-07-11T22:14:10Z"
-          }
-        }
-      ],
-      "idName": "create-installation-token",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#create-a-new-installation-token"
-    },
-    {
-      "name": "Find organization installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/orgs/:org/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-org-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#find-organization-installation"
-    },
-    {
-      "name": "Find repository installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-repo-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#find-repository-installation"
-    },
-    {
-      "name": "Find user installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/users/:username/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 3,
-            "account": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "repository_selection": "selected",
-            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/3",
-            "app_id": 2,
-            "target_id": 1,
-            "target_type": "User",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "label"
-            ],
-            "created_at": "2018-02-22T20:51:14Z",
-            "updated_at": "2018-02-22T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-user-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/#find-user-installation"
-    },
-    {
-      "name": "List repositories",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/installation/repositories",
+      "path": "/gitignore/templates/:name",
       "previews": [],
       "params": [
         {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
         }
       ],
-      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](/enterprise/2.15/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/enterprise/2.15/v3/media/) to get the raw contents.\n\n",
       "responses": [
         {
           "headers": {
@@ -10932,361 +10630,20 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0,
-                "anonymous_access_enabled": false
-              }
-            ]
+            "name": "C",
+            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
           }
-        }
-      ],
-      "idName": "list-repos",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/installations/#list-repositories"
-    },
-    {
-      "name": "List repositories accessible to the user for an installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations/:installation_id/repositories",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
         },
-        {
-          "name": "mercy",
-          "description": "**Note:** The `topics` property for repositories on GitHub Enterprise is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.15/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
-      "responses": [
         {
           "headers": {
             "status": "200 OK",
             "content-type": "application/json; charset=utf-8"
           },
-          "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "permissions": {
-                  "admin": false,
-                  "push": false,
-                  "pull": true
-                },
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0,
-                "anonymous_access_enabled": false
-              }
-            ]
-          },
-          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+          "description": "Use the raw [media type](/enterprise/2.15/v3/media/) to get the raw contents."
         }
       ],
-      "idName": "list-installation-repos-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
-    },
-    {
-      "name": "Add repository to installation",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.15/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.15/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "add-repo-to-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/installations/#add-repository-to-installation"
-    },
-    {
-      "name": "Remove repository from installation",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.15/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.15/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-repo-from-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/apps/installations/#remove-repository-from-installation"
+      "idName": "get-template",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/gitignore/#get-a-single-template"
     }
   ],
   "issues": [
@@ -16378,219 +15735,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/issues/timeline/#list-events-for-an-issue"
     }
   ],
-  "codesOfConduct": [
-    {
-      "name": "List all codes of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/codes_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "key": "citizen_code_of_conduct",
-              "name": "Citizen Code of Conduct",
-              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
-            },
-            {
-              "key": "contributor_covenant",
-              "name": "Contributor Covenant",
-              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
-            }
-          ]
-        }
-      ],
-      "idName": "list-conduct-codes",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/codes_of_conduct/#list-all-codes-of-conduct"
-    },
-    {
-      "name": "Get an individual code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/codes_of_conduct/:key",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "key",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-conduct-code",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
-    },
-    {
-      "name": "Get the contents of a repository's code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/community/code_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-for-repo",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
-    }
-  ],
-  "emojis": [
-    {
-      "name": "Get",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/emojis",
-      "previews": [],
-      "params": [],
-      "description": "Lists all the emojis available to use on GitHub Enterprise.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/emojis/#emojis"
-    }
-  ],
-  "gitignore": [
-    {
-      "name": "Listing available templates",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates",
-      "previews": [],
-      "params": [],
-      "description": "List all templates available to pass as an option when [creating a repository](/enterprise/2.15/v3/repos/#create).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            "Actionscript",
-            "Android",
-            "AppceleratorTitanium",
-            "Autotools",
-            "Bancha",
-            "C",
-            "C++"
-          ]
-        }
-      ],
-      "idName": "list-templates",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/gitignore/#listing-available-templates"
-    },
-    {
-      "name": "Get a single template",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates/:name",
-      "previews": [],
-      "params": [
-        {
-          "name": "name",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/enterprise/2.15/v3/media/) to get the raw contents.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "name": "C",
-            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
-          }
-        },
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "description": "Use the raw [media type](/enterprise/2.15/v3/media/) to get the raw contents."
-        }
-      ],
-      "idName": "get-template",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/gitignore/#get-a-single-template"
-    }
-  ],
   "licenses": [
     {
       "name": "List commonly used licenses",
@@ -16951,15 +16095,75 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/meta/#meta"
     }
   ],
-  "rateLimit": [
+  "oauthAuthorizations": [
     {
-      "name": "Get your current rate limit status",
-      "enabledForApps": true,
+      "name": "List your grants",
+      "enabledForApps": false,
       "method": "GET",
-      "path": "/rate_limit",
+      "path": "/applications/grants",
       "previews": [],
-      "params": [],
-      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](/enterprise/2.15/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/enterprise/2.15/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](/enterprise/2.15/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/enterprise/2.15/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](/enterprise/2.15/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/enterprise/2.15/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/applications/grants/1",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "created_at": "2011-09-06T17:26:27Z",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "scopes": [
+                "public_repo"
+              ]
+            }
+          ]
+        }
+      ],
+      "idName": "list-grants",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#list-your-grants"
+    },
+    {
+      "name": "Get a single grant",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
       "responses": [
         {
           "headers": {
@@ -16967,33 +16171,784 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "resources": {
-              "core": {
-                "limit": 5000,
-                "remaining": 4999,
-                "reset": 1372700873
-              },
-              "search": {
-                "limit": 30,
-                "remaining": 18,
-                "reset": 1372697452
-              },
-              "graphql": {
-                "limit": 5000,
-                "remaining": 4993,
-                "reset": 1372700389
-              }
+            "id": 1,
+            "url": "https://api.github.com/applications/grants/1",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
             },
-            "rate": {
-              "limit": 5000,
-              "remaining": 4999,
-              "reset": 1372700873
+            "created_at": "2011-09-06T17:26:27Z",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "scopes": [
+              "public_repo"
+            ]
+          }
+        }
+      ],
+      "idName": "get-grant",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-a-single-grant"
+    },
+    {
+      "name": "Delete a grant",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-grant",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#delete-a-grant"
+    },
+    {
+      "name": "List your authorizations",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/authorizations/1",
+              "scopes": [
+                "public_repo"
+              ],
+              "token": "",
+              "token_last_eight": "12345678",
+              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "note": "optional note",
+              "note_url": "http://optional/note/url",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z",
+              "fingerprint": "jklmnop12345678"
+            }
+          ]
+        }
+      ],
+      "idName": "list-authorizations",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#list-your-authorizations"
+    },
+    {
+      "name": "Get a single authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "get-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-a-single-authorization"
+    },
+    {
+      "name": "Create a new authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_id",
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "If you need a small number of personal access tokens, implementing the [web flow](/enterprise/2.15/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": ""
+          }
+        }
+      ],
+      "idName": "create-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#create-a-new-authorization"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/enterprise/2.15/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-and-fingerprint",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-fingerprint",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
+      "deprecated": {
+        "date": "2018-12-27",
+        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
+        "before": {
+          "idName": "get-or-create-authorization-for-app-fingerprint"
+        },
+        "after": {
+          "idName": "get-or-create-authorization-for-app-and-fingerprint"
+        }
+      }
+    },
+    {
+      "name": "Update an existing authorization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "Replaces the authorization scopes with these.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to add to this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to remove from this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "add_scopes": [
+            "repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "You can only send one of these scope keys at a time.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "update-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#update-an-existing-authorization"
+    },
+    {
+      "name": "Delete an authorization",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#delete-an-authorization"
+    },
+    {
+      "name": "Check an authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
             }
           }
         }
       ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/rate_limit/#get-your-current-rate-limit-status"
+      "idName": "check-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#check-an-authorization"
+    },
+    {
+      "name": "Reset an authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            }
+          }
+        }
+      ],
+      "idName": "reset-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#reset-an-authorization"
+    },
+    {
+      "name": "Revoke an authorization for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-authorization-for-application",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
+    },
+    {
+      "name": "Revoke a grant for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/grants/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/enterprise/2.15/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-grant-for-application",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
     }
   ],
   "orgs": [
@@ -17397,6 +17352,412 @@
       ],
       "idName": "edit",
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/#edit-an-organization"
+    },
+    {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/orgs/octocat/hooks/1",
+              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Must be passed as \"web\".",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Here's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This will trigger a [ping event](/enterprise/2.15/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#delete-a-hook"
     },
     {
       "name": "Members list",
@@ -18275,412 +18636,6 @@
       ],
       "idName": "convert-member-to-outside-collaborator",
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-    },
-    {
-      "name": "List hooks",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/orgs/octocat/hooks/1",
-              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#list-hooks"
-    },
-    {
-      "name": "Get single hook",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#get-single-hook"
-    },
-    {
-      "name": "Create a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Must be passed as \"web\".",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Here's how you can create a hook that posts payloads in JSON format:",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#create-a-hook"
-    },
-    {
-      "name": "Edit a hook",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "active": true,
-          "events": [
-            "pull_request"
-          ]
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#edit-a-hook"
-    },
-    {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This will trigger a [ping event](/enterprise/2.15/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#delete-a-hook"
     }
   ],
   "projects": [
@@ -23416,731 +23371,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/#merge-a-pull-request-merge-button"
     },
     {
-      "name": "List reviews on a pull request",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "The list of reviews returns in chronological order.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 80,
-              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Here is the body for the review.",
-              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-              "state": "APPROVED",
-              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-              "_links": {
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-                }
-              }
-            }
-          ],
-          "description": "The list of reviews returns in chronological order."
-        }
-      ],
-      "idName": "list-reviews",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-    },
-    {
-      "name": "Get a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "get-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#get-a-single-review"
-    },
-    {
-      "name": "Delete a pending review",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "PENDING",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "delete-pending-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#delete-a-pending-review"
-    },
-    {
-      "name": "Get comments for a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-              "id": 10,
-              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-              "pull_request_review_id": 42,
-              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-              "path": "file1.txt",
-              "position": 1,
-              "original_position": 4,
-              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-              "in_reply_to_id": 8,
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Great stuff",
-              "created_at": "2011-04-14T16:00:49Z",
-              "updated_at": "2011-04-14T16:00:49Z",
-              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-              "_links": {
-                "self": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-                },
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "get-comments-for-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#get-comments-for-a-single-review"
-    },
-    {
-      "name": "Create a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "commit_id",
-          "type": "string",
-          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.15/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-          "required": false,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        },
-        {
-          "name": "comments",
-          "type": "object[]",
-          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "comments[].path",
-          "type": "string",
-          "description": "The relative path to the file that necessitates a review comment.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].position",
-          "type": "integer",
-          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].body",
-          "type": "string",
-          "description": "Text of the review comment.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "event": "REQUEST_CHANGES",
-          "comments": [
-            {
-              "path": "file.md",
-              "position": 6,
-              "body": "Please add more information here, and fix this typo."
-            }
-          ]
-        }
-      ],
-      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.15/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.15/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.15/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "This is close to perfect! Please address the suggested inline change.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "CHANGES_REQUESTED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#create-a-pull-request-review"
-    },
-    {
-      "name": "Submit a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The body text of the pull request review",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-          "required": true,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "submit-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#submit-a-pull-request-review"
-    },
-    {
-      "name": "Dismiss a pull request review",
-      "enabledForApps": true,
-      "method": "PUT",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "message",
-          "type": "string",
-          "description": "The message for the pull request review dismissal",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.15/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "DISMISSED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "dismiss-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#dismiss-a-pull-request-review"
-    },
-    {
       "name": "List comments on a pull request",
       "enabledForApps": true,
       "method": "GET",
@@ -25637,6 +24867,776 @@
       ],
       "idName": "delete-review-request",
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/review_requests/#delete-a-review-request"
+    },
+    {
+      "name": "List reviews on a pull request",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "The list of reviews returns in chronological order.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 80,
+              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Here is the body for the review.",
+              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+              "state": "APPROVED",
+              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+              "_links": {
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+                }
+              }
+            }
+          ],
+          "description": "The list of reviews returns in chronological order."
+        }
+      ],
+      "idName": "list-reviews",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+    },
+    {
+      "name": "Get a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "get-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#get-a-single-review"
+    },
+    {
+      "name": "Delete a pending review",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "PENDING",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "delete-pending-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#delete-a-pending-review"
+    },
+    {
+      "name": "Get comments for a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+              "id": 10,
+              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+              "pull_request_review_id": 42,
+              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+              "path": "file1.txt",
+              "position": 1,
+              "original_position": 4,
+              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+              "in_reply_to_id": 8,
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Great stuff",
+              "created_at": "2011-04-14T16:00:49Z",
+              "updated_at": "2011-04-14T16:00:49Z",
+              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+              "_links": {
+                "self": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+                },
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "get-comments-for-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#get-comments-for-a-single-review"
+    },
+    {
+      "name": "Create a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "commit_id",
+          "type": "string",
+          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.15/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+          "required": false,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        },
+        {
+          "name": "comments",
+          "type": "object[]",
+          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "comments[].path",
+          "type": "string",
+          "description": "The relative path to the file that necessitates a review comment.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].position",
+          "type": "integer",
+          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].body",
+          "type": "string",
+          "description": "Text of the review comment.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "event": "REQUEST_CHANGES",
+          "comments": [
+            {
+              "path": "file.md",
+              "position": 6,
+              "body": "Please add more information here, and fix this typo."
+            }
+          ]
+        }
+      ],
+      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.15/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.15/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.15/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "This is close to perfect! Please address the suggested inline change.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "CHANGES_REQUESTED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#create-a-pull-request-review"
+    },
+    {
+      "name": "Submit a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The body text of the pull request review",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+          "required": true,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "submit-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#submit-a-pull-request-review"
+    },
+    {
+      "name": "Dismiss a pull request review",
+      "enabledForApps": true,
+      "method": "PUT",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "message",
+          "type": "string",
+          "description": "The message for the pull request review dismissal",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.15/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "DISMISSED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "dismiss-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#dismiss-a-pull-request-review"
+    }
+  ],
+  "rateLimit": [
+    {
+      "name": "Get your current rate limit status",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/rate_limit",
+      "previews": [],
+      "params": [],
+      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](/enterprise/2.15/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/enterprise/2.15/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](/enterprise/2.15/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/enterprise/2.15/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](/enterprise/2.15/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "resources": {
+              "core": {
+                "limit": 5000,
+                "remaining": 4999,
+                "reset": 1372700873
+              },
+              "search": {
+                "limit": 30,
+                "remaining": 18,
+                "reset": 1372697452
+              },
+              "graphql": {
+                "limit": 5000,
+                "remaining": 4993,
+                "reset": 1372700389
+              }
+            },
+            "rate": {
+              "limit": 5000,
+              "remaining": 4999,
+              "reset": 1372700873
+            }
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/rate_limit/#get-your-current-rate-limit-status"
     }
   ],
   "reactions": [
@@ -33398,229 +33398,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/contents/#get-archive-link"
     },
     {
-      "name": "List deploy keys",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-deploy-keys",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#list-deploy-keys"
-    },
-    {
-      "name": "Get a deploy key",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#get-a-deploy-key"
-    },
-    {
-      "name": "Add a new deploy key",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A name for the key.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The contents of the key.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "read_only",
-          "type": "boolean",
-          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA...",
-          "read_only": true
-        }
-      ],
-      "description": "Here's how you can create a read-only deploy key:\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "add-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#add-a-new-deploy-key"
-    },
-    {
-      "name": "Remove a deploy key",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#remove-a-deploy-key"
-    },
-    {
       "name": "List deployments",
       "enabledForApps": true,
       "method": "GET",
@@ -34753,6 +34530,515 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/forks/#create-a-fork"
     },
     {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com/webhook",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) for details.",
+          "default": "web",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "add_events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Test a push hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "test-push-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#test-a-push-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.15/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#delete-a-hook"
+    },
+    {
       "name": "List invitations for a repository",
       "enabledForApps": true,
       "method": "GET",
@@ -35334,6 +35620,229 @@
       ],
       "idName": "decline-invitation",
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/invitations/#decline-a-repository-invitation"
+    },
+    {
+      "name": "List deploy keys",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-deploy-keys",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#list-deploy-keys"
+    },
+    {
+      "name": "Get a deploy key",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#get-a-deploy-key"
+    },
+    {
+      "name": "Add a new deploy key",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A name for the key.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The contents of the key.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "read_only",
+          "type": "boolean",
+          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA...",
+          "read_only": true
+        }
+      ],
+      "description": "Here's how you can create a read-only deploy key:\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "add-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#add-a-new-deploy-key"
+    },
+    {
+      "name": "Remove a deploy key",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#remove-a-deploy-key"
     },
     {
       "name": "Perform a merge",
@@ -37510,515 +38019,6 @@
       ],
       "idName": "get-combined-status-for-ref",
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref"
-    },
-    {
-      "name": "List hooks",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com/webhook",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#list-hooks"
-    },
-    {
-      "name": "Get single hook",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#get-single-hook"
-    },
-    {
-      "name": "Create a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) for details.",
-          "default": "web",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#create-a-hook"
-    },
-    {
-      "name": "Edit a hook",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "active": true,
-          "add_events": [
-            "pull_request"
-          ]
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#edit-a-hook"
-    },
-    {
-      "name": "Test a push hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "test-push-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#test-a-push-hook"
-    },
-    {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.15/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#delete-a-hook"
     }
   ],
   "search": [
@@ -39847,6 +39847,474 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/#remove-team-project"
     },
     {
+      "name": "List comments",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "direction",
+          "type": "string",
+          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "location": "query"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "author": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Do you like apples?",
+              "body_html": "<p>Do you like apples?</p>",
+              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+              "created_at": "2018-01-15T23:53:58Z",
+              "last_edited_at": null,
+              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+              "number": 1,
+              "updated_at": "2018-01-15T23:53:58Z",
+              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+              "reactions": {
+                "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+                "total_count": 5,
+                "+1": 3,
+                "-1": 1,
+                "laugh": 0,
+                "confused": 0,
+                "heart": 1,
+                "hooray": 0
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "list-discussion-comments",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#list-comments"
+    },
+    {
+      "name": "Get a single comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "idName": "get-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#get-a-single-comment"
+    },
+    {
+      "name": "Create a comment",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like apples?"
+        }
+      ],
+      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.15/v3/#abuse-rate-limits)\" for details.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#create-a-comment"
+    },
+    {
+      "name": "Edit a comment",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like pineapples?"
+        }
+      ],
+      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like pineapples?",
+            "body_html": "<p>Do you like pineapples?</p>",
+            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": "2018-01-26T18:22:20Z",
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-26T18:22:20Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "idName": "edit-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#edit-a-comment"
+    },
+    {
+      "name": "Delete a comment",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#delete-a-comment"
+    },
+    {
       "name": "List discussions",
       "enabledForApps": true,
       "method": "GET",
@@ -40321,474 +40789,6 @@
       ],
       "idName": "delete-discussion",
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussions/#delete-a-discussion"
-    },
-    {
-      "name": "List comments",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "direction",
-          "type": "string",
-          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-          "default": "desc",
-          "required": false,
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "location": "query"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "author": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Do you like apples?",
-              "body_html": "<p>Do you like apples?</p>",
-              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-              "created_at": "2018-01-15T23:53:58Z",
-              "last_edited_at": null,
-              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-              "number": 1,
-              "updated_at": "2018-01-15T23:53:58Z",
-              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-              "reactions": {
-                "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-                "total_count": 5,
-                "+1": 3,
-                "-1": 1,
-                "laugh": 0,
-                "confused": 0,
-                "heart": 1,
-                "hooray": 0
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "list-discussion-comments",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#list-comments"
-    },
-    {
-      "name": "Get a single comment",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "idName": "get-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#get-a-single-comment"
-    },
-    {
-      "name": "Create a comment",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like apples?"
-        }
-      ],
-      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.15/v3/#abuse-rate-limits)\" for details.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#create-a-comment"
-    },
-    {
-      "name": "Edit a comment",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like pineapples?"
-        }
-      ],
-      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like pineapples?",
-            "body_html": "<p>Do you like pineapples?</p>",
-            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": "2018-01-26T18:22:20Z",
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-26T18:22:20Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "idName": "edit-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#edit-a-comment"
-    },
-    {
-      "name": "Delete a comment",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#delete-a-comment"
     },
     {
       "name": "List team members",
@@ -41950,214 +41950,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/followers/#unfollow-a-user"
     },
     {
-      "name": "List public keys for a user",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/users/:username/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA..."
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys-for-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#list-public-keys-for-a-user"
-    },
-    {
-      "name": "List your public keys",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/user/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#list-your-public-keys"
-    },
-    {
-      "name": "Get a single public key",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#get-a-single-public-key"
-    },
-    {
-      "name": "Create a public key",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA..."
-        }
-      ],
-      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "create-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#create-a-public-key"
-    },
-    {
-      "name": "Delete a public key",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#delete-a-public-key"
-    },
-    {
       "name": "List GPG keys for a user",
       "enabledForApps": true,
       "method": "GET",
@@ -42461,6 +42253,214 @@
       ],
       "idName": "delete-gpg-key",
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/gpg_keys/#delete-a-gpg-key"
+    },
+    {
+      "name": "List public keys for a user",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/users/:username/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA..."
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys-for-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#list-public-keys-for-a-user"
+    },
+    {
+      "name": "List your public keys",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/user/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#list-your-public-keys"
+    },
+    {
+      "name": "Get a single public key",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#get-a-single-public-key"
+    },
+    {
+      "name": "Create a public key",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA..."
+        }
+      ],
+      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "create-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#create-a-public-key"
+    },
+    {
+      "name": "Delete a public key",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#delete-a-public-key"
     }
   ]
 }

--- a/routes/ghe-2.15/index.json
+++ b/routes/ghe-2.15/index.json
@@ -16657,6 +16657,80 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/licenses/#list-commonly-used-licenses"
     },
     {
+      "name": "List all licenses",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/licenses",
+      "previews": [],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "mit",
+              "name": "MIT License",
+              "spdx_id": "MIT",
+              "url": "https://api.github.com/licenses/mit",
+              "node_id": "MDc6TGljZW5zZW1pdA=="
+            },
+            {
+              "key": "lgpl-3.0",
+              "name": "GNU Lesser General Public License v3.0",
+              "spdx_id": "LGPL-3.0",
+              "url": "https://api.github.com/licenses/lgpl-3.0"
+            },
+            {
+              "key": "mpl-2.0",
+              "name": "Mozilla Public License 2.0",
+              "spdx_id": "MPL-2.0",
+              "url": "https://api.github.com/licenses/mpl-2.0"
+            },
+            {
+              "key": "agpl-3.0",
+              "name": "GNU Affero General Public License v3.0",
+              "spdx_id": "AGPL-3.0",
+              "url": "https://api.github.com/licenses/agpl-3.0"
+            },
+            {
+              "key": "unlicense",
+              "name": "The Unlicense",
+              "spdx_id": "Unlicense",
+              "url": "https://api.github.com/licenses/unlicense"
+            },
+            {
+              "key": "apache-2.0",
+              "name": "Apache License 2.0",
+              "spdx_id": "Apache-2.0",
+              "url": "https://api.github.com/licenses/apache-2.0"
+            },
+            {
+              "key": "gpl-3.0",
+              "name": "GNU General Public License v3.0",
+              "spdx_id": "GPL-3.0",
+              "url": "https://api.github.com/licenses/gpl-3.0"
+            }
+          ]
+        }
+      ],
+      "idName": "list",
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/licenses/#list-commonly-used-licenses",
+      "deprecated": {
+        "date": "2019-03-05",
+        "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+        "before": {
+          "idName": "list"
+        },
+        "after": {
+          "idName": "list-commonly-used"
+        }
+      }
+    },
+    {
       "name": "Get an individual license",
       "enabledForApps": true,
       "method": "GET",

--- a/routes/ghe-2.15/licenses.json
+++ b/routes/ghe-2.15/licenses.json
@@ -64,6 +64,80 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/licenses/#list-commonly-used-licenses"
   },
   {
+    "name": "List all licenses",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/licenses",
+    "previews": [],
+    "params": [],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "key": "mit",
+            "name": "MIT License",
+            "spdx_id": "MIT",
+            "url": "https://api.github.com/licenses/mit",
+            "node_id": "MDc6TGljZW5zZW1pdA=="
+          },
+          {
+            "key": "lgpl-3.0",
+            "name": "GNU Lesser General Public License v3.0",
+            "spdx_id": "LGPL-3.0",
+            "url": "https://api.github.com/licenses/lgpl-3.0"
+          },
+          {
+            "key": "mpl-2.0",
+            "name": "Mozilla Public License 2.0",
+            "spdx_id": "MPL-2.0",
+            "url": "https://api.github.com/licenses/mpl-2.0"
+          },
+          {
+            "key": "agpl-3.0",
+            "name": "GNU Affero General Public License v3.0",
+            "spdx_id": "AGPL-3.0",
+            "url": "https://api.github.com/licenses/agpl-3.0"
+          },
+          {
+            "key": "unlicense",
+            "name": "The Unlicense",
+            "spdx_id": "Unlicense",
+            "url": "https://api.github.com/licenses/unlicense"
+          },
+          {
+            "key": "apache-2.0",
+            "name": "Apache License 2.0",
+            "spdx_id": "Apache-2.0",
+            "url": "https://api.github.com/licenses/apache-2.0"
+          },
+          {
+            "key": "gpl-3.0",
+            "name": "GNU General Public License v3.0",
+            "spdx_id": "GPL-3.0",
+            "url": "https://api.github.com/licenses/gpl-3.0"
+          }
+        ]
+      }
+    ],
+    "idName": "list",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/licenses/#list-commonly-used-licenses",
+    "deprecated": {
+      "date": "2019-03-05",
+      "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+      "before": {
+        "idName": "list"
+      },
+      "after": {
+        "idName": "list-commonly-used"
+      }
+    }
+  },
+  {
     "name": "Get an individual license",
     "enabledForApps": true,
     "method": "GET",

--- a/routes/ghe-2.15/licenses/list.json
+++ b/routes/ghe-2.15/licenses/list.json
@@ -1,0 +1,74 @@
+{
+  "name": "List all licenses",
+  "enabledForApps": true,
+  "method": "GET",
+  "path": "/licenses",
+  "previews": [],
+  "params": [],
+  "description": "",
+  "responses": [
+    {
+      "headers": {
+        "status": "200 OK",
+        "content-type": "application/json; charset=utf-8"
+      },
+      "body": [
+        {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZW1pdA=="
+        },
+        {
+          "key": "lgpl-3.0",
+          "name": "GNU Lesser General Public License v3.0",
+          "spdx_id": "LGPL-3.0",
+          "url": "https://api.github.com/licenses/lgpl-3.0"
+        },
+        {
+          "key": "mpl-2.0",
+          "name": "Mozilla Public License 2.0",
+          "spdx_id": "MPL-2.0",
+          "url": "https://api.github.com/licenses/mpl-2.0"
+        },
+        {
+          "key": "agpl-3.0",
+          "name": "GNU Affero General Public License v3.0",
+          "spdx_id": "AGPL-3.0",
+          "url": "https://api.github.com/licenses/agpl-3.0"
+        },
+        {
+          "key": "unlicense",
+          "name": "The Unlicense",
+          "spdx_id": "Unlicense",
+          "url": "https://api.github.com/licenses/unlicense"
+        },
+        {
+          "key": "apache-2.0",
+          "name": "Apache License 2.0",
+          "spdx_id": "Apache-2.0",
+          "url": "https://api.github.com/licenses/apache-2.0"
+        },
+        {
+          "key": "gpl-3.0",
+          "name": "GNU General Public License v3.0",
+          "spdx_id": "GPL-3.0",
+          "url": "https://api.github.com/licenses/gpl-3.0"
+        }
+      ]
+    }
+  ],
+  "idName": "list",
+  "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/licenses/#list-commonly-used-licenses",
+  "deprecated": {
+    "date": "2019-03-05",
+    "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+    "before": {
+      "idName": "list"
+    },
+    "after": {
+      "idName": "list-commonly-used"
+    }
+  }
+}

--- a/routes/ghe-2.15/orgs.json
+++ b/routes/ghe-2.15/orgs.json
@@ -401,6 +401,412 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/#edit-an-organization"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Must be passed as \"web\".",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Here's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "This will trigger a [ping event](/enterprise/2.15/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#delete-a-hook"
+  },
+  {
     "name": "Members list",
     "enabledForApps": true,
     "method": "GET",
@@ -1277,411 +1683,5 @@
     ],
     "idName": "convert-member-to-outside-collaborator",
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Must be passed as \"web\".",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Here's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "This will trigger a [ping event](/enterprise/2.15/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/orgs/hooks/#delete-a-hook"
   }
 ]

--- a/routes/ghe-2.15/pulls.json
+++ b/routes/ghe-2.15/pulls.json
@@ -3275,731 +3275,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/#merge-a-pull-request-merge-button"
   },
   {
-    "name": "List reviews on a pull request",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "The list of reviews returns in chronological order.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        ],
-        "description": "The list of reviews returns in chronological order."
-      }
-    ],
-    "idName": "list-reviews",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-  },
-  {
-    "name": "Get a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "get-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#get-a-single-review"
-  },
-  {
-    "name": "Delete a pending review",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "PENDING",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "delete-pending-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#delete-a-pending-review"
-  },
-  {
-    "name": "Get comments for a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-            "id": 10,
-            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-            "pull_request_review_id": 42,
-            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-            "path": "file1.txt",
-            "position": 1,
-            "original_position": 4,
-            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-            "in_reply_to_id": 8,
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Great stuff",
-            "created_at": "2011-04-14T16:00:49Z",
-            "updated_at": "2011-04-14T16:00:49Z",
-            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-            "_links": {
-              "self": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-              },
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-              }
-            }
-          }
-        ]
-      }
-    ],
-    "idName": "get-comments-for-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#get-comments-for-a-single-review"
-  },
-  {
-    "name": "Create a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "commit_id",
-        "type": "string",
-        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.15/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-        "required": false,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      },
-      {
-        "name": "comments",
-        "type": "object[]",
-        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "comments[].path",
-        "type": "string",
-        "description": "The relative path to the file that necessitates a review comment.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].position",
-        "type": "integer",
-        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].body",
-        "type": "string",
-        "description": "Text of the review comment.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-        "body": "This is close to perfect! Please address the suggested inline change.",
-        "event": "REQUEST_CHANGES",
-        "comments": [
-          {
-            "path": "file.md",
-            "position": 6,
-            "body": "Please add more information here, and fix this typo."
-          }
-        ]
-      }
-    ],
-    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.15/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.15/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.15/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "CHANGES_REQUESTED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#create-a-pull-request-review"
-  },
-  {
-    "name": "Submit a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The body text of the pull request review",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-        "required": true,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "submit-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#submit-a-pull-request-review"
-  },
-  {
-    "name": "Dismiss a pull request review",
-    "enabledForApps": true,
-    "method": "PUT",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "message",
-        "type": "string",
-        "description": "The message for the pull request review dismissal",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.15/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "DISMISSED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "dismiss-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#dismiss-a-pull-request-review"
-  },
-  {
     "name": "List comments on a pull request",
     "enabledForApps": true,
     "method": "GET",
@@ -5496,5 +4771,730 @@
     ],
     "idName": "delete-review-request",
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/review_requests/#delete-a-review-request"
+  },
+  {
+    "name": "List reviews on a pull request",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "The list of reviews returns in chronological order.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        ],
+        "description": "The list of reviews returns in chronological order."
+      }
+    ],
+    "idName": "list-reviews",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+  },
+  {
+    "name": "Get a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "get-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#get-a-single-review"
+  },
+  {
+    "name": "Delete a pending review",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "PENDING",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "delete-pending-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#delete-a-pending-review"
+  },
+  {
+    "name": "Get comments for a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+            "id": 10,
+            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+            "pull_request_review_id": 42,
+            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+            "path": "file1.txt",
+            "position": 1,
+            "original_position": 4,
+            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+            "in_reply_to_id": 8,
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Great stuff",
+            "created_at": "2011-04-14T16:00:49Z",
+            "updated_at": "2011-04-14T16:00:49Z",
+            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+            "_links": {
+              "self": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+              },
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "idName": "get-comments-for-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#get-comments-for-a-single-review"
+  },
+  {
+    "name": "Create a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "commit_id",
+        "type": "string",
+        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.15/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+        "required": false,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      },
+      {
+        "name": "comments",
+        "type": "object[]",
+        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "comments[].path",
+        "type": "string",
+        "description": "The relative path to the file that necessitates a review comment.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].position",
+        "type": "integer",
+        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].body",
+        "type": "string",
+        "description": "Text of the review comment.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+        "body": "This is close to perfect! Please address the suggested inline change.",
+        "event": "REQUEST_CHANGES",
+        "comments": [
+          {
+            "path": "file.md",
+            "position": 6,
+            "body": "Please add more information here, and fix this typo."
+          }
+        ]
+      }
+    ],
+    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.15/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.15/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.15/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "CHANGES_REQUESTED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#create-a-pull-request-review"
+  },
+  {
+    "name": "Submit a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The body text of the pull request review",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+        "required": true,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "submit-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#submit-a-pull-request-review"
+  },
+  {
+    "name": "Dismiss a pull request review",
+    "enabledForApps": true,
+    "method": "PUT",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "message",
+        "type": "string",
+        "description": "The message for the pull request review dismissal",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.15/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "DISMISSED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "dismiss-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/pulls/reviews/#dismiss-a-pull-request-review"
   }
 ]

--- a/routes/ghe-2.15/repos.json
+++ b/routes/ghe-2.15/repos.json
@@ -6517,229 +6517,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/contents/#get-archive-link"
   },
   {
-    "name": "List deploy keys",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-deploy-keys",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#list-deploy-keys"
-  },
-  {
-    "name": "Get a deploy key",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#get-a-deploy-key"
-  },
-  {
-    "name": "Add a new deploy key",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A name for the key.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The contents of the key.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "read_only",
-        "type": "boolean",
-        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA...",
-        "read_only": true
-      }
-    ],
-    "description": "Here's how you can create a read-only deploy key:\n\n",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "add-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#add-a-new-deploy-key"
-  },
-  {
-    "name": "Remove a deploy key",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "remove-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#remove-a-deploy-key"
-  },
-  {
     "name": "List deployments",
     "enabledForApps": true,
     "method": "GET",
@@ -7872,6 +7649,515 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/forks/#create-a-fork"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) for details.",
+        "default": "web",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "add_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "remove_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "add_events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Test a push hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "test-push-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#test-a-push-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.15/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#delete-a-hook"
+  },
+  {
     "name": "List invitations for a repository",
     "enabledForApps": true,
     "method": "GET",
@@ -8453,6 +8739,229 @@
     ],
     "idName": "decline-invitation",
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/invitations/#decline-a-repository-invitation"
+  },
+  {
+    "name": "List deploy keys",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-deploy-keys",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#list-deploy-keys"
+  },
+  {
+    "name": "Get a deploy key",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#get-a-deploy-key"
+  },
+  {
+    "name": "Add a new deploy key",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A name for the key.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The contents of the key.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "read_only",
+        "type": "boolean",
+        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA...",
+        "read_only": true
+      }
+    ],
+    "description": "Here's how you can create a read-only deploy key:\n\n",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "add-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#add-a-new-deploy-key"
+  },
+  {
+    "name": "Remove a deploy key",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "remove-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/keys/#remove-a-deploy-key"
   },
   {
     "name": "Perform a merge",
@@ -10629,514 +11138,5 @@
     ],
     "idName": "get-combined-status-for-ref",
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) for details.",
-        "default": "web",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.15/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.15/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "add_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "remove_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "add_events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Test a push hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "test-push-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#test-a-push-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.15/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.15/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/hooks/#delete-a-hook"
   }
 ]

--- a/routes/ghe-2.15/teams.json
+++ b/routes/ghe-2.15/teams.json
@@ -1163,6 +1163,474 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/#remove-team-project"
   },
   {
+    "name": "List comments",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "direction",
+        "type": "string",
+        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+        "default": "desc",
+        "required": false,
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "location": "query"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        ]
+      }
+    ],
+    "idName": "list-discussion-comments",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#list-comments"
+  },
+  {
+    "name": "Get a single comment",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "idName": "get-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#get-a-single-comment"
+  },
+  {
+    "name": "Create a comment",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like apples?"
+      }
+    ],
+    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.15/v3/#abuse-rate-limits)\" for details.",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#create-a-comment"
+  },
+  {
+    "name": "Edit a comment",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like pineapples?"
+      }
+    ],
+    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like pineapples?",
+          "body_html": "<p>Do you like pineapples?</p>",
+          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": "2018-01-26T18:22:20Z",
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-26T18:22:20Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "idName": "edit-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#edit-a-comment"
+  },
+  {
+    "name": "Delete a comment",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#delete-a-comment"
+  },
+  {
     "name": "List discussions",
     "enabledForApps": true,
     "method": "GET",
@@ -1637,474 +2105,6 @@
     ],
     "idName": "delete-discussion",
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussions/#delete-a-discussion"
-  },
-  {
-    "name": "List comments",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "direction",
-        "type": "string",
-        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-        "default": "desc",
-        "required": false,
-        "enum": [
-          "asc",
-          "desc"
-        ],
-        "location": "query"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        ]
-      }
-    ],
-    "idName": "list-discussion-comments",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#list-comments"
-  },
-  {
-    "name": "Get a single comment",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "idName": "get-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#get-a-single-comment"
-  },
-  {
-    "name": "Create a comment",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like apples?"
-      }
-    ],
-    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.15/v3/#abuse-rate-limits)\" for details.",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#create-a-comment"
-  },
-  {
-    "name": "Edit a comment",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.15/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.15/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like pineapples?"
-      }
-    ],
-    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like pineapples?",
-          "body_html": "<p>Do you like pineapples?</p>",
-          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": "2018-01-26T18:22:20Z",
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-26T18:22:20Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "idName": "edit-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#edit-a-comment"
-  },
-  {
-    "name": "Delete a comment",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/teams/discussion_comments/#delete-a-comment"
   },
   {
     "name": "List team members",

--- a/routes/ghe-2.15/users.json
+++ b/routes/ghe-2.15/users.json
@@ -841,214 +841,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/followers/#unfollow-a-user"
   },
   {
-    "name": "List public keys for a user",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/users/:username/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "username",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA..."
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys-for-user",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#list-public-keys-for-a-user"
-  },
-  {
-    "name": "List your public keys",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#list-your-public-keys"
-  },
-  {
-    "name": "Get a single public key",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#get-a-single-public-key"
-  },
-  {
-    "name": "Create a public key",
-    "enabledForApps": false,
-    "method": "POST",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA..."
-      }
-    ],
-    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "create-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#create-a-public-key"
-  },
-  {
-    "name": "Delete a public key",
-    "enabledForApps": false,
-    "method": "DELETE",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#delete-a-public-key"
-  },
-  {
     "name": "List GPG keys for a user",
     "enabledForApps": true,
     "method": "GET",
@@ -1352,5 +1144,213 @@
     ],
     "idName": "delete-gpg-key",
     "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/gpg_keys/#delete-a-gpg-key"
+  },
+  {
+    "name": "List public keys for a user",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/users/:username/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "username",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA..."
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys-for-user",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#list-public-keys-for-a-user"
+  },
+  {
+    "name": "List your public keys",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#list-your-public-keys"
+  },
+  {
+    "name": "Get a single public key",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#get-a-single-public-key"
+  },
+  {
+    "name": "Create a public key",
+    "enabledForApps": false,
+    "method": "POST",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA..."
+      }
+    ],
+    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "create-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#create-a-public-key"
+  },
+  {
+    "name": "Delete a public key",
+    "enabledForApps": false,
+    "method": "DELETE",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.15/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/users/keys/#delete-a-public-key"
   }
 ]

--- a/routes/ghe-2.16/enterprise-admin.json
+++ b/routes/ghe-2.16/enterprise-admin.json
@@ -1219,111 +1219,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/management_console/#remove-an-authorized-ssh-key"
   },
   {
-    "name": "Create an organization",
-    "enabledForApps": false,
-    "method": "POST",
-    "path": "/admin/organizations",
-    "previews": [],
-    "params": [
-      {
-        "name": "login",
-        "type": "string",
-        "description": "The organization's username.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "admin",
-        "type": "string",
-        "description": "The login of the user who will manage this organization.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "profile_name",
-        "type": "string",
-        "description": "The organization's display name.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "login": "github",
-        "profile_name": "GitHub, Inc.",
-        "admin": "monalisaoctocat"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "login": "github",
-          "id": 1,
-          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-          "url": "https://api.github.com/orgs/github",
-          "repos_url": "https://api.github.com/orgs/github/repos",
-          "events_url": "https://api.github.com/orgs/github/events",
-          "hooks_url": "https://api.github.com/orgs/github/hooks",
-          "issues_url": "https://api.github.com/orgs/github/issues",
-          "members_url": "https://api.github.com/orgs/github/members{/member}",
-          "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-          "description": "A great organization"
-        }
-      }
-    ],
-    "idName": "create-org",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/#create-an-organization"
-  },
-  {
-    "name": "Rename an organization",
-    "enabledForApps": false,
-    "method": "PATCH",
-    "path": "/admin/organizations/:org",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "login",
-        "type": "string",
-        "description": "The organization's new name.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "login": "the-new-octocats"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "202 Accepted",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "message": "Job queued to rename organization. It may take a few minutes to complete.",
-          "url": "https://<hostname>/api/v3/organizations/1"
-        }
-      }
-    ],
-    "idName": "rename-org",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/#rename-an-organization"
-  },
-  {
     "name": "List pre-receive hooks for organization",
     "enabledForApps": true,
     "method": "GET",
@@ -1456,6 +1351,111 @@
     "description": "Removes any overrides for this hook at the org level for this org.",
     "idName": "remove-enforcement-overrides-for-pre-receive-hook-for-org",
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/org_pre_receive_hooks/#remove-enforcement-overrides-for-a-pre-receive-hook"
+  },
+  {
+    "name": "Create an organization",
+    "enabledForApps": false,
+    "method": "POST",
+    "path": "/admin/organizations",
+    "previews": [],
+    "params": [
+      {
+        "name": "login",
+        "type": "string",
+        "description": "The organization's username.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "admin",
+        "type": "string",
+        "description": "The login of the user who will manage this organization.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "profile_name",
+        "type": "string",
+        "description": "The organization's display name.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "login": "github",
+        "profile_name": "GitHub, Inc.",
+        "admin": "monalisaoctocat"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "login": "github",
+          "id": 1,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+          "url": "https://api.github.com/orgs/github",
+          "repos_url": "https://api.github.com/orgs/github/repos",
+          "events_url": "https://api.github.com/orgs/github/events",
+          "hooks_url": "https://api.github.com/orgs/github/hooks",
+          "issues_url": "https://api.github.com/orgs/github/issues",
+          "members_url": "https://api.github.com/orgs/github/members{/member}",
+          "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+          "description": "A great organization"
+        }
+      }
+    ],
+    "idName": "create-org",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/#create-an-organization"
+  },
+  {
+    "name": "Rename an organization",
+    "enabledForApps": false,
+    "method": "PATCH",
+    "path": "/admin/organizations/:org",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "login",
+        "type": "string",
+        "description": "The organization's new name.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "login": "the-new-octocats"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "202 Accepted",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "message": "Job queued to rename organization. It may take a few minutes to complete.",
+          "url": "https://<hostname>/api/v3/organizations/1"
+        }
+      }
+    ],
+    "idName": "rename-org",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/#rename-an-organization"
   },
   {
     "name": "Get a single pre-receive environment",

--- a/routes/ghe-2.16/index.json
+++ b/routes/ghe-2.16/index.json
@@ -16717,6 +16717,80 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/licenses/#list-commonly-used-licenses"
     },
     {
+      "name": "List all licenses",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/licenses",
+      "previews": [],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "mit",
+              "name": "MIT License",
+              "spdx_id": "MIT",
+              "url": "https://api.github.com/licenses/mit",
+              "node_id": "MDc6TGljZW5zZW1pdA=="
+            },
+            {
+              "key": "lgpl-3.0",
+              "name": "GNU Lesser General Public License v3.0",
+              "spdx_id": "LGPL-3.0",
+              "url": "https://api.github.com/licenses/lgpl-3.0"
+            },
+            {
+              "key": "mpl-2.0",
+              "name": "Mozilla Public License 2.0",
+              "spdx_id": "MPL-2.0",
+              "url": "https://api.github.com/licenses/mpl-2.0"
+            },
+            {
+              "key": "agpl-3.0",
+              "name": "GNU Affero General Public License v3.0",
+              "spdx_id": "AGPL-3.0",
+              "url": "https://api.github.com/licenses/agpl-3.0"
+            },
+            {
+              "key": "unlicense",
+              "name": "The Unlicense",
+              "spdx_id": "Unlicense",
+              "url": "https://api.github.com/licenses/unlicense"
+            },
+            {
+              "key": "apache-2.0",
+              "name": "Apache License 2.0",
+              "spdx_id": "Apache-2.0",
+              "url": "https://api.github.com/licenses/apache-2.0"
+            },
+            {
+              "key": "gpl-3.0",
+              "name": "GNU General Public License v3.0",
+              "spdx_id": "GPL-3.0",
+              "url": "https://api.github.com/licenses/gpl-3.0"
+            }
+          ]
+        }
+      ],
+      "idName": "list",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/licenses/#list-commonly-used-licenses",
+      "deprecated": {
+        "date": "2019-03-05",
+        "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+        "before": {
+          "idName": "list"
+        },
+        "after": {
+          "idName": "list-commonly-used"
+        }
+      }
+    },
+    {
       "name": "Get an individual license",
       "enabledForApps": true,
       "method": "GET",

--- a/routes/ghe-2.16/index.json
+++ b/routes/ghe-2.16/index.json
@@ -1,860 +1,4 @@
 {
-  "oauthAuthorizations": [
-    {
-      "name": "List your grants",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/enterprise/2.16/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/applications/grants/1",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "created_at": "2011-09-06T17:26:27Z",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "scopes": [
-                "public_repo"
-              ]
-            }
-          ]
-        }
-      ],
-      "idName": "list-grants",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#list-your-grants"
-    },
-    {
-      "name": "Get a single grant",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/applications/grants/1",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "created_at": "2011-09-06T17:26:27Z",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "scopes": [
-              "public_repo"
-            ]
-          }
-        }
-      ],
-      "idName": "get-grant",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-a-single-grant"
-    },
-    {
-      "name": "Delete a grant",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/grants/:grant_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "grant_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-grant",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#delete-a-grant"
-    },
-    {
-      "name": "List your authorizations",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/authorizations/1",
-              "scopes": [
-                "public_repo"
-              ],
-              "token": "",
-              "token_last_eight": "12345678",
-              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-              "app": {
-                "url": "http://my-github-app.com",
-                "name": "my github app",
-                "client_id": "abcde12345fghij67890"
-              },
-              "note": "optional note",
-              "note_url": "http://optional/note/url",
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z",
-              "fingerprint": "jklmnop12345678"
-            }
-          ]
-        }
-      ],
-      "idName": "list-authorizations",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#list-your-authorizations"
-    },
-    {
-      "name": "Get a single authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "get-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-a-single-authorization"
-    },
-    {
-      "name": "Create a new authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/authorizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_id",
-          "type": "string",
-          "description": "The 20 character OAuth app client key for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret for which to create the token.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "If you need a small number of personal access tokens, implementing the [web flow](/enterprise/2.16/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": ""
-          }
-        }
-      ],
-      "idName": "create-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#create-a-new-authorization"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/enterprise/2.16/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-and-fingerprint",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
-    },
-    {
-      "name": "Get-or-create an authorization for a specific app and fingerprint",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/authorizations/clients/:client_id/:fingerprint",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "client_secret",
-          "type": "string",
-          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "A list of scopes that this authorization is in.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-          "scopes": [
-            "public_repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
-      "idName": "get-or-create-authorization-for-app-fingerprint",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
-      "deprecated": {
-        "date": "2018-12-27",
-        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
-        "before": {
-          "idName": "get-or-create-authorization-for-app-fingerprint"
-        },
-        "after": {
-          "idName": "get-or-create-authorization-for-app-and-fingerprint"
-        }
-      }
-    },
-    {
-      "name": "Update an existing authorization",
-      "enabledForApps": false,
-      "method": "PATCH",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "scopes",
-          "type": "string[]",
-          "description": "Replaces the authorization scopes with these.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to add to this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_scopes",
-          "type": "string[]",
-          "description": "A list of scopes to remove from this authorization.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note",
-          "type": "string",
-          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "note_url",
-          "type": "string",
-          "description": "A URL to remind you what app the OAuth token is for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "fingerprint",
-          "type": "string",
-          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "add_scopes": [
-            "repo"
-          ],
-          "note": "admin script"
-        }
-      ],
-      "description": "You can only send one of these scope keys at a time.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678"
-          }
-        }
-      ],
-      "idName": "update-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#update-an-existing-authorization"
-    },
-    {
-      "name": "Delete an authorization",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/authorizations/:authorization_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "authorization_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#delete-an-authorization"
-    },
-    {
-      "name": "Check an authorization",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "check-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#check-an-authorization"
-    },
-    {
-      "name": "Reset an authorization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/authorizations/1",
-            "scopes": [
-              "public_repo"
-            ],
-            "token": "abcdefgh12345678",
-            "token_last_eight": "12345678",
-            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
-            "app": {
-              "url": "http://my-github-app.com",
-              "name": "my github app",
-              "client_id": "abcde12345fghij67890"
-            },
-            "note": "optional note",
-            "note_url": "http://optional/note/url",
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z",
-            "fingerprint": "jklmnop12345678",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            }
-          }
-        }
-      ],
-      "idName": "reset-authorization",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#reset-an-authorization"
-    },
-    {
-      "name": "Revoke an authorization for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/tokens/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-authorization-for-application",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
-    },
-    {
-      "name": "Revoke a grant for an application",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/applications/:client_id/grants/:access_token",
-      "previews": [],
-      "params": [
-        {
-          "name": "client_id",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "access_token",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "revoke-grant-for-application",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
-    }
-  ],
   "activity": [
     {
       "name": "List public events",
@@ -2965,6 +2109,1090 @@
       ],
       "idName": "stop-watching-repo-legacy",
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/activity/watching/#stop-watching-a-repository-legacy"
+    }
+  ],
+  "apps": [
+    {
+      "name": "Get a single GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/apps/:app_slug",
+      "previews": [],
+      "params": [
+        {
+          "name": "app_slug",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-by-slug",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#get-a-single-github-app"
+    },
+    {
+      "name": "Get the authenticated GitHub App",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "name": "Super CI",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/super-ci",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00"
+          }
+        }
+      ],
+      "idName": "get-authenticated",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#get-the-authenticated-github-app"
+    },
+    {
+      "name": "Find installations",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "account": {
+                "login": "github",
+                "id": 1,
+                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                "url": "https://api.github.com/orgs/github",
+                "repos_url": "https://api.github.com/orgs/github/repos",
+                "events_url": "https://api.github.com/orgs/github/events",
+                "hooks_url": "https://api.github.com/orgs/github/hooks",
+                "issues_url": "https://api.github.com/orgs/github/issues",
+                "members_url": "https://api.github.com/orgs/github/members{/member}",
+                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "description": "A great organization"
+              },
+              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+              "repositories_url": "https://api.github.com/installation/repositories",
+              "html_url": "https://github.com/organizations/github/settings/installations/1",
+              "app_id": 1,
+              "target_id": 1,
+              "target_type": "Organization",
+              "permissions": {
+                "metadata": "read",
+                "contents": "read",
+                "issues": "write",
+                "single_file": "write"
+              },
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "single_file_name": "config.yml",
+              "repository_selection": "selected"
+            }
+          ],
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#find-installations"
+    },
+    {
+      "name": "Get a single installation",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/app/installations/:installation_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "You must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+              "url": "https://api.github.com/orgs/github",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "hooks_url": "https://api.github.com/orgs/github/hooks",
+              "issues_url": "https://api.github.com/orgs/github/issues",
+              "members_url": "https://api.github.com/orgs/github/members{/member}",
+              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "description": "A great organization"
+            },
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "metadata": "read",
+              "contents": "read",
+              "issues": "write",
+              "single_file": "write"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "single_file_name": "config.yml",
+            "repository_selection": "selected"
+          }
+        }
+      ],
+      "idName": "get-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#get-a-single-installation"
+    },
+    {
+      "name": "List installations for user",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.16/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 2,
+            "installations": [
+              {
+                "id": 1,
+                "account": {
+                  "login": "github",
+                  "id": 1,
+                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                  "url": "https://api.github.com/orgs/github",
+                  "repos_url": "https://api.github.com/orgs/github/repos",
+                  "events_url": "https://api.github.com/orgs/github/events",
+                  "hooks_url": "https://api.github.com/orgs/github/hooks",
+                  "issues_url": "https://api.github.com/orgs/github/issues",
+                  "members_url": "https://api.github.com/orgs/github/members{/member}",
+                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "description": "A great organization"
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              },
+              {
+                "id": 3,
+                "account": {
+                  "login": "octocat",
+                  "id": 2,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+                "repositories_url": "https://api.github.com/installation/repositories",
+                "html_url": "https://github.com/organizations/github/settings/installations/1",
+                "app_id": 1,
+                "target_id": 1,
+                "target_type": "Organization",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ],
+                "single_file_name": "config.yml"
+              }
+            ]
+          },
+          "description": "The permissions the installation has are included under the `permissions` key."
+        }
+      ],
+      "idName": "list-installations-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#list-installations-for-user"
+    },
+    {
+      "name": "Create a new installation token",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/app/installations/:installation_id/access_tokens",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "token": "v1.1f699f1069f60xxx",
+            "expires_at": "2016-07-11T22:14:10Z"
+          }
+        }
+      ],
+      "idName": "create-installation-token",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#create-a-new-installation-token"
+    },
+    {
+      "name": "Find organization installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/orgs/:org/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-org-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#find-organization-installation"
+    },
+    {
+      "name": "Find repository installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "account": {
+              "login": "github",
+              "id": 1,
+              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/orgs/github",
+              "html_url": "https://github.com/github",
+              "followers_url": "https://api.github.com/users/github/followers",
+              "following_url": "https://api.github.com/users/github/following{/other_user}",
+              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+              "organizations_url": "https://api.github.com/users/github/orgs",
+              "repos_url": "https://api.github.com/orgs/github/repos",
+              "events_url": "https://api.github.com/orgs/github/events",
+              "received_events_url": "https://api.github.com/users/github/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "repository_selection": "all",
+            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/1",
+            "app_id": 1,
+            "target_id": 1,
+            "target_type": "Organization",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "created_at": "2018-02-09T20:51:14Z",
+            "updated_at": "2018-02-09T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-repo-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#find-repository-installation"
+    },
+    {
+      "name": "Find user installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/users/:username/installation",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 3,
+            "account": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "repository_selection": "selected",
+            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
+            "repositories_url": "https://api.github.com/installation/repositories",
+            "html_url": "https://github.com/organizations/github/settings/installations/3",
+            "app_id": 2,
+            "target_id": 1,
+            "target_type": "User",
+            "permissions": {
+              "checks": "write",
+              "metadata": "read",
+              "contents": "read"
+            },
+            "events": [
+              "label"
+            ],
+            "created_at": "2018-02-22T20:51:14Z",
+            "updated_at": "2018-02-22T20:51:14Z",
+            "single_file_name": null
+          }
+        }
+      ],
+      "idName": "find-user-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#find-user-installation"
+    },
+    {
+      "name": "Create a content attachment",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/content_references/:content_reference_id/attachments",
+      "previews": [
+        {
+          "name": "corsair",
+          "description": "**Note:** To access the Content Attachments API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.corsair-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "content_reference_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "description": "The title of the content attachment displayed in the body or comment of an issue or pull request.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The body text of the content attachment displayed in the body or comment of an issue or pull request. This parameter supports markdown.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "[A-1234] Error found in core/models.py file",
+          "body": "You have used an email that already exists for the user_email_uniq field.\n ## DETAILS:\n\nThe (email)=(Octocat@github.com) already exists.\n\n The error was found in core/models.py in get_or_create_user at line 62.\n\nself.save()"
+        }
+      ],
+      "description": "Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](/enterprise/2.16/v3/activity/events/types/#contentreferenceevent) to create an attachment.\n\nThe app must create a content attachment within six hours of the content reference URL being posted. See \"[Using content attachments](/enterprise/2.16/apps/using-content-attachments/)\" for details about content attachments.\n\nYou must use an [installation access token](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.\n\nThis example creates a content attachment for the domain `https://errors.ai/`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 101,
+            "title": "[A-1234] Error found in core/models.py file'",
+            "body": "You have used an email that already exists for the user_email_uniq field.\n ## DETAILS:\n\nThe (email)=(Octocat@github.com) already exists.\n\n The error was found in core/models.py in get_or_create_user at line 62.\n\n self.save()"
+          }
+        }
+      ],
+      "idName": "create-content-attachment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#create-a-content-attachment"
+    },
+    {
+      "name": "List repositories",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/installation/repositories",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0,
+                "anonymous_access_enabled": false
+              }
+            ]
+          }
+        }
+      ],
+      "idName": "list-repos",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/installations/#list-repositories"
+    },
+    {
+      "name": "List repositories accessible to the user for an installation",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/installations/:installation_id/repositories",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        },
+        {
+          "name": "mercy",
+          "description": "**Note:** The `topics` property for repositories on GitHub Enterprise Server is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.16/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "total_count": 1,
+            "repositories": [
+              {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "owner": {
+                  "login": "octocat",
+                  "id": 1,
+                  "node_id": "MDQ6VXNlcjE=",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "url": "https://api.github.com/users/octocat",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "repos_url": "https://api.github.com/users/octocat/repos",
+                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": false
+                },
+                "private": false,
+                "html_url": "https://github.com/octocat/Hello-World",
+                "description": "This your first repo!",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/Hello-World",
+                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+                "git_url": "git:github.com/octocat/Hello-World.git",
+                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+                "ssh_url": "git@github.com:octocat/Hello-World.git",
+                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+                "clone_url": "https://github.com/octocat/Hello-World.git",
+                "mirror_url": "git:git.example.com/octocat/Hello-World",
+                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+                "svn_url": "https://svn.github.com/octocat/Hello-World",
+                "homepage": "https://github.com",
+                "language": null,
+                "forks_count": 9,
+                "stargazers_count": 80,
+                "watchers_count": 80,
+                "size": 108,
+                "default_branch": "master",
+                "open_issues_count": 0,
+                "topics": [
+                  "octocat",
+                  "atom",
+                  "electron",
+                  "API"
+                ],
+                "has_issues": true,
+                "has_projects": true,
+                "has_wiki": true,
+                "has_pages": false,
+                "has_downloads": true,
+                "archived": false,
+                "pushed_at": "2011-01-26T19:06:43Z",
+                "created_at": "2011-01-26T19:01:12Z",
+                "updated_at": "2011-01-26T19:14:43Z",
+                "permissions": {
+                  "admin": false,
+                  "push": false,
+                  "pull": true
+                },
+                "allow_rebase_merge": true,
+                "allow_squash_merge": true,
+                "allow_merge_commit": true,
+                "subscribers_count": 42,
+                "network_count": 0,
+                "anonymous_access_enabled": false
+              }
+            ]
+          },
+          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+        }
+      ],
+      "idName": "list-installation-repos-for-authenticated-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
+    },
+    {
+      "name": "Add repository to installation",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.16/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.16/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "add-repo-to-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/installations/#add-repository-to-installation"
+    },
+    {
+      "name": "Remove repository from installation",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/installations/:installation_id/repositories/:repository_id",
+      "previews": [
+        {
+          "name": "machine-man",
+          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "installation_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repository_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.16/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.16/v3/auth/#basic-authentication) to access this endpoint.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-repo-from-installation",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/installations/#remove-repository-from-installation"
     }
   ],
   "checks": [
@@ -5094,6 +5322,151 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/checks/suites/#rerequest-check-suite"
     }
   ],
+  "codesOfConduct": [
+    {
+      "name": "List all codes of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "key": "citizen_code_of_conduct",
+              "name": "Citizen Code of Conduct",
+              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
+            },
+            {
+              "key": "contributor_covenant",
+              "name": "Contributor Covenant",
+              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
+            }
+          ]
+        }
+      ],
+      "idName": "list-conduct-codes",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/codes_of_conduct/#list-all-codes-of-conduct"
+    },
+    {
+      "name": "Get an individual code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/codes_of_conduct/:key",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-conduct-code",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
+    },
+    {
+      "name": "Get the contents of a repository's code of conduct",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/community/code_of_conduct",
+      "previews": [
+        {
+          "name": "scarlet-witch",
+          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "key": "contributor_covenant",
+            "name": "Contributor Covenant",
+            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
+            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
+          }
+        }
+      ],
+      "idName": "get-for-repo",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
+    }
+  ],
+  "emojis": [
+    {
+      "name": "Get",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/emojis",
+      "previews": [],
+      "params": [],
+      "description": "Lists all the emojis available to use on GitHub Enterprise Server.\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/emojis/#emojis"
+    }
+  ],
   "enterpriseAdmin": [
     {
       "name": "Get statistics",
@@ -6315,111 +6688,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/management_console/#remove-an-authorized-ssh-key"
     },
     {
-      "name": "Create an organization",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/admin/organizations",
-      "previews": [],
-      "params": [
-        {
-          "name": "login",
-          "type": "string",
-          "description": "The organization's username.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "admin",
-          "type": "string",
-          "description": "The login of the user who will manage this organization.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "profile_name",
-          "type": "string",
-          "description": "The organization's display name.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "login": "github",
-          "profile_name": "GitHub, Inc.",
-          "admin": "monalisaoctocat"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "login": "github",
-            "id": 1,
-            "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-            "url": "https://api.github.com/orgs/github",
-            "repos_url": "https://api.github.com/orgs/github/repos",
-            "events_url": "https://api.github.com/orgs/github/events",
-            "hooks_url": "https://api.github.com/orgs/github/hooks",
-            "issues_url": "https://api.github.com/orgs/github/issues",
-            "members_url": "https://api.github.com/orgs/github/members{/member}",
-            "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "description": "A great organization"
-          }
-        }
-      ],
-      "idName": "create-org",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/#create-an-organization"
-    },
-    {
-      "name": "Rename an organization",
-      "enabledForApps": false,
-      "method": "PATCH",
-      "path": "/admin/organizations/:org",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "login",
-          "type": "string",
-          "description": "The organization's new name.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "login": "the-new-octocats"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "202 Accepted",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "message": "Job queued to rename organization. It may take a few minutes to complete.",
-            "url": "https://<hostname>/api/v3/organizations/1"
-          }
-        }
-      ],
-      "idName": "rename-org",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/#rename-an-organization"
-    },
-    {
       "name": "List pre-receive hooks for organization",
       "enabledForApps": true,
       "method": "GET",
@@ -6552,6 +6820,111 @@
       "description": "Removes any overrides for this hook at the org level for this org.",
       "idName": "remove-enforcement-overrides-for-pre-receive-hook-for-org",
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/org_pre_receive_hooks/#remove-enforcement-overrides-for-a-pre-receive-hook"
+    },
+    {
+      "name": "Create an organization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/admin/organizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "login",
+          "type": "string",
+          "description": "The organization's username.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "admin",
+          "type": "string",
+          "description": "The login of the user who will manage this organization.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "profile_name",
+          "type": "string",
+          "description": "The organization's display name.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "login": "github",
+          "profile_name": "GitHub, Inc.",
+          "admin": "monalisaoctocat"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "login": "github",
+            "id": 1,
+            "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+            "url": "https://api.github.com/orgs/github",
+            "repos_url": "https://api.github.com/orgs/github/repos",
+            "events_url": "https://api.github.com/orgs/github/events",
+            "hooks_url": "https://api.github.com/orgs/github/hooks",
+            "issues_url": "https://api.github.com/orgs/github/issues",
+            "members_url": "https://api.github.com/orgs/github/members{/member}",
+            "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "description": "A great organization"
+          }
+        }
+      ],
+      "idName": "create-org",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/#create-an-organization"
+    },
+    {
+      "name": "Rename an organization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "path": "/admin/organizations/:org",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "login",
+          "type": "string",
+          "description": "The organization's new name.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "login": "the-new-octocats"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "202 Accepted",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "message": "Job queued to rename organization. It may take a few minutes to complete.",
+            "url": "https://<hostname>/api/v3/organizations/1"
+          }
+        }
+      ],
+      "idName": "rename-org",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/enterprise-admin/orgs/#rename-an-organization"
     },
     {
       "name": "Get a single pre-receive environment",
@@ -10263,138 +10636,15 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/git/trees/#create-a-tree"
     }
   ],
-  "apps": [
+  "gitignore": [
     {
-      "name": "Get a single GitHub App",
+      "name": "Listing available templates",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/apps/:app_slug",
+      "path": "/gitignore/templates",
       "previews": [],
-      "params": [
-        {
-          "name": "app_slug",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).\n\nIf the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
-        }
-      ],
-      "idName": "get-by-slug",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#get-a-single-github-app"
-    },
-    {
-      "name": "Get the authenticated GitHub App",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
       "params": [],
-      "description": "Returns the GitHub App associated with the authentication credentials used.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "node_id": "MDExOkludGVncmF0aW9uMQ==",
-            "owner": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "name": "Super CI",
-            "description": "",
-            "external_url": "https://example.com",
-            "html_url": "https://github.com/apps/super-ci",
-            "created_at": "2017-07-08T16:18:44-04:00",
-            "updated_at": "2017-07-08T16:18:44-04:00"
-          }
-        }
-      ],
-      "idName": "get-authenticated",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#get-the-authenticated-github-app"
-    },
-    {
-      "name": "Find installations",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/app/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "You must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
+      "description": "List all templates available to pass as an option when [creating a repository](/enterprise/2.16/v3/repos/#create).",
       "responses": [
         {
           "headers": {
@@ -10402,587 +10652,35 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": [
-            {
-              "id": 1,
-              "account": {
-                "login": "github",
-                "id": 1,
-                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                "url": "https://api.github.com/orgs/github",
-                "repos_url": "https://api.github.com/orgs/github/repos",
-                "events_url": "https://api.github.com/orgs/github/events",
-                "hooks_url": "https://api.github.com/orgs/github/hooks",
-                "issues_url": "https://api.github.com/orgs/github/issues",
-                "members_url": "https://api.github.com/orgs/github/members{/member}",
-                "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "description": "A great organization"
-              },
-              "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-              "repositories_url": "https://api.github.com/installation/repositories",
-              "html_url": "https://github.com/organizations/github/settings/installations/1",
-              "app_id": 1,
-              "target_id": 1,
-              "target_type": "Organization",
-              "permissions": {
-                "metadata": "read",
-                "contents": "read",
-                "issues": "write",
-                "single_file": "write"
-              },
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "single_file_name": "config.yml",
-              "repository_selection": "selected"
-            }
-          ],
-          "description": "The permissions the installation has are included under the `permissions` key."
+            "Actionscript",
+            "Android",
+            "AppceleratorTitanium",
+            "Autotools",
+            "Bancha",
+            "C",
+            "C++"
+          ]
         }
       ],
-      "idName": "list-installations",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#find-installations"
+      "idName": "list-templates",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/gitignore/#listing-available-templates"
     },
     {
-      "name": "Get a single installation",
+      "name": "Get a single template",
       "enabledForApps": true,
       "method": "GET",
-      "path": "/app/installations/:installation_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "You must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-              "url": "https://api.github.com/orgs/github",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "hooks_url": "https://api.github.com/orgs/github/hooks",
-              "issues_url": "https://api.github.com/orgs/github/issues",
-              "members_url": "https://api.github.com/orgs/github/members{/member}",
-              "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "description": "A great organization"
-            },
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "metadata": "read",
-              "contents": "read",
-              "issues": "write",
-              "single_file": "write"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "single_file_name": "config.yml",
-            "repository_selection": "selected"
-          }
-        }
-      ],
-      "idName": "get-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#get-a-single-installation"
-    },
-    {
-      "name": "List installations for user",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists installations in a repository that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.16/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nThe permissions the installation has are included under the `permissions` key.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "total_count": 2,
-            "installations": [
-              {
-                "id": 1,
-                "account": {
-                  "login": "github",
-                  "id": 1,
-                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
-                  "url": "https://api.github.com/orgs/github",
-                  "repos_url": "https://api.github.com/orgs/github/repos",
-                  "events_url": "https://api.github.com/orgs/github/events",
-                  "hooks_url": "https://api.github.com/orgs/github/hooks",
-                  "issues_url": "https://api.github.com/orgs/github/issues",
-                  "members_url": "https://api.github.com/orgs/github/members{/member}",
-                  "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "description": "A great organization"
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              },
-              {
-                "id": 3,
-                "account": {
-                  "login": "octocat",
-                  "id": 2,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-                "repositories_url": "https://api.github.com/installation/repositories",
-                "html_url": "https://github.com/organizations/github/settings/installations/1",
-                "app_id": 1,
-                "target_id": 1,
-                "target_type": "Organization",
-                "permissions": {
-                  "metadata": "read",
-                  "contents": "read",
-                  "issues": "write",
-                  "single_file": "write"
-                },
-                "events": [
-                  "push",
-                  "pull_request"
-                ],
-                "single_file_name": "config.yml"
-              }
-            ]
-          },
-          "description": "The permissions the installation has are included under the `permissions` key."
-        }
-      ],
-      "idName": "list-installations-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#list-installations-for-user"
-    },
-    {
-      "name": "Create a new installation token",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/app/installations/:installation_id/access_tokens",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Creates an access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "token": "v1.1f699f1069f60xxx",
-            "expires_at": "2016-07-11T22:14:10Z"
-          }
-        }
-      ],
-      "idName": "create-installation-token",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#create-a-new-installation-token"
-    },
-    {
-      "name": "Find organization installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/orgs/:org/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the organization's installation information.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-org-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#find-organization-installation"
-    },
-    {
-      "name": "Find repository installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "account": {
-              "login": "github",
-              "id": 1,
-              "avatar_url": "https://github.com/images/error/hubot_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/orgs/github",
-              "html_url": "https://github.com/github",
-              "followers_url": "https://api.github.com/users/github/followers",
-              "following_url": "https://api.github.com/users/github/following{/other_user}",
-              "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-              "organizations_url": "https://api.github.com/users/github/orgs",
-              "repos_url": "https://api.github.com/orgs/github/repos",
-              "events_url": "https://api.github.com/orgs/github/events",
-              "received_events_url": "https://api.github.com/users/github/received_events",
-              "type": "Organization",
-              "site_admin": false
-            },
-            "repository_selection": "all",
-            "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/1",
-            "app_id": 1,
-            "target_id": 1,
-            "target_type": "Organization",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "created_at": "2018-02-09T20:51:14Z",
-            "updated_at": "2018-02-09T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-repo-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#find-repository-installation"
-    },
-    {
-      "name": "Find user installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/users/:username/installation",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Enables an authenticated GitHub App to find the user’s installation information.\n\nYou must use a [JWT](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 3,
-            "account": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "repository_selection": "selected",
-            "access_tokens_url": "https://api.github.com/installations/3/access_tokens",
-            "repositories_url": "https://api.github.com/installation/repositories",
-            "html_url": "https://github.com/organizations/github/settings/installations/3",
-            "app_id": 2,
-            "target_id": 1,
-            "target_type": "User",
-            "permissions": {
-              "checks": "write",
-              "metadata": "read",
-              "contents": "read"
-            },
-            "events": [
-              "label"
-            ],
-            "created_at": "2018-02-22T20:51:14Z",
-            "updated_at": "2018-02-22T20:51:14Z",
-            "single_file_name": null
-          }
-        }
-      ],
-      "idName": "find-user-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#find-user-installation"
-    },
-    {
-      "name": "Create a content attachment",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/content_references/:content_reference_id/attachments",
-      "previews": [
-        {
-          "name": "corsair",
-          "description": "**Note:** To access the Content Attachments API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.corsair-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "content_reference_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "title",
-          "type": "string",
-          "description": "The title of the content attachment displayed in the body or comment of an issue or pull request.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The body text of the content attachment displayed in the body or comment of an issue or pull request. This parameter supports markdown.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "[A-1234] Error found in core/models.py file",
-          "body": "You have used an email that already exists for the user_email_uniq field.\n ## DETAILS:\n\nThe (email)=(Octocat@github.com) already exists.\n\n The error was found in core/models.py in get_or_create_user at line 62.\n\nself.save()"
-        }
-      ],
-      "description": "Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](/enterprise/2.16/v3/activity/events/types/#contentreferenceevent) to create an attachment.\n\nThe app must create a content attachment within six hours of the content reference URL being posted. See \"[Using content attachments](/enterprise/2.16/apps/using-content-attachments/)\" for details about content attachments.\n\nYou must use an [installation access token](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.\n\nThis example creates a content attachment for the domain `https://errors.ai/`.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 101,
-            "title": "[A-1234] Error found in core/models.py file'",
-            "body": "You have used an email that already exists for the user_email_uniq field.\n ## DETAILS:\n\nThe (email)=(Octocat@github.com) already exists.\n\n The error was found in core/models.py in get_or_create_user at line 62.\n\n self.save()"
-          }
-        }
-      ],
-      "idName": "create-content-attachment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/#create-a-content-attachment"
-    },
-    {
-      "name": "List repositories",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/installation/repositories",
+      "path": "/gitignore/templates/:name",
       "previews": [],
       "params": [
         {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
         }
       ],
-      "description": "List repositories that an installation can access.\n\nYou must use an [installation access token](/enterprise/2.16/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.",
+      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/enterprise/2.16/v3/media/) to get the raw contents.\n\n",
       "responses": [
         {
           "headers": {
@@ -10990,361 +10688,20 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0,
-                "anonymous_access_enabled": false
-              }
-            ]
+            "name": "C",
+            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
           }
-        }
-      ],
-      "idName": "list-repos",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/installations/#list-repositories"
-    },
-    {
-      "name": "List repositories accessible to the user for an installation",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/installations/:installation_id/repositories",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
         },
-        {
-          "name": "mercy",
-          "description": "**Note:** The `topics` property for repositories on GitHub Enterprise Server is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.\n\nThe authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.\n\nYou must use a [user-to-server OAuth access token](/enterprise/2.16/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.\n\nThe access the user has to each repository is included in the hash under the `permissions` key.",
-      "responses": [
         {
           "headers": {
             "status": "200 OK",
             "content-type": "application/json; charset=utf-8"
           },
-          "body": {
-            "total_count": 1,
-            "repositories": [
-              {
-                "id": 1296269,
-                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
-                "name": "Hello-World",
-                "full_name": "octocat/Hello-World",
-                "owner": {
-                  "login": "octocat",
-                  "id": 1,
-                  "node_id": "MDQ6VXNlcjE=",
-                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                  "gravatar_id": "",
-                  "url": "https://api.github.com/users/octocat",
-                  "html_url": "https://github.com/octocat",
-                  "followers_url": "https://api.github.com/users/octocat/followers",
-                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                  "organizations_url": "https://api.github.com/users/octocat/orgs",
-                  "repos_url": "https://api.github.com/users/octocat/repos",
-                  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                  "received_events_url": "https://api.github.com/users/octocat/received_events",
-                  "type": "User",
-                  "site_admin": false
-                },
-                "private": false,
-                "html_url": "https://github.com/octocat/Hello-World",
-                "description": "This your first repo!",
-                "fork": false,
-                "url": "https://api.github.com/repos/octocat/Hello-World",
-                "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
-                "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
-                "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
-                "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
-                "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
-                "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
-                "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
-                "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
-                "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
-                "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
-                "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
-                "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
-                "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
-                "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
-                "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
-                "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
-                "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
-                "git_url": "git:github.com/octocat/Hello-World.git",
-                "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
-                "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
-                "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
-                "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
-                "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
-                "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
-                "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
-                "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
-                "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
-                "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
-                "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
-                "ssh_url": "git@github.com:octocat/Hello-World.git",
-                "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
-                "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
-                "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
-                "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
-                "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
-                "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
-                "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
-                "clone_url": "https://github.com/octocat/Hello-World.git",
-                "mirror_url": "git:git.example.com/octocat/Hello-World",
-                "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
-                "svn_url": "https://svn.github.com/octocat/Hello-World",
-                "homepage": "https://github.com",
-                "language": null,
-                "forks_count": 9,
-                "stargazers_count": 80,
-                "watchers_count": 80,
-                "size": 108,
-                "default_branch": "master",
-                "open_issues_count": 0,
-                "topics": [
-                  "octocat",
-                  "atom",
-                  "electron",
-                  "API"
-                ],
-                "has_issues": true,
-                "has_projects": true,
-                "has_wiki": true,
-                "has_pages": false,
-                "has_downloads": true,
-                "archived": false,
-                "pushed_at": "2011-01-26T19:06:43Z",
-                "created_at": "2011-01-26T19:01:12Z",
-                "updated_at": "2011-01-26T19:14:43Z",
-                "permissions": {
-                  "admin": false,
-                  "push": false,
-                  "pull": true
-                },
-                "allow_rebase_merge": true,
-                "allow_squash_merge": true,
-                "allow_merge_commit": true,
-                "subscribers_count": 42,
-                "network_count": 0,
-                "anonymous_access_enabled": false
-              }
-            ]
-          },
-          "description": "The access the user has to each repository is included in the hash under the `permissions` key."
+          "description": "Use the raw [media type](/enterprise/2.16/v3/media/) to get the raw contents."
         }
       ],
-      "idName": "list-installation-repos-for-authenticated-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation"
-    },
-    {
-      "name": "Add repository to installation",
-      "enabledForApps": false,
-      "method": "PUT",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Add a single repository to an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.16/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.16/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "add-repo-to-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/installations/#add-repository-to-installation"
-    },
-    {
-      "name": "Remove repository from installation",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/installations/:installation_id/repositories/:repository_id",
-      "previews": [
-        {
-          "name": "machine-man",
-          "description": "**Note:** To access the API with your GitHub App, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "installation_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repository_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Remove a single repository from an installation. The authenticated user must have admin access to the repository.\n\nYou must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](/enterprise/2.16/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](/enterprise/2.16/v3/auth/#basic-authentication) to access this endpoint.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-repo-from-installation",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/apps/installations/#remove-repository-from-installation"
+      "idName": "get-template",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/gitignore/#get-a-single-template"
     }
   ],
   "issues": [
@@ -16438,219 +15795,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/issues/timeline/#list-events-for-an-issue"
     }
   ],
-  "codesOfConduct": [
-    {
-      "name": "List all codes of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/codes_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "key": "citizen_code_of_conduct",
-              "name": "Citizen Code of Conduct",
-              "url": "https://api.github.com/codes_of_conduct/citizen_code_of_conduct"
-            },
-            {
-              "key": "contributor_covenant",
-              "name": "Contributor Covenant",
-              "url": "https://api.github.com/codes_of_conduct/contributor_covenant"
-            }
-          ]
-        }
-      ],
-      "idName": "list-conduct-codes",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/codes_of_conduct/#list-all-codes-of-conduct"
-    },
-    {
-      "name": "Get an individual code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/codes_of_conduct/:key",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "key",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://api.github.com/codes_of_conduct/contributor_covenant",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include:\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include:\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\n                  to any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\n                  posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [EMAIL]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-conduct-code",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/codes_of_conduct/#get-an-individual-code-of-conduct"
-    },
-    {
-      "name": "Get the contents of a repository's code of conduct",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/community/code_of_conduct",
-      "previews": [
-        {
-          "name": "scarlet-witch",
-          "description": "**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This method returns the contents of the repository's code of conduct file, if one is detected.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "key": "contributor_covenant",
-            "name": "Contributor Covenant",
-            "url": "https://github.com/LindseyB/cosee/blob/master/CODE_OF_CONDUCT.md",
-            "body": "# Contributor Covenant Code of Conduct\n\n## Our Pledge\n\nIn the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.\n\n## Our Standards\n\nExamples of behavior that contributes to creating a positive environment include=>\n\n* Using welcoming and inclusive language\n* Being respectful of differing viewpoints and experiences\n* Gracefully accepting constructive criticism\n* Focusing on what is best for the community\n* Showing empathy towards other community members\n\nExamples of unacceptable behavior by participants include=>\n\n* The use of sexualized language or imagery and unwelcome sexual attention or advances\n* Trolling, insulting/derogatory comments, and personal or political attacks\n* Public or private harassment\n* Publishing others' private information, such as a physical or electronic address, without explicit permission\n* Other conduct which could reasonably be considered inappropriate in a professional setting\n\n## Our Responsibilities\n\nProject maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response\nto any instances of unacceptable behavior.\n\nProject maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.\n\n## Scope\n\nThis Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address,\nposting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.\n\n## Enforcement\n\nInstances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lindseyb@github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.\n\nProject maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.\n\n## Attribution\n\nThis Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]\n\n[homepage]: http://contributor-covenant.org\n[version]: http://contributor-covenant.org/version/1/4/\n"
-          }
-        }
-      ],
-      "idName": "get-for-repo",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct"
-    }
-  ],
-  "emojis": [
-    {
-      "name": "Get",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/emojis",
-      "previews": [],
-      "params": [],
-      "description": "Lists all the emojis available to use on GitHub Enterprise Server.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/emojis/#emojis"
-    }
-  ],
-  "gitignore": [
-    {
-      "name": "Listing available templates",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates",
-      "previews": [],
-      "params": [],
-      "description": "List all templates available to pass as an option when [creating a repository](/enterprise/2.16/v3/repos/#create).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            "Actionscript",
-            "Android",
-            "AppceleratorTitanium",
-            "Autotools",
-            "Bancha",
-            "C",
-            "C++"
-          ]
-        }
-      ],
-      "idName": "list-templates",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/gitignore/#listing-available-templates"
-    },
-    {
-      "name": "Get a single template",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/gitignore/templates/:name",
-      "previews": [],
-      "params": [
-        {
-          "name": "name",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "The API also allows fetching the source of a single template.\n\nUse the raw [media type](/enterprise/2.16/v3/media/) to get the raw contents.\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "name": "C",
-            "source": "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a\n\n# Shared objects (inc. Windows DLLs)\n*.dll\n*.so\n*.so.*\n*.dylib\n\n# Executables\n*.exe\n*.out\n*.app\n"
-          }
-        },
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "description": "Use the raw [media type](/enterprise/2.16/v3/media/) to get the raw contents."
-        }
-      ],
-      "idName": "get-template",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/gitignore/#get-a-single-template"
-    }
-  ],
   "licenses": [
     {
       "name": "List commonly used licenses",
@@ -17011,15 +16155,75 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/meta/#meta"
     }
   ],
-  "rateLimit": [
+  "oauthAuthorizations": [
     {
-      "name": "Get your current rate limit status",
-      "enabledForApps": true,
+      "name": "List your grants",
+      "enabledForApps": false,
       "method": "GET",
-      "path": "/rate_limit",
+      "path": "/applications/grants",
       "previews": [],
-      "params": [],
-      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](/enterprise/2.16/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/enterprise/2.16/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](/enterprise/2.16/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/enterprise/2.16/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](/enterprise/2.16/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](/enterprise/2.16/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `[\"repo\", \"user\"]`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/applications/grants/1",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "created_at": "2011-09-06T17:26:27Z",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "scopes": [
+                "public_repo"
+              ]
+            }
+          ]
+        }
+      ],
+      "idName": "list-grants",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#list-your-grants"
+    },
+    {
+      "name": "Get a single grant",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
       "responses": [
         {
           "headers": {
@@ -17027,33 +16231,784 @@
             "content-type": "application/json; charset=utf-8"
           },
           "body": {
-            "resources": {
-              "core": {
-                "limit": 5000,
-                "remaining": 4999,
-                "reset": 1372700873
-              },
-              "search": {
-                "limit": 30,
-                "remaining": 18,
-                "reset": 1372697452
-              },
-              "graphql": {
-                "limit": 5000,
-                "remaining": 4993,
-                "reset": 1372700389
-              }
+            "id": 1,
+            "url": "https://api.github.com/applications/grants/1",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
             },
-            "rate": {
-              "limit": 5000,
-              "remaining": 4999,
-              "reset": 1372700873
+            "created_at": "2011-09-06T17:26:27Z",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "scopes": [
+              "public_repo"
+            ]
+          }
+        }
+      ],
+      "idName": "get-grant",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-a-single-grant"
+    },
+    {
+      "name": "Delete a grant",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/grants/:grant_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "grant_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-grant",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#delete-a-grant"
+    },
+    {
+      "name": "List your authorizations",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/authorizations/1",
+              "scopes": [
+                "public_repo"
+              ],
+              "token": "",
+              "token_last_eight": "12345678",
+              "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+              "app": {
+                "url": "http://my-github-app.com",
+                "name": "my github app",
+                "client_id": "abcde12345fghij67890"
+              },
+              "note": "optional note",
+              "note_url": "http://optional/note/url",
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z",
+              "fingerprint": "jklmnop12345678"
+            }
+          ]
+        }
+      ],
+      "idName": "list-authorizations",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#list-your-authorizations"
+    },
+    {
+      "name": "Get a single authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "get-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-a-single-authorization"
+    },
+    {
+      "name": "Create a new authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/authorizations",
+      "previews": [],
+      "params": [
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_id",
+          "type": "string",
+          "description": "The 20 character OAuth app client key for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret for which to create the token.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "If you need a small number of personal access tokens, implementing the [web flow](/enterprise/2.16/apps/building-oauth-apps/authorizing-oauth-apps/) can be cumbersome. Instead, tokens can be created using the OAuth Authorizations API using [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication). To create personal access tokens for a particular OAuth application, you must provide its client ID and secret, found on the OAuth application settings page, linked from your [OAuth applications listing on GitHub](https://github.com/settings/developers).\n\nIf your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.\n\nYou can also create OAuth tokens through the web UI via the [personal access tokens settings](https://github.com/settings/tokens). Read more about these tokens on the [GitHub Help site](https://help.github.com/articles/creating-an-access-token-for-command-line-use).",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": ""
+          }
+        }
+      ],
+      "idName": "create-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#create-a-new-authorization"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client and user. If provided, this API is functionally equivalent to [Get-or-create an authorization for a specific app and fingerprint](/enterprise/2.16/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint).",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-and-fingerprint",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint"
+    },
+    {
+      "name": "Get-or-create an authorization for a specific app and fingerprint",
+      "enabledForApps": false,
+      "method": "PUT",
+      "path": "/authorizations/clients/:client_id/:fingerprint",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "client_secret",
+          "type": "string",
+          "description": "The 40 character OAuth app client secret associated with the client ID specified in the URL.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "A list of scopes that this authorization is in.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "client_secret": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+          "scopes": [
+            "public_repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.",
+      "idName": "get-or-create-authorization-for-app-fingerprint",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
+      "deprecated": {
+        "date": "2018-12-27",
+        "message": "`idName` changed for \"Get-or-create an authorization for a specific app and fingerprint\". It now includes `-and-`",
+        "before": {
+          "idName": "get-or-create-authorization-for-app-fingerprint"
+        },
+        "after": {
+          "idName": "get-or-create-authorization-for-app-and-fingerprint"
+        }
+      }
+    },
+    {
+      "name": "Update an existing authorization",
+      "enabledForApps": false,
+      "method": "PATCH",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "scopes",
+          "type": "string[]",
+          "description": "Replaces the authorization scopes with these.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to add to this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_scopes",
+          "type": "string[]",
+          "description": "A list of scopes to remove from this authorization.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "description": "A note to remind you what the OAuth token is for. Tokens not associated with a specific OAuth application (i.e. personal access tokens) must have a unique note.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "note_url",
+          "type": "string",
+          "description": "A URL to remind you what app the OAuth token is for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "fingerprint",
+          "type": "string",
+          "description": "A unique string to distinguish an authorization from others created for the same client ID and user.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "add_scopes": [
+            "repo"
+          ],
+          "note": "admin script"
+        }
+      ],
+      "description": "You can only send one of these scope keys at a time.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678"
+          }
+        }
+      ],
+      "idName": "update-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#update-an-existing-authorization"
+    },
+    {
+      "name": "Delete an authorization",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/authorizations/:authorization_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "authorization_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#delete-an-authorization"
+    },
+    {
+      "name": "Check an authorization",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth applications can use a special API method for checking OAuth token validity without running afoul of normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
             }
           }
         }
       ],
-      "idName": "get",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/rate_limit/#get-your-current-rate-limit-status"
+      "idName": "check-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#check-an-authorization"
+    },
+    {
+      "name": "Reset an authorization",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth applications can use this API method to reset a valid OAuth token without end user involvement. Applications must save the \"token\" property in the response, because changes take effect immediately. You must use [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication) when accessing it, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/authorizations/1",
+            "scopes": [
+              "public_repo"
+            ],
+            "token": "abcdefgh12345678",
+            "token_last_eight": "12345678",
+            "hashed_token": "25f94a2a5c7fbaf499c665bc73d67c1c87e496da8985131633ee0a95819db2e8",
+            "app": {
+              "url": "http://my-github-app.com",
+              "name": "my github app",
+              "client_id": "abcde12345fghij67890"
+            },
+            "note": "optional note",
+            "note_url": "http://optional/note/url",
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z",
+            "fingerprint": "jklmnop12345678",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            }
+          }
+        }
+      ],
+      "idName": "reset-authorization",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#reset-an-authorization"
+    },
+    {
+      "name": "Revoke an authorization for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/tokens/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-authorization-for-application",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#revoke-an-authorization-for-an-application"
+    },
+    {
+      "name": "Revoke a grant for an application",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/applications/:client_id/grants/:access_token",
+      "previews": [],
+      "params": [
+        {
+          "name": "client_id",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "access_token",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](/enterprise/2.16/v3/auth#basic-authentication) for this method, where the username is the OAuth application `client_id` and the password is its `client_secret`. You must also provide a valid token as `:token` and the grant for the token's owner will be deleted.\n\nDeleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "revoke-grant-for-application",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/oauth_authorizations/#revoke-a-grant-for-an-application"
     }
   ],
   "orgs": [
@@ -17482,6 +17437,412 @@
       ],
       "idName": "edit",
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/#edit-an-organization"
+    },
+    {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/orgs/octocat/hooks/1",
+              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Must be passed as \"web\".",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Here's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/orgs/:org/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "This will trigger a [ping event](/enterprise/2.16/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/orgs/:org/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "org",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#delete-a-hook"
     },
     {
       "name": "Members list",
@@ -18360,412 +18721,6 @@
       ],
       "idName": "convert-member-to-outside-collaborator",
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-    },
-    {
-      "name": "List hooks",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/orgs/octocat/hooks/1",
-              "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#list-hooks"
-    },
-    {
-      "name": "Get single hook",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#get-single-hook"
-    },
-    {
-      "name": "Create a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Must be passed as \"web\".",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Here's how you can create a hook that posts payloads in JSON format:",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#create-a-hook"
-    },
-    {
-      "name": "Edit a hook",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "active": true,
-          "events": [
-            "pull_request"
-          ]
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#edit-a-hook"
-    },
-    {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/orgs/:org/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "This will trigger a [ping event](/enterprise/2.16/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/orgs/:org/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "org",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#delete-a-hook"
     }
   ],
   "projects": [
@@ -23501,731 +23456,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/#merge-a-pull-request-merge-button"
     },
     {
-      "name": "List reviews on a pull request",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "The list of reviews returns in chronological order.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 80,
-              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Here is the body for the review.",
-              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-              "state": "APPROVED",
-              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-              "_links": {
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-                }
-              }
-            }
-          ],
-          "description": "The list of reviews returns in chronological order."
-        }
-      ],
-      "idName": "list-reviews",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-    },
-    {
-      "name": "Get a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "get-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#get-a-single-review"
-    },
-    {
-      "name": "Delete a pending review",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "PENDING",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "delete-pending-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#delete-a-pending-review"
-    },
-    {
-      "name": "Get comments for a single review",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-              "id": 10,
-              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-              "pull_request_review_id": 42,
-              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-              "path": "file1.txt",
-              "position": 1,
-              "original_position": 4,
-              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-              "in_reply_to_id": 8,
-              "user": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Great stuff",
-              "created_at": "2011-04-14T16:00:49Z",
-              "updated_at": "2011-04-14T16:00:49Z",
-              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-              "_links": {
-                "self": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-                },
-                "html": {
-                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-                },
-                "pull_request": {
-                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "get-comments-for-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#get-comments-for-a-single-review"
-    },
-    {
-      "name": "Create a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "commit_id",
-          "type": "string",
-          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.16/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-          "required": false,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        },
-        {
-          "name": "comments",
-          "type": "object[]",
-          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "comments[].path",
-          "type": "string",
-          "description": "The relative path to the file that necessitates a review comment.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].position",
-          "type": "integer",
-          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "comments[].body",
-          "type": "string",
-          "description": "Text of the review comment.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "event": "REQUEST_CHANGES",
-          "comments": [
-            {
-              "path": "file.md",
-              "position": 6,
-              "body": "Please add more information here, and fix this typo."
-            }
-          ]
-        }
-      ],
-      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.16/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.16/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.16/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "This is close to perfect! Please address the suggested inline change.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "CHANGES_REQUESTED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#create-a-pull-request-review"
-    },
-    {
-      "name": "Submit a pull request review",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The body text of the pull request review",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "event",
-          "type": "string",
-          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-          "required": true,
-          "enum": [
-            "APPROVE",
-            "REQUEST_CHANGES",
-            "COMMENT"
-          ],
-          "location": "body"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "submit-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#submit-a-pull-request-review"
-    },
-    {
-      "name": "Dismiss a pull request review",
-      "enabledForApps": true,
-      "method": "PUT",
-      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "review_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "message",
-          "type": "string",
-          "description": "The message for the pull request review dismissal",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.16/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "DISMISSED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        }
-      ],
-      "idName": "dismiss-review",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#dismiss-a-pull-request-review"
-    },
-    {
       "name": "List comments on a pull request",
       "enabledForApps": true,
       "method": "GET",
@@ -25722,6 +24952,776 @@
       ],
       "idName": "delete-review-request",
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/review_requests/#delete-a-review-request"
+    },
+    {
+      "name": "List reviews on a pull request",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "The list of reviews returns in chronological order.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 80,
+              "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Here is the body for the review.",
+              "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+              "state": "APPROVED",
+              "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+              "_links": {
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+                }
+              }
+            }
+          ],
+          "description": "The list of reviews returns in chronological order."
+        }
+      ],
+      "idName": "list-reviews",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+    },
+    {
+      "name": "Get a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "get-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#get-a-single-review"
+    },
+    {
+      "name": "Delete a pending review",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "PENDING",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "delete-pending-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#delete-a-pending-review"
+    },
+    {
+      "name": "Get comments for a single review",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+              "id": 10,
+              "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+              "pull_request_review_id": 42,
+              "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+              "path": "file1.txt",
+              "position": 1,
+              "original_position": 4,
+              "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+              "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+              "in_reply_to_id": 8,
+              "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Great stuff",
+              "created_at": "2011-04-14T16:00:49Z",
+              "updated_at": "2011-04-14T16:00:49Z",
+              "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+              "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+              "_links": {
+                "self": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+                },
+                "html": {
+                  "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+                },
+                "pull_request": {
+                  "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "get-comments-for-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#get-comments-for-a-single-review"
+    },
+    {
+      "name": "Create a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "commit_id",
+          "type": "string",
+          "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.16/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+          "required": false,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        },
+        {
+          "name": "comments",
+          "type": "object[]",
+          "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "comments[].path",
+          "type": "string",
+          "description": "The relative path to the file that necessitates a review comment.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].position",
+          "type": "integer",
+          "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "comments[].body",
+          "type": "string",
+          "description": "Text of the review comment.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "event": "REQUEST_CHANGES",
+          "comments": [
+            {
+              "path": "file.md",
+              "position": 6,
+              "body": "Please add more information here, and fix this typo."
+            }
+          ]
+        }
+      ],
+      "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.16/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.16/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.16/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "This is close to perfect! Please address the suggested inline change.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "CHANGES_REQUESTED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#create-a-pull-request-review"
+    },
+    {
+      "name": "Submit a pull request review",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The body text of the pull request review",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+          "required": true,
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ],
+          "location": "body"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "submit-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#submit-a-pull-request-review"
+    },
+    {
+      "name": "Dismiss a pull request review",
+      "enabledForApps": true,
+      "method": "PUT",
+      "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "review_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "message",
+          "type": "string",
+          "description": "The message for the pull request review dismissal",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.16/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "DISMISSED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        }
+      ],
+      "idName": "dismiss-review",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#dismiss-a-pull-request-review"
+    }
+  ],
+  "rateLimit": [
+    {
+      "name": "Get your current rate limit status",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/rate_limit",
+      "previews": [],
+      "params": [],
+      "description": "**Note:** Accessing this endpoint does not count against your REST API rate limit.\n\n**Understanding your rate limit status**\n\nThe Search API has a [custom rate limit](/enterprise/2.16/v3/search/#rate-limit), separate from the rate limit governing the rest of the REST API. The GraphQL API also has a [custom rate limit](/enterprise/2.16/v4/guides/resource-limitations/#rate-limit) that is separate from and calculated differently than rate limits in the REST API.\n\nFor these reasons, the Rate Limit API response categorizes your rate limit. Under `resources`, you'll see three objects:\n\n*   The `core` object provides your rate limit status for all non-search-related resources in the REST API.\n*   The `search` object provides your rate limit status for the [Search API](/enterprise/2.16/v3/search/).\n*   The `graphql` object provides your rate limit status for the [GraphQL API](/enterprise/2.16/v4/).\n\nFor more information on the headers and values in the rate limit response, see \"[Rate limiting](/enterprise/2.16/v3/#rate-limiting).\"\n\nThe `rate` object (shown at the bottom of the response above) is deprecated.\n\nIf you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "resources": {
+              "core": {
+                "limit": 5000,
+                "remaining": 4999,
+                "reset": 1372700873
+              },
+              "search": {
+                "limit": 30,
+                "remaining": 18,
+                "reset": 1372697452
+              },
+              "graphql": {
+                "limit": 5000,
+                "remaining": 4993,
+                "reset": 1372700389
+              }
+            },
+            "rate": {
+              "limit": 5000,
+              "remaining": 4999,
+              "reset": 1372700873
+            }
+          }
+        }
+      ],
+      "idName": "get",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/rate_limit/#get-your-current-rate-limit-status"
     }
   ],
   "reactions": [
@@ -33483,229 +33483,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/contents/#get-archive-link"
     },
     {
-      "name": "List deploy keys",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-deploy-keys",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#list-deploy-keys"
-    },
-    {
-      "name": "Get a deploy key",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#get-a-deploy-key"
-    },
-    {
-      "name": "Add a new deploy key",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A name for the key.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The contents of the key.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "read_only",
-          "type": "boolean",
-          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA...",
-          "read_only": true
-        }
-      ],
-      "description": "Here's how you can create a read-only deploy key:\n\n",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "add-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#add-a-new-deploy-key"
-    },
-    {
-      "name": "Remove a deploy key",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "remove-deploy-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#remove-a-deploy-key"
-    },
-    {
       "name": "List deployments",
       "enabledForApps": true,
       "method": "GET",
@@ -34872,6 +34649,515 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/forks/#create-a-fork"
     },
     {
+      "name": "List hooks",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+              "name": "web",
+              "events": [
+                "push",
+                "pull_request"
+              ],
+              "active": true,
+              "config": {
+                "url": "http://example.com/webhook",
+                "content_type": "json"
+              },
+              "updated_at": "2011-09-06T20:39:23Z",
+              "created_at": "2011-09-06T17:26:27Z"
+            }
+          ]
+        }
+      ],
+      "idName": "list-hooks",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#list-hooks"
+    },
+    {
+      "name": "Get single hook",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "get-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#get-single-hook"
+    },
+    {
+      "name": "Create a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) for details.",
+          "default": "web",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "name": "web",
+          "active": true,
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          }
+        }
+      ],
+      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "create-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#create-a-hook"
+    },
+    {
+      "name": "Edit a hook",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "config",
+          "type": "object",
+          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.url",
+          "type": "string",
+          "description": "The URL to which the payloads will be delivered.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "config.content_type",
+          "type": "string",
+          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.secret",
+          "type": "string",
+          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "config.insecure_ssl",
+          "type": "string",
+          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "events",
+          "type": "string[]",
+          "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+          "default": "[\"push\"]",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "add_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "remove_events",
+          "type": "string[]",
+          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+          "default": true,
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "active": true,
+          "add_events": [
+            "pull_request"
+          ]
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        }
+      ],
+      "idName": "edit-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#edit-a-hook"
+    },
+    {
+      "name": "Test a push hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "test-push-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#test-a-push-hook"
+    },
+    {
+      "name": "Ping a hook",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.16/webhooks/#ping-event) to be sent to the hook.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "ping-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#ping-a-hook"
+    },
+    {
+      "name": "Delete a hook",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/hooks/:hook_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "hook_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-hook",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#delete-a-hook"
+    },
+    {
       "name": "List invitations for a repository",
       "enabledForApps": true,
       "method": "GET",
@@ -35453,6 +35739,229 @@
       ],
       "idName": "decline-invitation",
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/invitations/#decline-a-repository-invitation"
+    },
+    {
+      "name": "List deploy keys",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-deploy-keys",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#list-deploy-keys"
+    },
+    {
+      "name": "Get a deploy key",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#get-a-deploy-key"
+    },
+    {
+      "name": "Add a new deploy key",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/repos/:owner/:repo/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A name for the key.",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The contents of the key.",
+          "required": true,
+          "location": "body"
+        },
+        {
+          "name": "read_only",
+          "type": "boolean",
+          "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA...",
+          "read_only": true
+        }
+      ],
+      "description": "Here's how you can create a read-only deploy key:\n\n",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "add-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#add-a-new-deploy-key"
+    },
+    {
+      "name": "Remove a deploy key",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "repo",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "remove-deploy-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#remove-a-deploy-key"
     },
     {
       "name": "Perform a merge",
@@ -37629,515 +38138,6 @@
       ],
       "idName": "get-combined-status-for-ref",
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref"
-    },
-    {
-      "name": "List hooks",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-              "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-              "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-              "name": "web",
-              "events": [
-                "push",
-                "pull_request"
-              ],
-              "active": true,
-              "config": {
-                "url": "http://example.com/webhook",
-                "content_type": "json"
-              },
-              "updated_at": "2011-09-06T20:39:23Z",
-              "created_at": "2011-09-06T17:26:27Z"
-            }
-          ]
-        }
-      ],
-      "idName": "list-hooks",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#list-hooks"
-    },
-    {
-      "name": "Get single hook",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "get-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#get-single-hook"
-    },
-    {
-      "name": "Create a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) for details.",
-          "default": "web",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "name": "web",
-          "active": true,
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          }
-        }
-      ],
-      "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "create-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#create-a-hook"
-    },
-    {
-      "name": "Edit a hook",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "config",
-          "type": "object",
-          "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.url",
-          "type": "string",
-          "description": "The URL to which the payloads will be delivered.",
-          "required": true,
-          "location": "body"
-        },
-        {
-          "name": "config.content_type",
-          "type": "string",
-          "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.secret",
-          "type": "string",
-          "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "config.insecure_ssl",
-          "type": "string",
-          "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "events",
-          "type": "string[]",
-          "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-          "default": "[\"push\"]",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "add_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "remove_events",
-          "type": "string[]",
-          "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-          "default": true,
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "active": true,
-          "add_events": [
-            "pull_request"
-          ]
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        }
-      ],
-      "idName": "edit-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#edit-a-hook"
-    },
-    {
-      "name": "Test a push hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "test-push-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#test-a-push-hook"
-    },
-    {
-      "name": "Ping a hook",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.16/webhooks/#ping-event) to be sent to the hook.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "ping-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#ping-a-hook"
-    },
-    {
-      "name": "Delete a hook",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/repos/:owner/:repo/hooks/:hook_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "owner",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "repo",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "hook_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-hook",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#delete-a-hook"
     }
   ],
   "search": [
@@ -39966,6 +39966,474 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/#remove-team-project"
     },
     {
+      "name": "List comments",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "direction",
+          "type": "string",
+          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+          "default": "desc",
+          "required": false,
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "location": "query"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "author": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+              },
+              "body": "Do you like apples?",
+              "body_html": "<p>Do you like apples?</p>",
+              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+              "created_at": "2018-01-15T23:53:58Z",
+              "last_edited_at": null,
+              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+              "number": 1,
+              "updated_at": "2018-01-15T23:53:58Z",
+              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+              "reactions": {
+                "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+                "total_count": 5,
+                "+1": 3,
+                "-1": 1,
+                "laugh": 0,
+                "confused": 0,
+                "heart": 1,
+                "hooray": 0
+              }
+            }
+          ]
+        }
+      ],
+      "idName": "list-discussion-comments",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#list-comments"
+    },
+    {
+      "name": "Get a single comment",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "idName": "get-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#get-a-single-comment"
+    },
+    {
+      "name": "Create a comment",
+      "enabledForApps": true,
+      "method": "POST",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like apples?"
+        }
+      ],
+      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.16/v3/#abuse-rate-limits)\" for details.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "triggersNotification": true,
+      "idName": "create-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#create-a-comment"
+    },
+    {
+      "name": "Edit a comment",
+      "enabledForApps": true,
+      "method": "PATCH",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        },
+        {
+          "name": "squirrel-girl",
+          "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+          "required": false
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "description": "The discussion comment's body text.",
+          "required": true,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "body": "Do you like pineapples?"
+        }
+      ],
+      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like pineapples?",
+            "body_html": "<p>Do you like pineapples?</p>",
+            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": "2018-01-26T18:22:20Z",
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-26T18:22:20Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        }
+      ],
+      "idName": "edit-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#edit-a-comment"
+    },
+    {
+      "name": "Delete a comment",
+      "enabledForApps": true,
+      "method": "DELETE",
+      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+      "previews": [
+        {
+          "name": "echo",
+          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+          "required": true
+        }
+      ],
+      "params": [
+        {
+          "name": "team_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "discussion_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "comment_number",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-discussion-comment",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#delete-a-comment"
+    },
+    {
       "name": "List discussions",
       "enabledForApps": true,
       "method": "GET",
@@ -40440,474 +40908,6 @@
       ],
       "idName": "delete-discussion",
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussions/#delete-a-discussion"
-    },
-    {
-      "name": "List comments",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "direction",
-          "type": "string",
-          "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-          "default": "desc",
-          "required": false,
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "location": "query"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "author": {
-                "login": "octocat",
-                "id": 1,
-                "node_id": "MDQ6VXNlcjE=",
-                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/octocat",
-                "html_url": "https://github.com/octocat",
-                "followers_url": "https://api.github.com/users/octocat/followers",
-                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                "organizations_url": "https://api.github.com/users/octocat/orgs",
-                "repos_url": "https://api.github.com/users/octocat/repos",
-                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/octocat/received_events",
-                "type": "User",
-                "site_admin": false
-              },
-              "body": "Do you like apples?",
-              "body_html": "<p>Do you like apples?</p>",
-              "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-              "created_at": "2018-01-15T23:53:58Z",
-              "last_edited_at": null,
-              "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-              "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-              "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-              "number": 1,
-              "updated_at": "2018-01-15T23:53:58Z",
-              "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-              "reactions": {
-                "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-                "total_count": 5,
-                "+1": 3,
-                "-1": 1,
-                "laugh": 0,
-                "confused": 0,
-                "heart": 1,
-                "hooray": 0
-              }
-            }
-          ]
-        }
-      ],
-      "idName": "list-discussion-comments",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#list-comments"
-    },
-    {
-      "name": "Get a single comment",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "idName": "get-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#get-a-single-comment"
-    },
-    {
-      "name": "Create a comment",
-      "enabledForApps": true,
-      "method": "POST",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like apples?"
-        }
-      ],
-      "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.16/v3/#abuse-rate-limits)\" for details.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "triggersNotification": true,
-      "idName": "create-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#create-a-comment"
-    },
-    {
-      "name": "Edit a comment",
-      "enabledForApps": true,
-      "method": "PATCH",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        },
-        {
-          "name": "squirrel-girl",
-          "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-          "required": false
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "body",
-          "type": "string",
-          "description": "The discussion comment's body text.",
-          "required": true,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "body": "Do you like pineapples?"
-        }
-      ],
-      "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like pineapples?",
-            "body_html": "<p>Do you like pineapples?</p>",
-            "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": "2018-01-26T18:22:20Z",
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-26T18:22:20Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        }
-      ],
-      "idName": "edit-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#edit-a-comment"
-    },
-    {
-      "name": "Delete a comment",
-      "enabledForApps": true,
-      "method": "DELETE",
-      "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-      "previews": [
-        {
-          "name": "echo",
-          "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-          "required": true
-        }
-      ],
-      "params": [
-        {
-          "name": "team_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "discussion_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "comment_number",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-discussion-comment",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#delete-a-comment"
     },
     {
       "name": "List team members",
@@ -42069,214 +42069,6 @@
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/followers/#unfollow-a-user"
     },
     {
-      "name": "List public keys for a user",
-      "enabledForApps": true,
-      "method": "GET",
-      "path": "/users/:username/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "username",
-          "type": "string",
-          "required": true,
-          "description": "",
-          "location": "url"
-        },
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA..."
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys-for-user",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#list-public-keys-for-a-user"
-    },
-    {
-      "name": "List your public keys",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "per_page",
-          "type": "integer",
-          "required": false,
-          "description": "Results per page (max 100)",
-          "default": 30,
-          "location": "query"
-        },
-        {
-          "name": "page",
-          "type": "integer",
-          "required": false,
-          "description": "Page number of the results to fetch.",
-          "default": 1,
-          "location": "query"
-        }
-      ],
-      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": [
-            {
-              "id": 1,
-              "key": "ssh-rsa AAA...",
-              "url": "https://api.github.com/user/keys/1",
-              "title": "octocat@octomac",
-              "verified": true,
-              "created_at": "2014-12-10T15:53:42Z",
-              "read_only": true
-            }
-          ]
-        }
-      ],
-      "idName": "list-public-keys",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#list-your-public-keys"
-    },
-    {
-      "name": "Get a single public key",
-      "enabledForApps": false,
-      "method": "GET",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-      "responses": [
-        {
-          "headers": {
-            "status": "200 OK",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "get-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#get-a-single-public-key"
-    },
-    {
-      "name": "Create a public key",
-      "enabledForApps": false,
-      "method": "POST",
-      "path": "/user/keys",
-      "previews": [],
-      "params": [
-        {
-          "name": "title",
-          "type": "string",
-          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-          "required": false,
-          "location": "body"
-        },
-        {
-          "name": "key",
-          "type": "string",
-          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-          "required": false,
-          "location": "body"
-        }
-      ],
-      "requests": [
-        {
-          "title": "octocat@octomac",
-          "key": "ssh-rsa AAA..."
-        }
-      ],
-      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise Server appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
-      "responses": [
-        {
-          "headers": {
-            "status": "201 Created",
-            "content-type": "application/json; charset=utf-8"
-          },
-          "body": {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        }
-      ],
-      "idName": "create-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#create-a-public-key"
-    },
-    {
-      "name": "Delete a public key",
-      "enabledForApps": false,
-      "method": "DELETE",
-      "path": "/user/keys/:key_id",
-      "previews": [],
-      "params": [
-        {
-          "name": "key_id",
-          "type": "integer",
-          "required": true,
-          "description": "",
-          "location": "url"
-        }
-      ],
-      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise Server appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
-      "responses": [
-        {
-          "headers": {
-            "status": "204 No Content",
-            "content-type": "application/json; charset=utf-8"
-          }
-        }
-      ],
-      "idName": "delete-public-key",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#delete-a-public-key"
-    },
-    {
       "name": "List GPG keys for a user",
       "enabledForApps": true,
       "method": "GET",
@@ -42580,6 +42372,214 @@
       ],
       "idName": "delete-gpg-key",
       "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/gpg_keys/#delete-a-gpg-key"
+    },
+    {
+      "name": "List public keys for a user",
+      "enabledForApps": true,
+      "method": "GET",
+      "path": "/users/:username/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA..."
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys-for-user",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#list-public-keys-for-a-user"
+    },
+    {
+      "name": "List your public keys",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "per_page",
+          "type": "integer",
+          "required": false,
+          "description": "Results per page (max 100)",
+          "default": 30,
+          "location": "query"
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number of the results to fetch.",
+          "default": 1,
+          "location": "query"
+        }
+      ],
+      "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": [
+            {
+              "id": 1,
+              "key": "ssh-rsa AAA...",
+              "url": "https://api.github.com/user/keys/1",
+              "title": "octocat@octomac",
+              "verified": true,
+              "created_at": "2014-12-10T15:53:42Z",
+              "read_only": true
+            }
+          ]
+        }
+      ],
+      "idName": "list-public-keys",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#list-your-public-keys"
+    },
+    {
+      "name": "Get a single public key",
+      "enabledForApps": false,
+      "method": "GET",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+      "responses": [
+        {
+          "headers": {
+            "status": "200 OK",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "get-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#get-a-single-public-key"
+    },
+    {
+      "name": "Create a public key",
+      "enabledForApps": false,
+      "method": "POST",
+      "path": "/user/keys",
+      "previews": [],
+      "params": [
+        {
+          "name": "title",
+          "type": "string",
+          "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+          "required": false,
+          "location": "body"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+          "required": false,
+          "location": "body"
+        }
+      ],
+      "requests": [
+        {
+          "title": "octocat@octomac",
+          "key": "ssh-rsa AAA..."
+        }
+      ],
+      "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise Server appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
+      "responses": [
+        {
+          "headers": {
+            "status": "201 Created",
+            "content-type": "application/json; charset=utf-8"
+          },
+          "body": {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        }
+      ],
+      "idName": "create-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#create-a-public-key"
+    },
+    {
+      "name": "Delete a public key",
+      "enabledForApps": false,
+      "method": "DELETE",
+      "path": "/user/keys/:key_id",
+      "previews": [],
+      "params": [
+        {
+          "name": "key_id",
+          "type": "integer",
+          "required": true,
+          "description": "",
+          "location": "url"
+        }
+      ],
+      "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise Server appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
+      "responses": [
+        {
+          "headers": {
+            "status": "204 No Content",
+            "content-type": "application/json; charset=utf-8"
+          }
+        }
+      ],
+      "idName": "delete-public-key",
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#delete-a-public-key"
     }
   ]
 }

--- a/routes/ghe-2.16/licenses.json
+++ b/routes/ghe-2.16/licenses.json
@@ -64,6 +64,80 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/licenses/#list-commonly-used-licenses"
   },
   {
+    "name": "List all licenses",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/licenses",
+    "previews": [],
+    "params": [],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "key": "mit",
+            "name": "MIT License",
+            "spdx_id": "MIT",
+            "url": "https://api.github.com/licenses/mit",
+            "node_id": "MDc6TGljZW5zZW1pdA=="
+          },
+          {
+            "key": "lgpl-3.0",
+            "name": "GNU Lesser General Public License v3.0",
+            "spdx_id": "LGPL-3.0",
+            "url": "https://api.github.com/licenses/lgpl-3.0"
+          },
+          {
+            "key": "mpl-2.0",
+            "name": "Mozilla Public License 2.0",
+            "spdx_id": "MPL-2.0",
+            "url": "https://api.github.com/licenses/mpl-2.0"
+          },
+          {
+            "key": "agpl-3.0",
+            "name": "GNU Affero General Public License v3.0",
+            "spdx_id": "AGPL-3.0",
+            "url": "https://api.github.com/licenses/agpl-3.0"
+          },
+          {
+            "key": "unlicense",
+            "name": "The Unlicense",
+            "spdx_id": "Unlicense",
+            "url": "https://api.github.com/licenses/unlicense"
+          },
+          {
+            "key": "apache-2.0",
+            "name": "Apache License 2.0",
+            "spdx_id": "Apache-2.0",
+            "url": "https://api.github.com/licenses/apache-2.0"
+          },
+          {
+            "key": "gpl-3.0",
+            "name": "GNU General Public License v3.0",
+            "spdx_id": "GPL-3.0",
+            "url": "https://api.github.com/licenses/gpl-3.0"
+          }
+        ]
+      }
+    ],
+    "idName": "list",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/licenses/#list-commonly-used-licenses",
+    "deprecated": {
+      "date": "2019-03-05",
+      "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+      "before": {
+        "idName": "list"
+      },
+      "after": {
+        "idName": "list-commonly-used"
+      }
+    }
+  },
+  {
     "name": "Get an individual license",
     "enabledForApps": true,
     "method": "GET",

--- a/routes/ghe-2.16/licenses/list.json
+++ b/routes/ghe-2.16/licenses/list.json
@@ -1,0 +1,74 @@
+{
+  "name": "List all licenses",
+  "enabledForApps": true,
+  "method": "GET",
+  "path": "/licenses",
+  "previews": [],
+  "params": [],
+  "description": "",
+  "responses": [
+    {
+      "headers": {
+        "status": "200 OK",
+        "content-type": "application/json; charset=utf-8"
+      },
+      "body": [
+        {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZW1pdA=="
+        },
+        {
+          "key": "lgpl-3.0",
+          "name": "GNU Lesser General Public License v3.0",
+          "spdx_id": "LGPL-3.0",
+          "url": "https://api.github.com/licenses/lgpl-3.0"
+        },
+        {
+          "key": "mpl-2.0",
+          "name": "Mozilla Public License 2.0",
+          "spdx_id": "MPL-2.0",
+          "url": "https://api.github.com/licenses/mpl-2.0"
+        },
+        {
+          "key": "agpl-3.0",
+          "name": "GNU Affero General Public License v3.0",
+          "spdx_id": "AGPL-3.0",
+          "url": "https://api.github.com/licenses/agpl-3.0"
+        },
+        {
+          "key": "unlicense",
+          "name": "The Unlicense",
+          "spdx_id": "Unlicense",
+          "url": "https://api.github.com/licenses/unlicense"
+        },
+        {
+          "key": "apache-2.0",
+          "name": "Apache License 2.0",
+          "spdx_id": "Apache-2.0",
+          "url": "https://api.github.com/licenses/apache-2.0"
+        },
+        {
+          "key": "gpl-3.0",
+          "name": "GNU General Public License v3.0",
+          "spdx_id": "GPL-3.0",
+          "url": "https://api.github.com/licenses/gpl-3.0"
+        }
+      ]
+    }
+  ],
+  "idName": "list",
+  "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/licenses/#list-commonly-used-licenses",
+  "deprecated": {
+    "date": "2019-03-05",
+    "message": "\"List all licenses\" renamed to \"List commonly used licenses\"",
+    "before": {
+      "idName": "list"
+    },
+    "after": {
+      "idName": "list-commonly-used"
+    }
+  }
+}

--- a/routes/ghe-2.16/orgs.json
+++ b/routes/ghe-2.16/orgs.json
@@ -426,6 +426,412 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/#edit-an-organization"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/orgs/octocat/hooks/1",
+            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Must be passed as \"web\".",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Here's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/orgs/octocat/hooks/1",
+          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/orgs/:org/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "This will trigger a [ping event](/enterprise/2.16/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/orgs/:org/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "org",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#delete-a-hook"
+  },
+  {
     "name": "Members list",
     "enabledForApps": true,
     "method": "GET",
@@ -1302,411 +1708,5 @@
     ],
     "idName": "convert-member-to-outside-collaborator",
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/outside_collaborators/#convert-member-to-outside-collaborator"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/orgs/octocat/hooks/1",
-            "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Must be passed as \"web\".",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Here's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#update-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/orgs/octocat/hooks/1",
-          "ping_url": "https://api.github.com/orgs/octocat/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/orgs/:org/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "This will trigger a [ping event](/enterprise/2.16/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/orgs/:org/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "org",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/orgs/hooks/#delete-a-hook"
   }
 ]

--- a/routes/ghe-2.16/pulls.json
+++ b/routes/ghe-2.16/pulls.json
@@ -3275,731 +3275,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/#merge-a-pull-request-merge-button"
   },
   {
-    "name": "List reviews on a pull request",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "The list of reviews returns in chronological order.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 80,
-            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Here is the body for the review.",
-            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-            "state": "APPROVED",
-            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-            "_links": {
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-              }
-            }
-          }
-        ],
-        "description": "The list of reviews returns in chronological order."
-      }
-    ],
-    "idName": "list-reviews",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#list-reviews-on-a-pull-request"
-  },
-  {
-    "name": "Get a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "get-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#get-a-single-review"
-  },
-  {
-    "name": "Delete a pending review",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "PENDING",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "delete-pending-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#delete-a-pending-review"
-  },
-  {
-    "name": "Get comments for a single review",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
-            "id": 10,
-            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
-            "pull_request_review_id": 42,
-            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
-            "path": "file1.txt",
-            "position": 1,
-            "original_position": 4,
-            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
-            "in_reply_to_id": 8,
-            "user": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Great stuff",
-            "created_at": "2011-04-14T16:00:49Z",
-            "updated_at": "2011-04-14T16:00:49Z",
-            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
-            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
-            "_links": {
-              "self": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
-              },
-              "html": {
-                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
-              },
-              "pull_request": {
-                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
-              }
-            }
-          }
-        ]
-      }
-    ],
-    "idName": "get-comments-for-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#get-comments-for-a-single-review"
-  },
-  {
-    "name": "Create a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "commit_id",
-        "type": "string",
-        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.16/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
-        "required": false,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      },
-      {
-        "name": "comments",
-        "type": "object[]",
-        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "comments[].path",
-        "type": "string",
-        "description": "The relative path to the file that necessitates a review comment.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].position",
-        "type": "integer",
-        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "comments[].body",
-        "type": "string",
-        "description": "Text of the review comment.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-        "body": "This is close to perfect! Please address the suggested inline change.",
-        "event": "REQUEST_CHANGES",
-        "comments": [
-          {
-            "path": "file.md",
-            "position": 6,
-            "body": "Please add more information here, and fix this typo."
-          }
-        ]
-      }
-    ],
-    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.16/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.16/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.16/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "This is close to perfect! Please address the suggested inline change.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "CHANGES_REQUESTED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#create-a-pull-request-review"
-  },
-  {
-    "name": "Submit a pull request review",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The body text of the pull request review",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "event",
-        "type": "string",
-        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
-        "required": true,
-        "enum": [
-          "APPROVE",
-          "REQUEST_CHANGES",
-          "COMMENT"
-        ],
-        "location": "body"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "APPROVED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "submit-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#submit-a-pull-request-review"
-  },
-  {
-    "name": "Dismiss a pull request review",
-    "enabledForApps": true,
-    "method": "PUT",
-    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "review_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "message",
-        "type": "string",
-        "description": "The message for the pull request review dismissal",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.16/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 80,
-          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Here is the body for the review.",
-          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
-          "state": "DISMISSED",
-          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
-          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
-          "_links": {
-            "html": {
-              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
-            },
-            "pull_request": {
-              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
-            }
-          }
-        }
-      }
-    ],
-    "idName": "dismiss-review",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#dismiss-a-pull-request-review"
-  },
-  {
     "name": "List comments on a pull request",
     "enabledForApps": true,
     "method": "GET",
@@ -5496,5 +4771,730 @@
     ],
     "idName": "delete-review-request",
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/review_requests/#delete-a-review-request"
+  },
+  {
+    "name": "List reviews on a pull request",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "The list of reviews returns in chronological order.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 80,
+            "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Here is the body for the review.",
+            "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+            "state": "APPROVED",
+            "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+            "_links": {
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+              }
+            }
+          }
+        ],
+        "description": "The list of reviews returns in chronological order."
+      }
+    ],
+    "idName": "list-reviews",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#list-reviews-on-a-pull-request"
+  },
+  {
+    "name": "Get a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "get-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#get-a-single-review"
+  },
+  {
+    "name": "Delete a pending review",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "PENDING",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "delete-pending-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#delete-a-pending-review"
+  },
+  {
+    "name": "Get comments for a single review",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/comments",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1",
+            "id": 10,
+            "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDEw",
+            "pull_request_review_id": 42,
+            "diff_hunk": "@@ -16,33 +16,40 @@ public class Connection : IConnection...",
+            "path": "file1.txt",
+            "position": 1,
+            "original_position": 4,
+            "commit_id": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            "original_commit_id": "9c48853fa3dc5c1c3d6f1f1cd1f2743e72652840",
+            "in_reply_to_id": 8,
+            "user": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Great stuff",
+            "created_at": "2011-04-14T16:00:49Z",
+            "updated_at": "2011-04-14T16:00:49Z",
+            "html_url": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
+            "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+            "_links": {
+              "self": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1"
+              },
+              "html": {
+                "href": "https://github.com/octocat/Hello-World/pull/1#discussion-diff-1"
+              },
+              "pull_request": {
+                "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "idName": "get-comments-for-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#get-comments-for-a-single-review"
+  },
+  {
+    "name": "Create a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "commit_id",
+        "type": "string",
+        "description": "The SHA of the commit that needs a review. Not using the latest commit SHA may render your review comment outdated if a subsequent commit modifies the line you specify as the `position`. Defaults to the most recent commit in the pull request when you do not specify a value.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "**Required** when using `REQUEST_CHANGES` or `COMMENT` for the `event` parameter. The body text of the pull request review.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. By leaving this blank, you set the review action state to `PENDING`, which means you will need to [submit the pull request review](/enterprise/2.16/v3/pulls/reviews/#submit-a-pull-request-review) when you are ready.",
+        "required": false,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      },
+      {
+        "name": "comments",
+        "type": "object[]",
+        "description": "Use the following table to specify the location, destination, and contents of the draft review comment.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "comments[].path",
+        "type": "string",
+        "description": "The relative path to the file that necessitates a review comment.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].position",
+        "type": "integer",
+        "description": "The position in the diff where you want to add a review comment. Note this value is not the same as the line number in the file. For help finding the position value, read the note below.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "comments[].body",
+        "type": "string",
+        "description": "Text of the review comment.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+        "body": "This is close to perfect! Please address the suggested inline change.",
+        "event": "REQUEST_CHANGES",
+        "comments": [
+          {
+            "path": "file.md",
+            "position": 6,
+            "body": "Please add more information here, and fix this typo."
+          }
+        ]
+      }
+    ],
+    "description": "This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.16/v3/#abuse-rate-limits)\" for details.\n\n**Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](/enterprise/2.16/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](/enterprise/2.16/v3/pulls/#get-a-single-pull-request) endpoint.\n\nThe `position` value equals the number of lines down from the first \"@@\" hunk header in the file you want to add a comment. The line just below the \"@@\" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "This is close to perfect! Please address the suggested inline change.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "CHANGES_REQUESTED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#create-a-pull-request-review"
+  },
+  {
+    "name": "Submit a pull request review",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/events",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The body text of the pull request review",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "event",
+        "type": "string",
+        "description": "The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action.",
+        "required": true,
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "location": "body"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "APPROVED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "submit-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#submit-a-pull-request-review"
+  },
+  {
+    "name": "Dismiss a pull request review",
+    "enabledForApps": true,
+    "method": "PUT",
+    "path": "/repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "review_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "message",
+        "type": "string",
+        "description": "The message for the pull request review dismissal",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "description": "**Note:** To dismiss a pull request review on a [protected branch](/enterprise/2.16/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 80,
+          "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+          "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Here is the body for the review.",
+          "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+          "state": "DISMISSED",
+          "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+          "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+          "_links": {
+            "html": {
+              "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+            },
+            "pull_request": {
+              "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+            }
+          }
+        }
+      }
+    ],
+    "idName": "dismiss-review",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/pulls/reviews/#dismiss-a-pull-request-review"
   }
 ]

--- a/routes/ghe-2.16/repos.json
+++ b/routes/ghe-2.16/repos.json
@@ -6517,229 +6517,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/contents/#get-archive-link"
   },
   {
-    "name": "List deploy keys",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-deploy-keys",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#list-deploy-keys"
-  },
-  {
-    "name": "Get a deploy key",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#get-a-deploy-key"
-  },
-  {
-    "name": "Add a new deploy key",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A name for the key.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The contents of the key.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "read_only",
-        "type": "boolean",
-        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA...",
-        "read_only": true
-      }
-    ],
-    "description": "Here's how you can create a read-only deploy key:\n\n",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "add-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#add-a-new-deploy-key"
-  },
-  {
-    "name": "Remove a deploy key",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "remove-deploy-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#remove-a-deploy-key"
-  },
-  {
     "name": "List deployments",
     "enabledForApps": true,
     "method": "GET",
@@ -7906,6 +7683,515 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/forks/#create-a-fork"
   },
   {
+    "name": "List hooks",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+            "name": "web",
+            "events": [
+              "push",
+              "pull_request"
+            ],
+            "active": true,
+            "config": {
+              "url": "http://example.com/webhook",
+              "content_type": "json"
+            },
+            "updated_at": "2011-09-06T20:39:23Z",
+            "created_at": "2011-09-06T17:26:27Z"
+          }
+        ]
+      }
+    ],
+    "idName": "list-hooks",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#list-hooks"
+  },
+  {
+    "name": "Get single hook",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "get-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#get-single-hook"
+  },
+  {
+    "name": "Create a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) for details.",
+        "default": "web",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "name": "web",
+        "active": true,
+        "events": [
+          "push",
+          "pull_request"
+        ],
+        "config": {
+          "url": "http://example.com/webhook",
+          "content_type": "json"
+        }
+      }
+    ],
+    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "create-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#create-a-hook"
+  },
+  {
+    "name": "Edit a hook",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.url",
+        "type": "string",
+        "description": "The URL to which the payloads will be delivered.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "config.content_type",
+        "type": "string",
+        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.secret",
+        "type": "string",
+        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "config.insecure_ssl",
+        "type": "string",
+        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "events",
+        "type": "string[]",
+        "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
+        "default": "[\"push\"]",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "add_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "remove_events",
+        "type": "string[]",
+        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
+        "default": true,
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "active": true,
+        "add_events": [
+          "pull_request"
+        ]
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
+          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
+          "name": "web",
+          "events": [
+            "push",
+            "pull_request"
+          ],
+          "active": true,
+          "config": {
+            "url": "http://example.com/webhook",
+            "content_type": "json"
+          },
+          "updated_at": "2011-09-06T20:39:23Z",
+          "created_at": "2011-09-06T17:26:27Z"
+        }
+      }
+    ],
+    "idName": "edit-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#edit-a-hook"
+  },
+  {
+    "name": "Test a push hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "test-push-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#test-a-push-hook"
+  },
+  {
+    "name": "Ping a hook",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.16/webhooks/#ping-event) to be sent to the hook.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "ping-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#ping-a-hook"
+  },
+  {
+    "name": "Delete a hook",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/hooks/:hook_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "hook_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-hook",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#delete-a-hook"
+  },
+  {
     "name": "List invitations for a repository",
     "enabledForApps": true,
     "method": "GET",
@@ -8487,6 +8773,229 @@
     ],
     "idName": "decline-invitation",
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/invitations/#decline-a-repository-invitation"
+  },
+  {
+    "name": "List deploy keys",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-deploy-keys",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#list-deploy-keys"
+  },
+  {
+    "name": "Get a deploy key",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#get-a-deploy-key"
+  },
+  {
+    "name": "Add a new deploy key",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/repos/:owner/:repo/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A name for the key.",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The contents of the key.",
+        "required": true,
+        "location": "body"
+      },
+      {
+        "name": "read_only",
+        "type": "boolean",
+        "description": "If `true`, the key will only be able to read repository contents. Otherwise, the key will be able to read and write.  \n  \nDeploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see \"[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)\" and \"[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/).\"",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA...",
+        "read_only": true
+      }
+    ],
+    "description": "Here's how you can create a read-only deploy key:\n\n",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/repos/octocat/Hello-World/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "add-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#add-a-new-deploy-key"
+  },
+  {
+    "name": "Remove a deploy key",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/repos/:owner/:repo/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "repo",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "remove-deploy-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/keys/#remove-a-deploy-key"
   },
   {
     "name": "Perform a merge",
@@ -10663,514 +11172,5 @@
     ],
     "idName": "get-combined-status-for-ref",
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref"
-  },
-  {
-    "name": "List hooks",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-            "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-            "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-            "name": "web",
-            "events": [
-              "push",
-              "pull_request"
-            ],
-            "active": true,
-            "config": {
-              "url": "http://example.com/webhook",
-              "content_type": "json"
-            },
-            "updated_at": "2011-09-06T20:39:23Z",
-            "created_at": "2011-09-06T17:26:27Z"
-          }
-        ]
-      }
-    ],
-    "idName": "list-hooks",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#list-hooks"
-  },
-  {
-    "name": "Get single hook",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "get-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#get-single-hook"
-  },
-  {
-    "name": "Create a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "Use `web` to create a webhook. To create a GitHub Service, use the name of a valid service. You can use [/hooks](https://api.github.com/hooks) for the list of valid service names. **Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install GitHub Services. Please see the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) for details.",
-        "default": "web",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "name": "web",
-        "active": true,
-        "events": [
-          "push",
-          "pull_request"
-        ],
-        "config": {
-          "url": "http://example.com/webhook",
-          "content_type": "json"
-        }
-      }
-    ],
-    "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can share the same `config` as long as those webhooks do not have any `events` that overlap.\n\n**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nHere's how you can create a hook that posts payloads in JSON format:",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "create-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#create-a-hook"
-  },
-  {
-    "name": "Edit a hook",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "config",
-        "type": "object",
-        "description": "Key/value pairs to provide settings for this webhook. [These are defined below](#create-hook-config-params).",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.url",
-        "type": "string",
-        "description": "The URL to which the payloads will be delivered.",
-        "required": true,
-        "location": "body"
-      },
-      {
-        "name": "config.content_type",
-        "type": "string",
-        "description": "The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.secret",
-        "type": "string",
-        "description": "If provided, the `secret` will be used as the `key` to generate the HMAC hex digest value in the [`X-Hub-Signature`](/enterprise/2.16/webhooks/#delivery-headers) header.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "config.insecure_ssl",
-        "type": "string",
-        "description": "Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "events",
-        "type": "string[]",
-        "description": "Determines what [events](/enterprise/2.16/v3/activity/events/types/) the hook is triggered for. This replaces the entire array of events.",
-        "default": "[\"push\"]",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "add_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be added to the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "remove_events",
-        "type": "string[]",
-        "description": "Determines a list of events to be removed from the list of events that the Hook triggers for.",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "description": "Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications.",
-        "default": true,
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "active": true,
-        "add_events": [
-          "pull_request"
-        ]
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
-          "test_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/test",
-          "ping_url": "https://api.github.com/repos/octocat/Hello-World/hooks/1/pings",
-          "name": "web",
-          "events": [
-            "push",
-            "pull_request"
-          ],
-          "active": true,
-          "config": {
-            "url": "http://example.com/webhook",
-            "content_type": "json"
-          },
-          "updated_at": "2011-09-06T20:39:23Z",
-          "created_at": "2011-09-06T17:26:27Z"
-        }
-      }
-    ],
-    "idName": "edit-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#edit-a-hook"
-  },
-  {
-    "name": "Test a push hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/tests",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.\n\n**Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "test-push-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#test-a-push-hook"
-  },
-  {
-    "name": "Ping a hook",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/repos/:owner/:repo/hooks/:hook_id/pings",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "**Note:** GitHub Enterprise release 2.17 and higher will discontinue allowing admins to install new GitHub Services, and existing services will stop working in GitHub Enterprise release 2.20 and higher. You can use the [Replacing GitHub Services guide](/enterprise/2.16/v3/guides/replacing-github-services) to help you update your services to webhooks.\n\nThis will trigger a [ping event](/enterprise/2.16/webhooks/#ping-event) to be sent to the hook.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "ping-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#ping-a-hook"
-  },
-  {
-    "name": "Delete a hook",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/repos/:owner/:repo/hooks/:hook_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "owner",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "repo",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "hook_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-hook",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/hooks/#delete-a-hook"
   }
 ]

--- a/routes/ghe-2.16/teams.json
+++ b/routes/ghe-2.16/teams.json
@@ -1163,6 +1163,474 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/#remove-team-project"
   },
   {
+    "name": "List comments",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "direction",
+        "type": "string",
+        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
+        "default": "desc",
+        "required": false,
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "location": "query"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "author": {
+              "login": "octocat",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "body": "Do you like apples?",
+            "body_html": "<p>Do you like apples?</p>",
+            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+            "created_at": "2018-01-15T23:53:58Z",
+            "last_edited_at": null,
+            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+            "number": 1,
+            "updated_at": "2018-01-15T23:53:58Z",
+            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+            "reactions": {
+              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+              "total_count": 5,
+              "+1": 3,
+              "-1": 1,
+              "laugh": 0,
+              "confused": 0,
+              "heart": 1,
+              "hooray": 0
+            }
+          }
+        ]
+      }
+    ],
+    "idName": "list-discussion-comments",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#list-comments"
+  },
+  {
+    "name": "Get a single comment",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "idName": "get-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#get-a-single-comment"
+  },
+  {
+    "name": "Create a comment",
+    "enabledForApps": true,
+    "method": "POST",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like apples?"
+      }
+    ],
+    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.16/v3/#abuse-rate-limits)\" for details.",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like apples?",
+          "body_html": "<p>Do you like apples?</p>",
+          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": null,
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-15T23:53:58Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "triggersNotification": true,
+    "idName": "create-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#create-a-comment"
+  },
+  {
+    "name": "Edit a comment",
+    "enabledForApps": true,
+    "method": "PATCH",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      },
+      {
+        "name": "squirrel-girl",
+        "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
+        "required": false
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "description": "The discussion comment's body text.",
+        "required": true,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "body": "Do you like pineapples?"
+      }
+    ],
+    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "body": "Do you like pineapples?",
+          "body_html": "<p>Do you like pineapples?</p>",
+          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
+          "created_at": "2018-01-15T23:53:58Z",
+          "last_edited_at": "2018-01-26T18:22:20Z",
+          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
+          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
+          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
+          "number": 1,
+          "updated_at": "2018-01-26T18:22:20Z",
+          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
+          "reactions": {
+            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
+            "total_count": 5,
+            "+1": 3,
+            "-1": 1,
+            "laugh": 0,
+            "confused": 0,
+            "heart": 1,
+            "hooray": 0
+          }
+        }
+      }
+    ],
+    "idName": "edit-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#edit-a-comment"
+  },
+  {
+    "name": "Delete a comment",
+    "enabledForApps": true,
+    "method": "DELETE",
+    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
+    "previews": [
+      {
+        "name": "echo",
+        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
+        "required": true
+      }
+    ],
+    "params": [
+      {
+        "name": "team_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "discussion_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "comment_number",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-discussion-comment",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#delete-a-comment"
+  },
+  {
     "name": "List discussions",
     "enabledForApps": true,
     "method": "GET",
@@ -1637,474 +2105,6 @@
     ],
     "idName": "delete-discussion",
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussions/#delete-a-discussion"
-  },
-  {
-    "name": "List comments",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "direction",
-        "type": "string",
-        "description": "Sorts the discussion comments by the date they were created. To return the oldest comments first, set to `asc`. Can be one of `asc` or `desc`.",
-        "default": "desc",
-        "required": false,
-        "enum": [
-          "asc",
-          "desc"
-        ],
-        "location": "query"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "author": {
-              "login": "octocat",
-              "id": 1,
-              "node_id": "MDQ6VXNlcjE=",
-              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-              "gravatar_id": "",
-              "url": "https://api.github.com/users/octocat",
-              "html_url": "https://github.com/octocat",
-              "followers_url": "https://api.github.com/users/octocat/followers",
-              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-              "organizations_url": "https://api.github.com/users/octocat/orgs",
-              "repos_url": "https://api.github.com/users/octocat/repos",
-              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-              "received_events_url": "https://api.github.com/users/octocat/received_events",
-              "type": "User",
-              "site_admin": false
-            },
-            "body": "Do you like apples?",
-            "body_html": "<p>Do you like apples?</p>",
-            "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-            "created_at": "2018-01-15T23:53:58Z",
-            "last_edited_at": null,
-            "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-            "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-            "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-            "number": 1,
-            "updated_at": "2018-01-15T23:53:58Z",
-            "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-            "reactions": {
-              "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-              "total_count": 5,
-              "+1": 3,
-              "-1": 1,
-              "laugh": 0,
-              "confused": 0,
-              "heart": 1,
-              "hooray": 0
-            }
-          }
-        ]
-      }
-    ],
-    "idName": "list-discussion-comments",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#list-comments"
-  },
-  {
-    "name": "Get a single comment",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "idName": "get-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#get-a-single-comment"
-  },
-  {
-    "name": "Create a comment",
-    "enabledForApps": true,
-    "method": "POST",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like apples?"
-      }
-    ],
-    "description": "Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nThis endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See \"[Abuse rate limits](/enterprise/2.16/v3/#abuse-rate-limits)\" for details.",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like apples?",
-          "body_html": "<p>Do you like apples?</p>",
-          "body_version": "5eb32b219cdc6a5a9b29ba5d6caa9c51",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": null,
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-15T23:53:58Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "triggersNotification": true,
-    "idName": "create-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#create-a-comment"
-  },
-  {
-    "name": "Edit a comment",
-    "enabledForApps": true,
-    "method": "PATCH",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      },
-      {
-        "name": "squirrel-girl",
-        "description": "**Note:** The [reactions API](/enterprise/2.16/v3/reactions/) is available for developers to preview. The `url` can be used to construct the API location for [listing and creating](/enterprise/2.16/v3/reactions) reactions. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To receive the `reactions` object in the response for this endpoint you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.squirrel-girl-preview\n\n```",
-        "required": false
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "body",
-        "type": "string",
-        "description": "The discussion comment's body text.",
-        "required": true,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "body": "Do you like pineapples?"
-      }
-    ],
-    "description": "Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "author": {
-            "login": "octocat",
-            "id": 1,
-            "node_id": "MDQ6VXNlcjE=",
-            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-            "gravatar_id": "",
-            "url": "https://api.github.com/users/octocat",
-            "html_url": "https://github.com/octocat",
-            "followers_url": "https://api.github.com/users/octocat/followers",
-            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-            "organizations_url": "https://api.github.com/users/octocat/orgs",
-            "repos_url": "https://api.github.com/users/octocat/repos",
-            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-            "received_events_url": "https://api.github.com/users/octocat/received_events",
-            "type": "User",
-            "site_admin": false
-          },
-          "body": "Do you like pineapples?",
-          "body_html": "<p>Do you like pineapples?</p>",
-          "body_version": "e6907b24d9c93cc0c5024a7af5888116",
-          "created_at": "2018-01-15T23:53:58Z",
-          "last_edited_at": "2018-01-26T18:22:20Z",
-          "discussion_url": "https://api.github.com/teams/2403582/discussions/1",
-          "html_url": "https://github.com/orgs/github/teams/justice-league/discussions/1/comments/1",
-          "node_id": "MDIxOlRlYW1EaXNjdXNzaW9uQ29tbWVudDE=",
-          "number": 1,
-          "updated_at": "2018-01-26T18:22:20Z",
-          "url": "https://api.github.com/teams/2403582/discussions/1/comments/1",
-          "reactions": {
-            "url": "https://api.github.com/teams/2403582/discussions/1/reactions",
-            "total_count": 5,
-            "+1": 3,
-            "-1": 1,
-            "laugh": 0,
-            "confused": 0,
-            "heart": 1,
-            "hooray": 0
-          }
-        }
-      }
-    ],
-    "idName": "edit-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#edit-a-comment"
-  },
-  {
-    "name": "Delete a comment",
-    "enabledForApps": true,
-    "method": "DELETE",
-    "path": "/teams/:team_id/discussions/:discussion_number/comments/:comment_number",
-    "previews": [
-      {
-        "name": "echo",
-        "description": "**Note:** The team discussions API is currently available for developers to preview. See the [blog post](/changes/2018-02-07-team-discussions-api) for full details. To access the API during the preview period, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.echo-preview+json\n\n```",
-        "required": true
-      }
-    ],
-    "params": [
-      {
-        "name": "team_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "discussion_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "comment_number",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-discussion-comment",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/teams/discussion_comments/#delete-a-comment"
   },
   {
     "name": "List team members",

--- a/routes/ghe-2.16/users.json
+++ b/routes/ghe-2.16/users.json
@@ -841,214 +841,6 @@
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/followers/#unfollow-a-user"
   },
   {
-    "name": "List public keys for a user",
-    "enabledForApps": true,
-    "method": "GET",
-    "path": "/users/:username/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "username",
-        "type": "string",
-        "required": true,
-        "description": "",
-        "location": "url"
-      },
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA..."
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys-for-user",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#list-public-keys-for-a-user"
-  },
-  {
-    "name": "List your public keys",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "per_page",
-        "type": "integer",
-        "required": false,
-        "description": "Results per page (max 100)",
-        "default": 30,
-        "location": "query"
-      },
-      {
-        "name": "page",
-        "type": "integer",
-        "required": false,
-        "description": "Page number of the results to fetch.",
-        "default": 1,
-        "location": "query"
-      }
-    ],
-    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "id": 1,
-            "key": "ssh-rsa AAA...",
-            "url": "https://api.github.com/user/keys/1",
-            "title": "octocat@octomac",
-            "verified": true,
-            "created_at": "2014-12-10T15:53:42Z",
-            "read_only": true
-          }
-        ]
-      }
-    ],
-    "idName": "list-public-keys",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#list-your-public-keys"
-  },
-  {
-    "name": "Get a single public key",
-    "enabledForApps": false,
-    "method": "GET",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
-    "responses": [
-      {
-        "headers": {
-          "status": "200 OK",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "get-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#get-a-single-public-key"
-  },
-  {
-    "name": "Create a public key",
-    "enabledForApps": false,
-    "method": "POST",
-    "path": "/user/keys",
-    "previews": [],
-    "params": [
-      {
-        "name": "title",
-        "type": "string",
-        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
-        "required": false,
-        "location": "body"
-      },
-      {
-        "name": "key",
-        "type": "string",
-        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
-        "required": false,
-        "location": "body"
-      }
-    ],
-    "requests": [
-      {
-        "title": "octocat@octomac",
-        "key": "ssh-rsa AAA..."
-      }
-    ],
-    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise Server appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
-    "responses": [
-      {
-        "headers": {
-          "status": "201 Created",
-          "content-type": "application/json; charset=utf-8"
-        },
-        "body": {
-          "id": 1,
-          "key": "ssh-rsa AAA...",
-          "url": "https://api.github.com/user/keys/1",
-          "title": "octocat@octomac",
-          "verified": true,
-          "created_at": "2014-12-10T15:53:42Z",
-          "read_only": true
-        }
-      }
-    ],
-    "idName": "create-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#create-a-public-key"
-  },
-  {
-    "name": "Delete a public key",
-    "enabledForApps": false,
-    "method": "DELETE",
-    "path": "/user/keys/:key_id",
-    "previews": [],
-    "params": [
-      {
-        "name": "key_id",
-        "type": "integer",
-        "required": true,
-        "description": "",
-        "location": "url"
-      }
-    ],
-    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise Server appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
-    "responses": [
-      {
-        "headers": {
-          "status": "204 No Content",
-          "content-type": "application/json; charset=utf-8"
-        }
-      }
-    ],
-    "idName": "delete-public-key",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#delete-a-public-key"
-  },
-  {
     "name": "List GPG keys for a user",
     "enabledForApps": true,
     "method": "GET",
@@ -1352,5 +1144,213 @@
     ],
     "idName": "delete-gpg-key",
     "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/gpg_keys/#delete-a-gpg-key"
+  },
+  {
+    "name": "List public keys for a user",
+    "enabledForApps": true,
+    "method": "GET",
+    "path": "/users/:username/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "username",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the _verified_ public SSH keys for a user. This is accessible by anyone.",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA..."
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys-for-user",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#list-public-keys-for-a-user"
+  },
+  {
+    "name": "List your public keys",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "per_page",
+        "type": "integer",
+        "required": false,
+        "description": "Results per page (max 100)",
+        "default": 30,
+        "location": "query"
+      },
+      {
+        "name": "page",
+        "type": "integer",
+        "required": false,
+        "description": "Page number of the results to fetch.",
+        "default": 1,
+        "location": "query"
+      }
+    ],
+    "description": "Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "id": 1,
+            "key": "ssh-rsa AAA...",
+            "url": "https://api.github.com/user/keys/1",
+            "title": "octocat@octomac",
+            "verified": true,
+            "created_at": "2014-12-10T15:53:42Z",
+            "read_only": true
+          }
+        ]
+      }
+    ],
+    "idName": "list-public-keys",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#list-your-public-keys"
+  },
+  {
+    "name": "Get a single public key",
+    "enabledForApps": false,
+    "method": "GET",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).",
+    "responses": [
+      {
+        "headers": {
+          "status": "200 OK",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "get-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#get-a-single-public-key"
+  },
+  {
+    "name": "Create a public key",
+    "enabledForApps": false,
+    "method": "POST",
+    "path": "/user/keys",
+    "previews": [],
+    "params": [
+      {
+        "name": "title",
+        "type": "string",
+        "description": "A descriptive name for the new key. Use a name that will help you recognize this key in your GitHub account. For example, if you're using a personal Mac, you might call this key \"Personal MacBook Air\".",
+        "required": false,
+        "location": "body"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "description": "The public SSH key to add to your GitHub account. See \"[Generating a new SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)\" for guidance on how to create a public SSH key.",
+        "required": false,
+        "location": "body"
+      }
+    ],
+    "requests": [
+      {
+        "title": "octocat@octomac",
+        "key": "ssh-rsa AAA..."
+      }
+    ],
+    "description": "Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise Server appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to add an SSH key address via the API with these options enabled.",
+    "responses": [
+      {
+        "headers": {
+          "status": "201 Created",
+          "content-type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "key": "ssh-rsa AAA...",
+          "url": "https://api.github.com/user/keys/1",
+          "title": "octocat@octomac",
+          "verified": true,
+          "created_at": "2014-12-10T15:53:42Z",
+          "read_only": true
+        }
+      }
+    ],
+    "idName": "create-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#create-a-public-key"
+  },
+  {
+    "name": "Delete a public key",
+    "enabledForApps": false,
+    "method": "DELETE",
+    "path": "/user/keys/:key_id",
+    "previews": [],
+    "params": [
+      {
+        "name": "key_id",
+        "type": "integer",
+        "required": true,
+        "description": "",
+        "location": "url"
+      }
+    ],
+    "description": "Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](/enterprise/2.16/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).\n\nIf your GitHub Enterprise Server appliance has [LDAP Sync enabled](https://help.github.com/enterprise/admin/guides/user-management/using-ldap) and the option to synchronize SSH keys enabled, this API is disabled and will return a `403` response. Users managed in LDAP won't be able to remove an SSH key address via the API with these options enabled.",
+    "responses": [
+      {
+        "headers": {
+          "status": "204 No Content",
+          "content-type": "application/json; charset=utf-8"
+        }
+      }
+    ],
+    "idName": "delete-public-key",
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/users/keys/#delete-a-public-key"
   }
 ]


### PR DESCRIPTION
Hey @gr2m 👋 

I just took @swinton's [`github-rest-apis-for-insomnia`](https://github.com/swinton/github-rest-apis-for-insomnia) for a spin and noticed the nouns (scopes?) are not in order. This PR updates the build script to alphabetically sort the keys in the endpoints map.

I didn't commit the changes that result from running `npm run update` because I think that happens automatically on a schedule, right?

Here's the order of keys after running the script:

```sh
$ cat routes/api.github.com/index.json | npx json -k
[
  "activity",
  "apps",
  "checks",
  "codesOfConduct",
  "emojis",
  "gists",
  "git",
  "gitignore",
  "interactions",
  "issues",
  "licenses",
  "markdown",
  "meta",
  "migrations",
  "oauthAuthorizations",
  "orgs",
  "projects",
  "pulls",
  "rateLimit",
  "reactions",
  "repos",
  "scim",
  "search",
  "teams",
  "users"
]
```

(Apologies for preemptively opening a PR without first opening an issue.)
