### PR TITLE
deprecate "Get the SHA-1 of a commit reference"

### DIFF
--- a/lib/endpoint/get.js
+++ b/lib/endpoint/get.js
@@ -62,7 +62,7 @@ async function getEndpoint (state, url) {
     })
   })
 
-  applyDeprecations(result)
+  applyDeprecations(state, result)
 
   return result
 }

--- a/lib/endpoint/overrides/deprecations.js
+++ b/lib/endpoint/overrides/deprecations.js
@@ -10,7 +10,7 @@
 
 module.exports = deprecations
 
-function deprecations (endpoints) {
+function deprecations (state, endpoints) {
   // 2018-12-27 – "Search issues" renamed to "Search issues and pull requests"
   const searchIssuesAndPullRequests = findByRoute(endpoints, 'GET /search/issues')
 
@@ -293,6 +293,15 @@ function deprecations (endpoints) {
       }
     }
     endpoints.push(deprecated)
+  }
+
+  // 2019-05-22 Deprecate "Get the SHA-1 of a commit reference"
+  const getCommitShaForRef = findByRoute(endpoints, 'GET /repos/:owner/:repo/commits/:ref')
+  if (getCommitShaForRef) {
+    getCommitShaForRef.deprecated = {
+      date: '2019-05-22',
+      message: '"Get the SHA-1 of a commit reference" will be removed. Use "Get a single commit" instead with medaType format "sha" instead.'
+    }
   }
 }
 

--- a/routes/api.github.com/index.json
+++ b/routes/api.github.com/index.json
@@ -35453,7 +35453,11 @@
         }
       ],
       "idName": "get-commit-ref-sha",
-      "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+      "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+      "deprecated": {
+        "date": "2019-05-22",
+        "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+      }
     },
     {
       "name": "Compare two commits",

--- a/routes/api.github.com/repos.json
+++ b/routes/api.github.com/repos.json
@@ -5754,7 +5754,11 @@
       }
     ],
     "idName": "get-commit-ref-sha",
-    "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+    "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+    "deprecated": {
+      "date": "2019-05-22",
+      "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+    }
   },
   {
     "name": "Compare two commits",

--- a/routes/api.github.com/repos/get-commit-ref-sha.json
+++ b/routes/api.github.com/repos/get-commit-ref-sha.json
@@ -38,5 +38,9 @@
     }
   ],
   "idName": "get-commit-ref-sha",
-  "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+  "documentationUrl": "https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+  "deprecated": {
+    "date": "2019-05-22",
+    "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+  }
 }

--- a/routes/ghe-2.14/index.json
+++ b/routes/ghe-2.14/index.json
@@ -33447,6 +33447,7 @@
     {
       "name": "Get the SHA-1 of a commit reference",
       "enabledForApps": true,
+      "githubCloudOnly": false,
       "method": "GET",
       "path": "/repos/:owner/:repo/commits/:ref",
       "previews": [],
@@ -33473,7 +33474,7 @@
           "location": "url"
         }
       ],
-      "description": "**Note:** To access this endpoint, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
+      "description": "**Note:** To access this endpoint, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
       "responses": [
         {
           "headers": {
@@ -33483,7 +33484,11 @@
         }
       ],
       "idName": "get-commit-ref-sha",
-      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+      "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+      "deprecated": {
+        "date": "2019-05-22",
+        "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+      }
     },
     {
       "name": "Compare two commits",

--- a/routes/ghe-2.14/repos.json
+++ b/routes/ghe-2.14/repos.json
@@ -5571,6 +5571,7 @@
   {
     "name": "Get the SHA-1 of a commit reference",
     "enabledForApps": true,
+    "githubCloudOnly": false,
     "method": "GET",
     "path": "/repos/:owner/:repo/commits/:ref",
     "previews": [],
@@ -5597,7 +5598,7 @@
         "location": "url"
       }
     ],
-    "description": "**Note:** To access this endpoint, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
+    "description": "**Note:** To access this endpoint, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
     "responses": [
       {
         "headers": {
@@ -5607,7 +5608,11 @@
       }
     ],
     "idName": "get-commit-ref-sha",
-    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+    "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+    "deprecated": {
+      "date": "2019-05-22",
+      "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+    }
   },
   {
     "name": "Compare two commits",

--- a/routes/ghe-2.14/repos/get-commit-ref-sha.json
+++ b/routes/ghe-2.14/repos/get-commit-ref-sha.json
@@ -1,6 +1,7 @@
 {
   "name": "Get the SHA-1 of a commit reference",
   "enabledForApps": true,
+  "githubCloudOnly": false,
   "method": "GET",
   "path": "/repos/:owner/:repo/commits/:ref",
   "previews": [],
@@ -27,7 +28,7 @@
       "location": "url"
     }
   ],
-  "description": "**Note:** To access this endpoint, you must provide a custom [media type](/enterprise/2.14/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
+  "description": "**Note:** To access this endpoint, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
   "responses": [
     {
       "headers": {
@@ -37,5 +38,9 @@
     }
   ],
   "idName": "get-commit-ref-sha",
-  "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+  "documentationUrl": "https://developer.github.com/enterprise/2.14/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+  "deprecated": {
+    "date": "2019-05-22",
+    "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+  }
 }

--- a/routes/ghe-2.15/index.json
+++ b/routes/ghe-2.15/index.json
@@ -33509,6 +33509,7 @@
     {
       "name": "Get the SHA-1 of a commit reference",
       "enabledForApps": true,
+      "githubCloudOnly": false,
       "method": "GET",
       "path": "/repos/:owner/:repo/commits/:ref",
       "previews": [],
@@ -33535,7 +33536,7 @@
           "location": "url"
         }
       ],
