### PR TITLE
fix(workarounds.js): Add workaround for /repos/:owner/:repo/topics

### DIFF
--- a/lib/endpoint/overrides/workarounds.js
+++ b/lib/endpoint/overrides/workarounds.js
@@ -109,6 +109,13 @@ function workarounds(state) {
         );
         preview.required = false;
       }
+
+      // If a route has any required previews, set acceptHeader to required.
+      if (
+        route.operation["x-github"].previews.some(preview => preview.required)
+      ) {
+        acceptHeader.required = true;
+      }
     }
   });
 }

--- a/lib/endpoint/overrides/workarounds.js
+++ b/lib/endpoint/overrides/workarounds.js
@@ -56,6 +56,14 @@ function workarounds(state) {
       operation.operationId = getOperationId(route);
     }
 
+    // The "List all topics for a repository" requires an Accept header with a preview
+    // content-type of "application/vnd.github.mercy-preview+json" to use.
+    // However, the GitHub API specification doesn't specify it as required.
+    // see https://github.com/octokit/routes/issues/356
+    if (route.path.startsWith("/repos/:owner/:repo/topics")) {
+      route.operation["x-github"].previews[0].required = true;
+    }
+
     // "Render a Markdown document in raw mode" requires Content-Type header to be set
     // see https://developer.github.com/v3/markdown/#example-1
     if (route.path === "/markdown/raw") {

--- a/lib/endpoint/overrides/workarounds.js
+++ b/lib/endpoint/overrides/workarounds.js
@@ -56,14 +56,6 @@ function workarounds(state) {
       operation.operationId = getOperationId(route);
     }
 
-    // The "List all topics for a repository" requires an Accept header with a preview
-    // content-type of "application/vnd.github.mercy-preview+json" to use.
-    // However, the GitHub API specification doesn't specify it as required.
-    // see https://github.com/octokit/routes/issues/356
-    if (route.path.startsWith("/repos/:owner/:repo/topics")) {
-      route.operation["x-github"].previews[0].required = true;
-    }
-
     // "Render a Markdown document in raw mode" requires Content-Type header to be set
     // see https://developer.github.com/v3/markdown/#example-1
     if (route.path === "/markdown/raw") {
@@ -100,6 +92,19 @@ function workarounds(state) {
     const acceptHeader = route.operation.parameters.find(
       parameter => parameter.in === "header" && parameter.name === "accept"
     );
+
+    // The "List all topics for a repository" requires an Accept header with a preview
+    // content-type of "application/vnd.github.mercy-preview+json" to use.
+    // However, the GitHub API specification doesn't specify it as required.
+    // see https://github.com/octokit/routes/issues/356
+    if (route.path.startsWith("/repos/:owner/:repo/topics")) {
+      const preview = route.operation["x-github"].previews[0];
+      preview.required = true;
+      acceptHeader.schema.default = `application/vnd.github.${preview.name}-preview+json`;
+      acceptHeader.description =
+        "This API is under preview and subject to change.";
+    }
+
     if (acceptHeader) {
       // luke-cage is not a required preview
       if (/luke-cage-preview/.test(acceptHeader.schema.default)) {

--- a/openapi/api.github.com/operations/repos/list-topics.json
+++ b/openapi/api.github.com/operations/repos/list-topics.json
@@ -15,7 +15,8 @@
       "schema": {
         "type": "string",
         "default": "application/vnd.github.v3+json"
-      }
+      },
+      "required": true
     },
     {
       "name": "owner",

--- a/openapi/api.github.com/operations/repos/list-topics.json
+++ b/openapi/api.github.com/operations/repos/list-topics.json
@@ -10,11 +10,11 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
+        "default": "application/vnd.github.mercy-preview+json"
       },
       "required": true
     },
@@ -52,7 +52,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://api.github.com/repos/octocat/hello-world/topics"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.mercy-preview+json\" \\\n  https://api.github.com/repos/octocat/hello-world/topics"
     },
     {
       "lang": "JS",

--- a/openapi/api.github.com/operations/repos/list-topics.json
+++ b/openapi/api.github.com/operations/repos/list-topics.json
@@ -66,7 +66,7 @@
       {
         "name": "mercy",
         "note": "The `topics` property for repositories on GitHub is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ]
   },

--- a/openapi/api.github.com/operations/repos/replace-topics.json
+++ b/openapi/api.github.com/operations/repos/replace-topics.json
@@ -10,11 +10,11 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
+        "default": "application/vnd.github.mercy-preview+json"
       },
       "required": true
     },
