### PR TITLE
retry fetching HTML if server responds with "temporarily down for maintenance

### DIFF
--- a/lib/get-html.js
+++ b/lib/get-html.js
@@ -3,7 +3,7 @@ module.exports = getHtml;
 const { URL } = require("url");
 const fetch = require("node-fetch");
 
-async function getHtml(state, url) {
+async function getHtml(state, url, retryCount = 0) {
   const cacheFilePath = new URL(url).pathname + "/index.html";
   const memoryCached = state.memoryCache[url];
 
@@ -22,6 +22,23 @@ async function getHtml(state, url) {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
   const html = await (await fetch(url)).text();
+
+  if (/GitHub Pages is temporarily down for maintenance/i.test(html)) {
+    retryCount++;
+
+    if (retryCount > 3) {
+      throw new Error(
+        `${url} responded with "down for maintenance" for 3 times. Aborting.`
+      );
+    }
+
+    console.log(
+      `🚧  GitHub Pages is temporarily down for maintenance. Retry ${retryCount} / 3`
+    );
+    await new Promise(resolve => setTimeout(resolve, retryCount * 1000));
+    return getHtml(state, url, retryCount);
+  }
+
   await state.cache.writeHtml(cacheFilePath, html);
   state.memoryCache[url] = html;
   return html;


### PR DESCRIPTION
ping @sarahs / @zeke. I have seen these responses starting to show up in the past 2 weeks. Any idea what might caus them?

Example:
https://github.com/octokit/routes/pull/587/commits/f01f07e3f29a928969a05d9f5b224effb8f636de\#diff-9fd683e37731fb9ec7644f0e8ba3de2d

See also:
https://github.com/octokit/routes/pull/584
https://github.com/octokit/routes/pull/583
https://github.com/octokit/routes/pull/587/commits/1a32f4714215f2e0bb74a9224240bd13ff72198b\#diff-1992e004100a55a00610eff1220cce77R1