### PR TITLE
WIP: fix default value for `client_payload` parameter

### DIFF
--- a/openapi/api.github.com/operations/repos/create-dispatch-event.json
+++ b/openapi/api.github.com/operations/repos/create-dispatch-event.json
@@ -70,7 +70,7 @@
             "client_payload": {
               "type": "object",
               "description": "JSON payload with extra information about the webhook event that your action or worklow may use.",
-              "default": "",
+              "default": {},
               "properties": {}
             }
           }


### PR DESCRIPTION
The problem is being addressed by the docs team, not worth to implement a workaround for the short time