### PR TITLE
Fix: Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Downloads
 
-- The de-referenced OpenAPI documents are [uploaded as attachements to each release](https://github.com/octokit/routes/releases)
+- The de-referenced OpenAPI documents are [uploaded as attachments to each release](https://github.com/octokit/routes/releases)
 
 Or install from package managers
 


### PR DESCRIPTION
This PR

* [x] fixes a typo in `README.md` 

-----
[View rendered README.md](https://github.com/localheinz/routes/blob/fix/typo/README.md)