### PR TITLE
`POST /repos/:owner/:repo/generate` is now `POST /repos/:template_owner/:template_repo/generate`

### DIFF
--- a/cache/api.github.com/v3/repos/create-repository-using-a-repository-template.html
+++ b/cache/api.github.com/v3/repos/create-repository-using-a-repository-template.html
@@ -14,7 +14,7 @@
 
 </div>
 <p>Creates a new repository using a repository template. Use the <code>repo</code> route parameter to specify the repository to use as the template. The authenticated user must own or be a member of an organization that owns the repository. To check if a repository is available to use as a template, get the repository&apos;s information using the <a href="/v3/repos/#get"><code>GET /repos/:owner/:repo</code></a> endpoint and check that the <code>is_template</code> key is <code>true</code>.</p>
-<pre><code>POST /repos/:owner/:repo/generate
+<pre><code>POST /repos/:template_owner/:template_repo/generate
 </code></pre>
 <h3>
 <a id="oauth-scope-requirements-1" class="anchor" href="#oauth-scope-requirements-1" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>OAuth scope requirements</h3>

--- a/cache/api.github.com/v3/repos/index.html
+++ b/cache/api.github.com/v3/repos/index.html
@@ -1083,7 +1083,7 @@ Location: https://api.github.com/repos/octocat/Hello-World
 
 <p>Creates a new repository using a repository template. Use the <code>repo</code> route parameter to specify the repository to use as the template. The authenticated user must own or be a member of an organization that owns the repository. To check if a repository is available to use as a template, get the repository's information using the <a href="/v3/repos/#get"><code>GET /repos/:owner/:repo</code></a> endpoint and check that the <code>is_template</code> key is <code>true</code>.</p>
 
-<pre><code>POST /repos/:owner/:repo/generate
+<pre><code>POST /repos/:template_owner/:template_repo/generate
 </code></pre>
 
 <h3>

--- a/routes/api.github.com/index.json
+++ b/routes/api.github.com/index.json
@@ -31009,7 +31009,7 @@
       "enabledForApps": false,
       "githubCloudOnly": false,
       "method": "POST",
-      "path": "/repos/:owner/:repo/generate",
+      "path": "/repos/:template_owner/:template_repo/generate",
       "previews": [
         {
           "name": "baptiste",
@@ -31019,7 +31019,14 @@
       ],
       "params": [
         {
-          "name": "repo",
+          "name": "template_owner",
+          "type": "string",
+          "required": true,
+          "description": "",
+          "location": "url"
+        },
+        {
+          "name": "template_repo",
           "type": "string",
           "required": true,
           "description": "",
@@ -31029,8 +31036,8 @@
           "name": "owner",
           "type": "string",
           "description": "The organization or person who will own the new repository. To create a new repository in an organization, the authenticated user must be a member of the specified organization.",
-          "required": true,
-          "location": "url"
+          "required": false,
+          "location": "body"
         },
         {
           "name": "name",

--- a/routes/api.github.com/repos.json
+++ b/routes/api.github.com/repos.json
@@ -1017,7 +1017,7 @@
     "enabledForApps": false,
     "githubCloudOnly": false,
     "method": "POST",
-    "path": "/repos/:owner/:repo/generate",
+    "path": "/repos/:template_owner/:template_repo/generate",
     "previews": [
       {
         "name": "baptiste",
@@ -1027,7 +1027,14 @@
     ],
     "params": [
       {
-        "name": "repo",
+        "name": "template_owner",
+        "type": "string",
+        "required": true,
+        "description": "",
+        "location": "url"
+      },
+      {
+        "name": "template_repo",
         "type": "string",
         "required": true,
         "description": "",
@@ -1037,8 +1044,8 @@
         "name": "owner",
         "type": "string",
         "description": "The organization or person who will own the new repository. To create a new repository in an organization, the authenticated user must be a member of the specified organization.",
-        "required": true,
-        "location": "url"
+        "required": false,
+        "location": "body"
       },
       {
         "name": "name",

--- a/routes/api.github.com/repos/create-using-template.json
+++ b/routes/api.github.com/repos/create-using-template.json
@@ -3,7 +3,7 @@
   "enabledForApps": false,
   "githubCloudOnly": false,
   "method": "POST",
-  "path": "/repos/:owner/:repo/generate",
+  "path": "/repos/:template_owner/:template_repo/generate",
   "previews": [
     {
       "name": "baptiste",
@@ -13,7 +13,14 @@
   ],
   "params": [
     {
-      "name": "repo",
+      "name": "template_owner",
+      "type": "string",
+      "required": true,
+      "description": "",
+      "location": "url"
+    },
+    {
+      "name": "template_repo",
       "type": "string",
       "required": true,
       "description": "",
@@ -23,8 +30,8 @@
       "name": "owner",
       "type": "string",
       "description": "The organization or person who will own the new repository. To create a new repository in an organization, the authenticated user must be a member of the specified organization.",
-      "required": true,
-      "location": "url"
+      "required": false,
+      "location": "body"
     },
     {
       "name": "name",


### PR DESCRIPTION
The URL parameter no longer conflicts with the `owner` input parameter. This is a fix, not a breaking change, as the existing definition had a parameter conflict