### PR TITLE
feat: add GHE-2.18 base openapi json

### DIFF
--- a/openapi/ghe-2.18/index.json
+++ b/openapi/ghe-2.18/index.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "version": "3.0.0",
+    "title": "GitHub Enterprise REST API v3",
+    "description": "This describes the resources that make up the official GitHub Enterprise Server REST API v3. If you have any problems or requests, please contact [GitHub Enterprise Support](https://enterprise.github.com/support).",
+    "license": {
+      "name": "GitHub Enterprise License Agreement",
+      "url": "https://enterprise.github.com/license"
+    },
+    "termsOfService": "https://help.github.com/en/articles/github-terms-of-service"
+  },
+  "servers": [
+    {
+      "url": "http://{hostname}",
+      "variables": {
+        "hostname": {
+          "description": "Self-hosted Enterprise Server or Enterprise Cloud hostname",
+          "default": "HOSTNAME"
+        }
+      }
+    }
+  ],
+  "externalDocs": {
+    "description": "GitHub Enterprise Developer Docs",
+    "url": "https://developer.github.com/enterprise/2.18/v3/"
+  },
+  "paths": {}
+}


### PR DESCRIPTION
Looks like GHE-2.18 was released recently. GitHub Actions jobs are failing because there is no `openapi/ghe-2.18` folder.

Added base `openapi/ghe-2.18` OpenAPI file. I believe that the rest changes and files will be added automatically by Actions once it's merged.