-      "description": "**Note:** To access this endpoint, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
+      "description": "**Note:** To access this endpoint, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
       "responses": [
         {
           "headers": {
@@ -33545,7 +33546,11 @@
         }
       ],
       "idName": "get-commit-ref-sha",
-      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+      "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+      "deprecated": {
+        "date": "2019-05-22",
+        "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+      }
     },
     {
       "name": "Compare two commits",

--- a/routes/ghe-2.15/repos.json
+++ b/routes/ghe-2.15/repos.json
@@ -5571,6 +5571,7 @@
   {
     "name": "Get the SHA-1 of a commit reference",
     "enabledForApps": true,
+    "githubCloudOnly": false,
     "method": "GET",
     "path": "/repos/:owner/:repo/commits/:ref",
     "previews": [],
@@ -5597,7 +5598,7 @@
         "location": "url"
       }
     ],
-    "description": "**Note:** To access this endpoint, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
+    "description": "**Note:** To access this endpoint, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
     "responses": [
       {
         "headers": {
@@ -5607,7 +5608,11 @@
       }
     ],
     "idName": "get-commit-ref-sha",
-    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+    "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+    "deprecated": {
+      "date": "2019-05-22",
+      "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+    }
   },
   {
     "name": "Compare two commits",

--- a/routes/ghe-2.15/repos/get-commit-ref-sha.json
+++ b/routes/ghe-2.15/repos/get-commit-ref-sha.json
@@ -1,6 +1,7 @@
 {
   "name": "Get the SHA-1 of a commit reference",
   "enabledForApps": true,
+  "githubCloudOnly": false,
   "method": "GET",
   "path": "/repos/:owner/:repo/commits/:ref",
   "previews": [],
@@ -27,7 +28,7 @@
       "location": "url"
     }
   ],
-  "description": "**Note:** To access this endpoint, you must provide a custom [media type](/enterprise/2.15/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
+  "description": "**Note:** To access this endpoint, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
   "responses": [
     {
       "headers": {
@@ -37,5 +38,9 @@
     }
   ],
   "idName": "get-commit-ref-sha",
-  "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+  "documentationUrl": "https://developer.github.com/enterprise/2.15/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+  "deprecated": {
+    "date": "2019-05-22",
+    "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+  }
 }

--- a/routes/ghe-2.16/index.json
+++ b/routes/ghe-2.16/index.json
@@ -33594,6 +33594,7 @@
     {
       "name": "Get the SHA-1 of a commit reference",
       "enabledForApps": true,
+      "githubCloudOnly": false,
       "method": "GET",
       "path": "/repos/:owner/:repo/commits/:ref",
       "previews": [],
@@ -33620,7 +33621,7 @@
           "location": "url"
         }
       ],
-      "description": "**Note:** To access this endpoint, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
+      "description": "**Note:** To access this endpoint, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
       "responses": [
         {
           "headers": {
@@ -33630,7 +33631,11 @@
         }
       ],
       "idName": "get-commit-ref-sha",
-      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+      "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+      "deprecated": {
+        "date": "2019-05-22",
+        "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+      }
     },
     {
       "name": "Compare two commits",

--- a/routes/ghe-2.16/repos.json
+++ b/routes/ghe-2.16/repos.json
@@ -5571,6 +5571,7 @@
   {
     "name": "Get the SHA-1 of a commit reference",
     "enabledForApps": true,
+    "githubCloudOnly": false,
     "method": "GET",
     "path": "/repos/:owner/:repo/commits/:ref",
     "previews": [],
@@ -5597,7 +5598,7 @@
         "location": "url"
       }
     ],
-    "description": "**Note:** To access this endpoint, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
+    "description": "**Note:** To access this endpoint, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
     "responses": [
       {
         "headers": {
@@ -5607,7 +5608,11 @@
       }
     ],
     "idName": "get-commit-ref-sha",
-    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+    "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+    "deprecated": {
+      "date": "2019-05-22",
+      "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+    }
   },
   {
     "name": "Compare two commits",

--- a/routes/ghe-2.16/repos/get-commit-ref-sha.json
+++ b/routes/ghe-2.16/repos/get-commit-ref-sha.json
@@ -1,6 +1,7 @@
 {
   "name": "Get the SHA-1 of a commit reference",
   "enabledForApps": true,
+  "githubCloudOnly": false,
   "method": "GET",
   "path": "/repos/:owner/:repo/commits/:ref",
   "previews": [],
@@ -27,7 +28,7 @@
       "location": "url"
     }
   ],
-  "description": "**Note:** To access this endpoint, you must provide a custom [media type](/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
+  "description": "**Note:** To access this endpoint, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.VERSION.sha\n\n```\n\nReturns the SHA-1 of the commit reference. You must have `read` access for the repository to get the SHA-1 of a commit reference. You can use this endpoint to check if a remote reference's SHA-1 is the same as your local reference's SHA-1 by providing the local SHA-1 reference as the ETag.\n\n",
   "responses": [
     {
       "headers": {
@@ -37,5 +38,9 @@
     }
   ],
   "idName": "get-commit-ref-sha",
-  "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/commits/#get-the-sha-1-of-a-commit-reference"
+  "documentationUrl": "https://developer.github.com/enterprise/2.16/v3/repos/commits/#get-the-sha-1-of-a-commit-reference",
+  "deprecated": {
+    "date": "2019-05-22",
+    "message": "\"Get the SHA-1 of a commit reference\" will be removed. Use \"Get a single commit\" instead with medaType format \"sha\" instead."
+  }
 }


### PR DESCRIPTION
It’s the same endpoint as "Get a single commit", just using a different media type format