### PR TITLE
fix: overrides keep incorrect documentation links in description

### DIFF
--- a/lib/endpoint/get.js
+++ b/lib/endpoint/get.js
@@ -21,6 +21,8 @@ async function getEndpoint (state, url) {
     const routes = require(pageOverridePath)
     if (routes) {
       routes.forEach(route => {
+        // sometimes description has link to external docs
+        route.operation.description = route.operation.description.replace(route.operation.externalDocs.url, url)
         route.operation.externalDocs.url = url
         route.operation['x-github'].overridden = true
       })

--- a/lib/endpoint/get.js
+++ b/lib/endpoint/get.js
@@ -21,7 +21,7 @@ async function getEndpoint (state, url) {
     const routes = require(pageOverridePath)
     if (routes) {
       routes.forEach(route => {
-        // sometimes description has link to external docs
+        // some descriptions have link to external docs
         route.operation.description = route.operation.description.replace(route.operation.externalDocs.url, url)
         route.operation.externalDocs.url = url
         route.operation['x-github'].overridden = true

--- a/openapi/ghe-2.15/operations/git/get-ref.json
+++ b/openapi/ghe-2.15/operations/git/get-ref.json
@@ -1,6 +1,6 @@
 {
   "summary": "Get a reference",
-  "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
+  "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/enterprise/2.15/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
   "operationId": "git/get-ref",
   "tags": [
     "git"

--- a/openapi/ghe-2.16/operations/git/get-ref.json
+++ b/openapi/ghe-2.16/operations/git/get-ref.json
@@ -1,6 +1,6 @@
 {
   "summary": "Get a reference",
-  "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
+  "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/enterprise/2.16/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
   "operationId": "git/get-ref",
   "tags": [
     "git"

--- a/openapi/ghe-2.17/operations/git/get-ref.json
+++ b/openapi/ghe-2.17/operations/git/get-ref.json
@@ -1,6 +1,6 @@
 {
   "summary": "Get a reference",
-  "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
+  "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/enterprise/2.17/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
   "operationId": "git/get-ref",
   "tags": [
     "git"

--- a/openapi/ghe-2.18/operations/git/get-ref.json
+++ b/openapi/ghe-2.18/operations/git/get-ref.json
@@ -1,6 +1,6 @@
 {
   "summary": "Get a reference",
-  "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
+  "description": "Returns a branch or tag reference. Other than the [REST API](https://developer.github.com/enterprise/2.18/v3/git/refs/#get-a-reference) it always returns a single reference. If the REST API returns with an array then the method responds with an error.",
   "operationId": "git/get-ref",
   "tags": [
     "git"


### PR DESCRIPTION
Fixes wrong docs URL e.g. here https://github.com/octokit/routes/blob/master/openapi/ghe-2.15/operations/git/get-ref.json#L3

cc @gr2m 	