### PR TITLE
Make GHE routes testable

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -20,7 +20,7 @@ action "test" {
   needs = "lint"
   uses = "docker://node:alpine"
   runs = "npm"
-  args = "test"
+  args = "run test:ci"
 }
 
 workflow "Record on demand" {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,12 @@ Please follow these steps to report such a problem
    TEST_URL=https://developer.github.com/v3/repos/#get ./node_modules/.bin/tap test/integration/single-endpoint-test.js
    ```
 
+   and for GitHub Enterprise:
+
+   ```
+   GHE_VERSION=2.17 TEST_URL=https://developer.github.com/enterprise/2.17/v3/repos/#get ./node_modules/.bin/tap test/integration/single-endpoint-test.js
+   ```
+
    Once you did, push your changes and wait for us to review. If you have any
    questions at any point, comment on the pull request, we are happy to help you out.
 9. Now you are more than awesome, thank you so much! 💐

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const { readdirSync } = require('fs')
+const { spawn } = require('tap')
+
+spawn(
+  'tap',
+  [ '--no-coverage', '--timeout=60', 'test/unit/*-test.js' ],
+  {
+    name: 'unit tests',
+    env: { PATH: process.env.PATH }
+    //     ^ might be unnecessary in ci?
+  }
+)
+
+const apis = readdirSync('routes')
+for (const api of apis) {
+  const GHE_VERSION = parseFloat(api.replace(/^ghe-(\d+\.\d+)$/, '$1')) || null
+  spawn(
+    'tap',
+    [ '--no-coverage', '--timeout=60', 'test/integration/*-test.js' ],
+    {
+      name: `${api} integration tests`,
+      env: { GHE_VERSION: GHE_VERSION, PATH: process.env.PATH }
+      //                               ^ might be unnecessary in ci?
+    }
+  )
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "lint": "standard",
     "test": "tap --coverage --timeout 60 'test/**/*-test.js'",
+    "test:ci": "node bin/run-tests.js",
     "update": "node bin/octokit-rest-routes.js update",
     "check": "node bin/octokit-rest-routes.js check",
     "semantic-release": "semantic-release"

--- a/test/integration/all-endpoints-test.js
+++ b/test/integration/all-endpoints-test.js
@@ -1,6 +1,13 @@
 const { test } = require('tap')
 
-const { getAllRoutesByDocumentUrl, getAllDocumentationUrls } = require('../util')
+const {
+  getAllRoutesByDocumentUrl,
+  getAllDocumentationUrls,
+  getGheVersion,
+  getBaseUrl,
+  getCacheDir,
+  getRoutesDir
+} = require('../util')
 const getEndpoint = require('../../lib/endpoint/get')
 const Cache = require('../../lib/cache')
 
@@ -14,9 +21,11 @@ URLS.forEach(url => {
     const expected = routesbByDocumentationUrl[url]
     const actual = await getEndpoint({
       cached: true,
-      cache: new Cache('api.github.com'),
-      baseUrl: 'https://developer.github.com/v3/',
-      folderName: 'api.github.com'
+      cache: new Cache(getCacheDir()),
+      baseUrl: getBaseUrl(),
+      folderName: getRoutesDir(),
+      gheVersion: getGheVersion(),
+      memoryCache: {}
     }, url)
 
     t.deepEquals(actual, expected)

--- a/test/integration/landing-page-test.js
+++ b/test/integration/landing-page-test.js
@@ -1,5 +1,11 @@
 const { test } = require('tap')
 
+const {
+  getBaseUrl,
+  getPathPrefix,
+  getCacheDir,
+  getRoutesDir
+} = require('../util')
 const Cache = require('../../lib/cache')
 const getDocPages = require('../../lib/landing-page/to-pages-json')
 
@@ -14,12 +20,14 @@ const getDocPages = require('../../lib/landing-page/to-pages-json')
 // 5. push all changes to your pull request. Review your changes, once you are
 //    happy remove the "WIP" from the pull request and ask for a review
 test(`v3/index.html -> pages.json`, async t => {
-  const expectedPages = require('../../cache/api.github.com/pages.json')
-  const cache = new Cache('api.github.com')
-  const html = await cache.read('v3/index.html')
+  const [ cacheRoot, cacheDir ] = [ '../../cache', getCacheDir() ]
+  const expectedPages = require(`${cacheRoot}/${cacheDir}/pages.json`)
+  const cache = new Cache(cacheDir)
+  const pathPrefix = getPathPrefix()
+  const html = await cache.read(`${pathPrefix}/index.html`)
   const actualPages = getDocPages({
-    baseUrl: 'https://developer.github.com/v3/',
-    folderName: 'api.github.com',
+    baseUrl: getBaseUrl(),
+    folderName: getRoutesDir(),
     cache
   }, html)
 

--- a/test/integration/scope-endpoints-test.js
+++ b/test/integration/scope-endpoints-test.js
@@ -1,6 +1,13 @@
 const { test } = require('tap')
 
-const { getScopeRoutesByDocumentUrl, getAllDocumentationUrls } = require('../util')
+const {
+  getScopeRoutesByDocumentUrl,
+  getAllDocumentationUrls,
+  getGheVersion,
+  getBaseUrl,
+  getCacheDir,
+  getRoutesDir
+} = require('../util')
 const getEndpoint = require('../../lib/endpoint/get')
 const Cache = require('../../lib/cache')
 
@@ -12,9 +19,11 @@ getAllDocumentationUrls().forEach(url => {
     const expected = routesByDocumentUrl[url]
     const actual = await getEndpoint({
       cached: true,
-      cache: new Cache('api.github.com'),
-      baseUrl: 'https://developer.github.com/v3/',
-      folderName: 'api.github.com'
+      cache: new Cache(getCacheDir()),
+      baseUrl: getBaseUrl(),
+      folderName: getRoutesDir(),
+      gheVersion: getGheVersion(),
+      memoryCache: {}
     }, url)
 
     t.deepEquals(actual, expected)

--- a/test/integration/single-endpoint-test.js
+++ b/test/integration/single-endpoint-test.js
@@ -2,7 +2,11 @@ const { test } = require('tap')
 
 const {
   getAllDocumentationUrls,
-  getRoutesForUrl
+  getRoutesForUrl,
+  getGheVersion,
+  getBaseUrl,
+  getCacheDir,
+  getRoutesDir
 } = require('../util')
 const getEndpoint = require('../../lib/endpoint/get')
 const Cache = require('../../lib/cache')
@@ -15,9 +19,11 @@ URLS.forEach(url => {
 
     const actual = await getEndpoint({
       cached: true,
-      cache: new Cache('api.github.com'),
-      baseUrl: 'https://developer.github.com/v3/',
-      folderName: 'api.github.com'
+      cache: new Cache(getCacheDir()),
+      baseUrl: getBaseUrl(),
+      folderName: getRoutesDir(),
+      gheVersion: getGheVersion(),
+      memoryCache: {}
     }, url)
 
     t.deepEquals(actual, expected)

--- a/test/util.js
+++ b/test/util.js
@@ -79,9 +79,7 @@ function getRoutesForUrl (url) {
   const routes = CACHED_ROUTES_BY_DOCUMENTATION_URL[url]
   const idNames = routes.map(route => route.idName)
 
-  return idNames.map(
-    idName => requireRoutesFile(`${scope}/${idName}.json`)
-  )
+  return idNames.map(idName => requireRoutesFile(`${scope}/${idName}.json`))
 }
 
 function reduceByDocumentationUrl (map, endpoint) {

--- a/test/util.js
+++ b/test/util.js
@@ -40,14 +40,13 @@ function getRoutesDir () {
   return gheVersion ? `ghe-${gheVersion}` : 'api.github.com'
 }
 
-function getRoutePath () {
-  const routesDir = getRoutesDir()
-  return `../routes/${routesDir}`
+function requireRoutesFile (filePath) {
+  const [ routesRoot, routesDir ] = [ '../routes', getRoutesDir() ]
+  return require(`${routesRoot}/${routesDir}/${filePath}`)
 }
 
 function getAllRoutesByScope () {
-  const routePath = getRoutePath()
-  return require(`${routePath}/index.json`)
+  return requireRoutesFile('index.json')
 }
 
 const CACHED_ROUTES_BY_DOCUMENTATION_URL = flatten(
@@ -66,8 +65,8 @@ function getAllDocumentationUrls () {
 }
 
 function getScopeRoutes (scope) {
-  const routePath = getRoutePath()
-  return require(`${routePath}/${kebabCase(scope)}.json`)
+  const kebabScope = kebabCase(scope)
+  return requireRoutesFile(`${kebabScope}.json`)
 }
 
 function getScopeRoutesByDocumentUrl (scope) {
@@ -75,14 +74,13 @@ function getScopeRoutesByDocumentUrl (scope) {
 }
 
 function getRoutesForUrl (url) {
-  const routePath = getRoutePath()
   const matches = url.match(/\/v3\/([^/#]+)((\/[^/#]+)*)/)
   const scope = kebabCase(matches[1])
   const routes = CACHED_ROUTES_BY_DOCUMENTATION_URL[url]
   const idNames = routes.map(route => route.idName)
 
   return idNames.map(
-    idName => require(`${routePath}/${scope}/${idName}.json`)
+    idName => requireRoutesFile(`${scope}/${idName}.json`)
   )
 }
 


### PR DESCRIPTION
fixes #443 

##### GitHub Enterprise 2.14
```
$ GHE_VERSION=2.14 npm test -- --no-coverage

> @octokit/routes@0.0.0-development test /home/derek/code/octokit/routes
> tap --coverage --timeout 60 'test/**/*-test.js' "--no-coverage"

 PASS  test/integration/landing-page-test.js 1 OK 724ms
 PASS  test/unit/options-urls-test.js 9 OK 882ms
 PASS  test/integration/all-endpoints-test.js 964 OK 10s
 PASS  test/integration/scope-endpoints-test.js 964 OK 10s
 PASS  test/integration/single-endpoint-test.js 964 OK 10s

  🌈 SUMMARY RESULTS 🌈  

Suites:   5 passed, 5 of 5 completed
Asserts:  2902 passed, of 2902
Time:     11s
```

##### GitHub Enterprise 2.15
```
$ GHE_VERSION=2.15 npm test -- --no-coverage

> @octokit/routes@0.0.0-development test /home/derek/code/octokit/routes
> tap --coverage --timeout 60 'test/**/*-test.js' "--no-coverage"

 PASS  test/integration/landing-page-test.js 1 OK 764ms
 PASS  test/unit/options-urls-test.js 9 OK 856ms
 PASS  test/integration/all-endpoints-test.js 966 OK 11s
 PASS  test/integration/scope-endpoints-test.js 966 OK 11s
 PASS  test/integration/single-endpoint-test.js 966 OK 11s

  🌈 SUMMARY RESULTS 🌈  

Suites:   5 passed, 5 of 5 completed
Asserts:  2908 passed, of 2908
Time:     11s
```

##### GitHub Enterprise 2.16
```
$ GHE_VERSION=2.16 npm test -- --no-coverage

> @octokit/routes@0.0.0-development test /home/derek/code/octokit/routes
> tap --coverage --timeout 60 'test/**/*-test.js' "--no-coverage"

 PASS  test/integration/landing-page-test.js 1 OK 768ms
 PASS  test/unit/options-urls-test.js 9 OK 907ms
 PASS  test/integration/all-endpoints-test.js 970 OK 10s
 PASS  test/integration/scope-endpoints-test.js 970 OK 11s
 PASS  test/integration/single-endpoint-test.js 970 OK 11s

  🌈 SUMMARY RESULTS 🌈  

Suites:   5 passed, 5 of 5 completed
Asserts:  2920 passed, of 2920
Time:     11s
```

##### GitHub Enterprise 2.17
```
$ GHE_VERSION=2.17 npm test -- --no-coverage

> @octokit/routes@0.0.0-development test /home/derek/code/octokit/routes
> tap --coverage --timeout 60 'test/**/*-test.js' "--no-coverage"

 PASS  test/integration/landing-page-test.js 1 OK 794ms
 PASS  test/unit/options-urls-test.js 9 OK 858ms
 PASS  test/integration/scope-endpoints-test.js 992 OK 11s
 PASS  test/integration/all-endpoints-test.js 992 OK 11s
 PASS  test/integration/single-endpoint-test.js 992 OK 11s
     
  🌈 SUMMARY RESULTS 🌈  

Suites:   5 passed, 5 of 5 completed
Asserts:  2986 passed, of 2986
Time:     11s
```

##### GitHub Cloud
```
$ npm test -- --no-coverage

> @octokit/routes@0.0.0-development test /home/derek/code/octokit/routes
> tap --coverage --timeout 60 'test/**/*-test.js' "--no-coverage"

 PASS  test/integration/landing-page-test.js 1 OK 737ms
 PASS  test/unit/options-urls-test.js 9 OK 853ms
 PASS  test/integration/all-endpoints-test.js 1006 OK 11s
 PASS  test/integration/scope-endpoints-test.js 1006 OK 11s
 PASS  test/integration/single-endpoint-test.js 1006 OK 11s

  🌈 SUMMARY RESULTS 🌈  

Suites:   5 passed, 5 of 5 completed
Asserts:  3028 passed, of 3028
Time:     12s
```