### PR TITLE
d11n/412 luke cage

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const { resolve: pathResolve } = require('path')
 const { readdirSync } = require('fs')
 const { spawn } = require('tap')
 
@@ -13,7 +14,7 @@ spawn(
   }
 )
 
-const apis = readdirSync('openapi')
+const apis = readdirSync(pathResolve(__dirname, '..', 'openapi'))
 for (const api of apis) {
   const GHE_VERSION = parseFloat(api.replace(/^ghe-(\d+\.\d+)$/, '$1')) || null
   spawn(

--- a/lib/endpoint/tags/div.alert.note-or-tip.js
+++ b/lib/endpoint/tags/div.alert.note-or-tip.js
@@ -20,7 +20,7 @@ module.exports = {
       // workarounds, can be removed once the wording in the docs is clarified
       const isAntManException = matches[1] === 'ant-man' && /^This endpoint is part of the deployment and deployment status enhancement/.test(text)
       const isHellcatException = matches[1] === 'hellcat' && /At this time, the hellcat-preview media type is required to use this endpoint/.test($el.parent().text())
-      const isNotRequired = !isAntManException && !isHellcatException && /^(luke-cage|hellcat|ant-man)$/.test(matches[1])
+      const isNotRequired = !isAntManException && !isHellcatException && /^(hellcat|ant-man)$/.test(matches[1])
 
       return {
         type: 'preview',

--- a/openapi/api.github.com/operations/repos/get-branch-protection.json
+++ b/openapi/api.github.com/operations/repos/get-branch-protection.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -348,7 +349,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection"
     },
     {
       "lang": "JS",

--- a/openapi/api.github.com/operations/repos/get-protected-branch-pull-request-review-enforcement.json
+++ b/openapi/api.github.com/operations/repos/get-protected-branch-pull-request-review-enforcement.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -55,7 +56,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     {
       "lang": "JS",

--- a/openapi/api.github.com/operations/repos/update-branch-protection.json
+++ b/openapi/api.github.com/operations/repos/update-branch-protection.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -348,7 +349,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection \\\n  -d '{\"required_status_checks\":\"required_status_checks\",\"required_status_checks.strict\":\"required_status_checks.strict\",\"required_status_checks.contexts\":\"required_status_checks.contexts\",\"enforce_admins\":\"enforce_admins\",\"required_pull_request_reviews\":\"required_pull_request_reviews\",\"restrictions\":\"restrictions\"}'"
+      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection \\\n  -d '{\"required_status_checks\":\"required_status_checks\",\"required_status_checks.strict\":\"required_status_checks.strict\",\"required_status_checks.contexts\":\"required_status_checks.contexts\",\"enforce_admins\":\"enforce_admins\",\"required_pull_request_reviews\":\"required_pull_request_reviews\",\"restrictions\":\"restrictions\"}'"
     },
     {
       "lang": "JS",

--- a/openapi/api.github.com/operations/repos/update-protected-branch-pull-request-review-enforcement.json
+++ b/openapi/api.github.com/operations/repos/update-protected-branch-pull-request-review-enforcement.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -192,7 +193,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPATCH \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
+      "source": "curl \\\n  -XPATCH \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.15/operations/repos/get-branch-protection.json
+++ b/openapi/ghe-2.15/operations/repos/get-branch-protection.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -348,7 +349,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.15/operations/repos/get-protected-branch-pull-request-review-enforcement.json
+++ b/openapi/ghe-2.15/operations/repos/get-protected-branch-pull-request-review-enforcement.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -55,7 +56,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.15/operations/repos/update-branch-protection.json
+++ b/openapi/ghe-2.15/operations/repos/update-branch-protection.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -348,7 +349,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection \\\n  -d '{\"required_status_checks\":\"required_status_checks\",\"required_status_checks.strict\":\"required_status_checks.strict\",\"required_status_checks.contexts\":\"required_status_checks.contexts\",\"enforce_admins\":\"enforce_admins\",\"required_pull_request_reviews\":\"required_pull_request_reviews\",\"restrictions\":\"restrictions\"}'"
+      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection \\\n  -d '{\"required_status_checks\":\"required_status_checks\",\"required_status_checks.strict\":\"required_status_checks.strict\",\"required_status_checks.contexts\":\"required_status_checks.contexts\",\"enforce_admins\":\"enforce_admins\",\"required_pull_request_reviews\":\"required_pull_request_reviews\",\"restrictions\":\"restrictions\"}'"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.15/operations/repos/update-protected-branch-pull-request-review-enforcement.json
+++ b/openapi/ghe-2.15/operations/repos/update-protected-branch-pull-request-review-enforcement.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -192,7 +193,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPATCH \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
+      "source": "curl \\\n  -XPATCH \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.16/operations/repos/get-branch-protection.json
+++ b/openapi/ghe-2.16/operations/repos/get-branch-protection.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -348,7 +349,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.16/operations/repos/get-protected-branch-pull-request-review-enforcement.json
+++ b/openapi/ghe-2.16/operations/repos/get-protected-branch-pull-request-review-enforcement.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -55,7 +56,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.16/operations/repos/update-branch-protection.json
+++ b/openapi/ghe-2.16/operations/repos/update-branch-protection.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -348,7 +349,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection \\\n  -d '{\"required_status_checks\":\"required_status_checks\",\"required_status_checks.strict\":\"required_status_checks.strict\",\"required_status_checks.contexts\":\"required_status_checks.contexts\",\"enforce_admins\":\"enforce_admins\",\"required_pull_request_reviews\":\"required_pull_request_reviews\",\"restrictions\":\"restrictions\"}'"
+      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection \\\n  -d '{\"required_status_checks\":\"required_status_checks\",\"required_status_checks.strict\":\"required_status_checks.strict\",\"required_status_checks.contexts\":\"required_status_checks.contexts\",\"enforce_admins\":\"enforce_admins\",\"required_pull_request_reviews\":\"required_pull_request_reviews\",\"restrictions\":\"restrictions\"}'"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.16/operations/repos/update-protected-branch-pull-request-review-enforcement.json
+++ b/openapi/ghe-2.16/operations/repos/update-protected-branch-pull-request-review-enforcement.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -192,7 +193,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPATCH \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
+      "source": "curl \\\n  -XPATCH \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.17/operations/repos/get-branch-protection.json
+++ b/openapi/ghe-2.17/operations/repos/get-branch-protection.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -348,7 +349,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.17/operations/repos/get-protected-branch-pull-request-review-enforcement.json
+++ b/openapi/ghe-2.17/operations/repos/get-protected-branch-pull-request-review-enforcement.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -55,7 +56,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.17/operations/repos/update-branch-protection.json
+++ b/openapi/ghe-2.17/operations/repos/update-branch-protection.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -348,7 +349,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection \\\n  -d '{\"required_status_checks\":\"required_status_checks\",\"required_status_checks.strict\":\"required_status_checks.strict\",\"required_status_checks.contexts\":\"required_status_checks.contexts\",\"enforce_admins\":\"enforce_admins\",\"required_pull_request_reviews\":\"required_pull_request_reviews\",\"restrictions\":\"restrictions\"}'"
+      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection \\\n  -d '{\"required_status_checks\":\"required_status_checks\",\"required_status_checks.strict\":\"required_status_checks.strict\",\"required_status_checks.contexts\":\"required_status_checks.contexts\",\"enforce_admins\":\"enforce_admins\",\"required_pull_request_reviews\":\"required_pull_request_reviews\",\"restrictions\":\"restrictions\"}'"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.17/operations/repos/update-protected-branch-pull-request-review-enforcement.json
+++ b/openapi/ghe-2.17/operations/repos/update-protected-branch-pull-request-review-enforcement.json
@@ -12,12 +12,13 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
-      }
+        "default": "application/vnd.github.luke-cage-preview+json"
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -192,7 +193,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPATCH \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
+      "source": "curl \\\n  -XPATCH \\\n  -H\"Accept: application/vnd.github.luke-cage-preview+json\" \\\n  https://developer.github.com/repos/octocat/:repo/branches/:branch/protection/required_pull_request_reviews"
     },
     {
       "lang": "JS",


### PR DESCRIPTION
fixes #412

Unsure of the original intent of the `isNotRequired` expression including `luke-cage`, but it was always being flagged as `isNotRequired` when present. The four endpoints that currently use the `luke-cage` header do it in fact require it. There doesn't seem to be an optional instance in the docs, at least that I can find. Let me know if there is some reason that I'm not seeing as to why matching `luke-cage` was bypassing "requirability".