@@ -52,7 +52,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  https://api.github.com/repos/octocat/hello-world/topics \\\n  -d '{\"names\":[\"names\"]}'"
+      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.mercy-preview+json\" \\\n  https://api.github.com/repos/octocat/hello-world/topics \\\n  -d '{\"names\":[\"names\"]}'"
     },
     {
       "lang": "JS",

--- a/openapi/api.github.com/operations/repos/replace-topics.json
+++ b/openapi/api.github.com/operations/repos/replace-topics.json
@@ -15,7 +15,8 @@
       "schema": {
         "type": "string",
         "default": "application/vnd.github.v3+json"
-      }
+      },
+      "required": true
     },
     {
       "name": "owner",

--- a/openapi/api.github.com/operations/repos/replace-topics.json
+++ b/openapi/api.github.com/operations/repos/replace-topics.json
@@ -66,7 +66,7 @@
       {
         "name": "mercy",
         "note": "The `topics` property for repositories on GitHub is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](https://developer.github.com/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ]
   },

--- a/openapi/ghe-2.16/operations/repos/list-topics.json
+++ b/openapi/ghe-2.16/operations/repos/list-topics.json
@@ -10,11 +10,11 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
+        "default": "application/vnd.github.mercy-preview+json"
       },
       "required": true
     },
@@ -52,7 +52,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.mercy-preview+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.16/operations/repos/list-topics.json
+++ b/openapi/ghe-2.16/operations/repos/list-topics.json
@@ -15,7 +15,8 @@
       "schema": {
         "type": "string",
         "default": "application/vnd.github.v3+json"
-      }
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -66,7 +67,7 @@
       {
         "name": "mercy",
         "note": "The `topics` property for repositories on GitHub Enterprise Server is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](https://developer.github.com/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ]
   },

--- a/openapi/ghe-2.16/operations/repos/replace-topics.json
+++ b/openapi/ghe-2.16/operations/repos/replace-topics.json
@@ -15,7 +15,8 @@
       "schema": {
         "type": "string",
         "default": "application/vnd.github.v3+json"
-      }
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -66,7 +67,7 @@
       {
         "name": "mercy",
         "note": "The `topics` property for repositories on GitHub Enterprise Server is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](https://developer.github.com/enterprise/2.16/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ]
   },

--- a/openapi/ghe-2.16/operations/repos/replace-topics.json
+++ b/openapi/ghe-2.16/operations/repos/replace-topics.json
@@ -10,11 +10,11 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
+        "default": "application/vnd.github.mercy-preview+json"
       },
       "required": true
     },
@@ -52,7 +52,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics \\\n  -d '{\"names\":[\"names\"]}'"
+      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.mercy-preview+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics \\\n  -d '{\"names\":[\"names\"]}'"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.17/operations/repos/list-topics.json
+++ b/openapi/ghe-2.17/operations/repos/list-topics.json
@@ -10,11 +10,11 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
+        "default": "application/vnd.github.mercy-preview+json"
       },
       "required": true
     },
@@ -52,7 +52,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.mercy-preview+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.17/operations/repos/list-topics.json
+++ b/openapi/ghe-2.17/operations/repos/list-topics.json
@@ -15,7 +15,8 @@
       "schema": {
         "type": "string",
         "default": "application/vnd.github.v3+json"
-      }
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -66,7 +67,7 @@
       {
         "name": "mercy",
         "note": "The `topics` property for repositories on GitHub Enterprise Server is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](https://developer.github.com/enterprise/2.17/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ]
   },

--- a/openapi/ghe-2.17/operations/repos/replace-topics.json
+++ b/openapi/ghe-2.17/operations/repos/replace-topics.json
@@ -15,7 +15,8 @@
       "schema": {
         "type": "string",
         "default": "application/vnd.github.v3+json"
-      }
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -66,7 +67,7 @@
       {
         "name": "mercy",
         "note": "The `topics` property for repositories on GitHub Enterprise Server is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](https://developer.github.com/enterprise/2.17/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ]
   },

--- a/openapi/ghe-2.17/operations/repos/replace-topics.json
+++ b/openapi/ghe-2.17/operations/repos/replace-topics.json
@@ -10,11 +10,11 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
+        "default": "application/vnd.github.mercy-preview+json"
       },
       "required": true
     },
@@ -52,7 +52,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics \\\n  -d '{\"names\":[\"names\"]}'"
+      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.mercy-preview+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics \\\n  -d '{\"names\":[\"names\"]}'"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.18/operations/repos/list-topics.json
+++ b/openapi/ghe-2.18/operations/repos/list-topics.json
@@ -15,7 +15,8 @@
       "schema": {
         "type": "string",
         "default": "application/vnd.github.v3+json"
-      }
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -66,7 +67,7 @@
       {
         "name": "mercy",
         "note": "The `topics` property for repositories on GitHub Enterprise Server is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](https://developer.github.com/enterprise/2.18/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ]
   },

--- a/openapi/ghe-2.18/operations/repos/list-topics.json
+++ b/openapi/ghe-2.18/operations/repos/list-topics.json
@@ -10,11 +10,11 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
+        "default": "application/vnd.github.mercy-preview+json"
       },
       "required": true
     },
@@ -52,7 +52,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics"
+      "source": "curl \\\n  -H\"Accept: application/vnd.github.mercy-preview+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics"
     },
     {
       "lang": "JS",

--- a/openapi/ghe-2.18/operations/repos/replace-topics.json
+++ b/openapi/ghe-2.18/operations/repos/replace-topics.json
@@ -15,7 +15,8 @@
       "schema": {
         "type": "string",
         "default": "application/vnd.github.v3+json"
-      }
+      },
+      "required": true
     },
     {
       "name": "owner",
@@ -66,7 +67,7 @@
       {
         "name": "mercy",
         "note": "The `topics` property for repositories on GitHub Enterprise Server is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](https://developer.github.com/enterprise/2.18/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```",
-        "required": false
+        "required": true
       }
     ]
   },

--- a/openapi/ghe-2.18/operations/repos/replace-topics.json
+++ b/openapi/ghe-2.18/operations/repos/replace-topics.json
@@ -10,11 +10,11 @@
   "parameters": [
     {
       "name": "accept",
-      "description": "Setting to `application/vnd.github.v3+json` is recommended",
+      "description": "This API is under preview and subject to change.",
       "in": "header",
       "schema": {
         "type": "string",
-        "default": "application/vnd.github.v3+json"
+        "default": "application/vnd.github.mercy-preview+json"
       },
       "required": true
     },
@@ -52,7 +52,7 @@
   "x-code-samples": [
     {
       "lang": "Shell",
-      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.v3+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics \\\n  -d '{\"names\":[\"names\"]}'"
+      "source": "curl \\\n  -XPUT \\\n  -H\"Accept: application/vnd.github.mercy-preview+json\" \\\n  http://{hostname}/repos/octocat/hello-world/topics \\\n  -d '{\"names\":[\"names\"]}'"
     },
     {
       "lang": "JS",


### PR DESCRIPTION
To use this endpoint, the user must specify a preview MIME type
in the Accept header, but the GitHub API spec doesn't mark it as
required.

This adds a workaround to mark that particular preview as required.

The changes in the `openapi/operations` subdirectories are the result of running `npm run update` with the added workaround in `workarounds.js`.

fixes #356 
