### PR TITLE
fix: update get-tree endpoint cache

### DIFF
--- a/cache/api.github.com/v3/git/trees/get-a-tree.html
+++ b/cache/api.github.com/v3/git/trees/get-a-tree.html
@@ -1,0 +1,46 @@
+<h2>
+<a id="get-a-tree" class="anchor" href="#get-a-tree" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Get a tree<a href="/apps/" class="tooltip-link github-apps-marker octicon octicon-info" title="Enabled for GitHub Apps"></a>
+</h2>
+<p>Returns a single tree using the SHA1 value for that tree.</p>
+<pre><code>GET /repos/:owner/:repo/git/trees/:tree_sha
+</code></pre>
+<h3>
+<a id="response" class="anchor" href="#response" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Response</h3>
+<div class="alert tip">
+
+<p>If <code>truncated</code> is <code>true</code> in the response then the number of items in the <code>tree</code> array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.</p>
+
+</div>
+<pre class="highlight highlight-headers"><code>Status: 200 OK
+</code></pre>
+<pre class="highlight highlight-json"><code><span class="p">{</span><span class="w">
+  </span><span class="nt">&quot;sha&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;9fb037999f264ba9a7fc6274d15fa3ae2ab98312&quot;</span><span class="p">,</span><span class="w">
+  </span><span class="nt">&quot;url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;https://api.github.com/repos/octocat/Hello-World/trees/9fb037999f264ba9a7fc6274d15fa3ae2ab98312&quot;</span><span class="p">,</span><span class="w">
+  </span><span class="nt">&quot;tree&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+    </span><span class="p">{</span><span class="w">
+      </span><span class="nt">&quot;path&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;file.rb&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;mode&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;100644&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;blob&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;size&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">30</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;sha&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;44b4fc6d56897b048c772eb4087f854f46256132&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132&quot;</span><span class="w">
+    </span><span class="p">},</span><span class="w">
+    </span><span class="p">{</span><span class="w">
+      </span><span class="nt">&quot;path&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;subdir&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;mode&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;040000&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;tree&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;sha&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;f484d249c660418515fb01c2b9662073663c242e&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;https://api.github.com/repos/octocat/Hello-World/git/blobs/f484d249c660418515fb01c2b9662073663c242e&quot;</span><span class="w">
+    </span><span class="p">},</span><span class="w">
+    </span><span class="p">{</span><span class="w">
+      </span><span class="nt">&quot;path&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;exec_file&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;mode&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;100755&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;type&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;blob&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;size&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">75</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;sha&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;45b983be36b73c0788dc9cbcb76cbb80fc7bb057&quot;</span><span class="p">,</span><span class="w">
+      </span><span class="nt">&quot;url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;https://api.github.com/repos/octocat/Hello-World/git/blobs/45b983be36b73c0788dc9cbcb76cbb80fc7bb057&quot;</span><span class="w">
+    </span><span class="p">}</span><span class="w">
+  </span><span class="p">],</span><span class="w">
+  </span><span class="nt">&quot;truncated&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre>

--- a/lib/endpoint/overrides/v3/git/trees/get-a-tree.json
+++ b/lib/endpoint/overrides/v3/git/trees/get-a-tree.json
@@ -48,9 +48,7 @@
           "in": "query",
           "schema": {
             "type": "integer",
-            "enum": [
-              1
-            ]
+            "enum": [1]
           }
         }
       ],

--- a/lib/endpoint/overrides/v3/git/trees/get-a-tree.json
+++ b/lib/endpoint/overrides/v3/git/trees/get-a-tree.json
@@ -4,7 +4,7 @@
     "path": "/repos/:owner/:repo/git/trees/:tree_sha",
     "operation": {
       "summary": "Get a tree",
-      "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+      "description": "Returns a single tree using the SHA1 value for that tree.\n\nIf `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
       "operationId": "git/get-tree",
       "tags": ["git"],
       "externalDocs": {
@@ -26,27 +26,21 @@
           "description": "owner parameter",
           "in": "path",
           "required": true,
-          "schema": {
-            "type": "string"
-          }
+          "schema": { "type": "string" }
         },
         {
           "name": "repo",
           "description": "repo parameter",
           "in": "path",
           "required": true,
-          "schema": {
-            "type": "string"
-          }
+          "schema": { "type": "string" }
         },
         {
           "name": "tree_sha",
           "description": "tree_sha parameter",
           "in": "path",
           "required": true,
-          "schema": {
-            "type": "string"
-          }
+          "schema": { "type": "string" }
         },
         {
           "name": "recursive",
@@ -54,55 +48,69 @@
           "in": "query",
           "schema": {
             "type": "integer",
-            "enum": [1]
+            "enum": [
+              1
+            ]
           }
         }
       ],
       "responses": {
         "200": {
-          "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+          "description": "If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
-                  "sha": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
+                  "sha": { "type": "string" },
+                  "url": { "type": "string" },
                   "tree": {
                     "type": "array",
                     "items": {
                       "type": "object",
                       "properties": {
-                        "path": {
-                          "type": "string"
-                        },
-                        "mode": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "type": "string"
-                        },
-                        "size": {
-                          "type": "number"
-                        },
-                        "sha": {
-                          "type": "string"
-                        },
-                        "url": {
-                          "type": "string"
-                        }
+                        "path": { "type": "string" },
+                        "mode": { "type": "string" },
+                        "type": { "type": "string" },
+                        "size": { "type": "number" },
+                        "sha": { "type": "string" },
+                        "url": { "type": "string" }
                       },
                       "required": ["path", "mode", "type", "sha", "url", "size"]
                     }
                   },
-                  "truncated": {
-                    "type": "boolean"
-                  }
+                  "truncated": { "type": "boolean" }
                 }
+              },
+              "example": {
+                "sha": "9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+                "url": "https://api.github.com/repos/octocat/Hello-World/trees/9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+                "tree": [
+                  {
+                    "path": "file.rb",
+                    "mode": "100644",
+                    "type": "blob",
+                    "size": 30,
+                    "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+                    "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132"
+                  },
+                  {
+                    "path": "subdir",
+                    "mode": "040000",
+                    "type": "tree",
+                    "sha": "f484d249c660418515fb01c2b9662073663c242e",
+                    "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/f484d249c660418515fb01c2b9662073663c242e"
+                  },
+                  {
+                    "path": "exec_file",
+                    "mode": "100755",
+                    "type": "blob",
+                    "size": 75,
+                    "sha": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+                    "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
+                  }
+                ],
+                "truncated": false
               }
             }
           }
@@ -116,6 +124,10 @@
         {
           "lang": "JS",
           "source": "octokit.git.getTree({\n  owner: 'octocat',\n  repo: 'hello-world',\n  tree_sha: 'tree_sha'\n})"
+        },
+        {
+          "lang": "Ruby",
+          "source": "octokit.tree(\n  'hello-world',\n  'tree_sha'\n)"
         }
       ],
       "x-github": {

--- a/openapi/api.github.com/operations/git/get-tree.json
+++ b/openapi/api.github.com/operations/git/get-tree.json
@@ -1,6 +1,6 @@
 {
   "summary": "Get a tree",
-  "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+  "description": "Returns a single tree using the SHA1 value for that tree.\n\nIf `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
   "operationId": "git/get-tree",
   "tags": ["git"],
   "externalDocs": {
@@ -47,7 +47,7 @@
   ],
   "responses": {
     "200": {
-      "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+      "description": "If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
       "content": {
         "application/json": {
           "schema": {
@@ -72,6 +72,36 @@
               },
               "truncated": { "type": "boolean" }
             }
+          },
+          "example": {
+            "sha": "9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "url": "https://api.github.com/repos/octocat/Hello-World/trees/9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "tree": [
+              {
+                "path": "file.rb",
+                "mode": "100644",
+                "type": "blob",
+                "size": 30,
+                "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132"
+              },
+              {
+                "path": "subdir",
+                "mode": "040000",
+                "type": "tree",
+                "sha": "f484d249c660418515fb01c2b9662073663c242e",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/f484d249c660418515fb01c2b9662073663c242e"
+              },
+              {
+                "path": "exec_file",
+                "mode": "100755",
+                "type": "blob",
+                "size": 75,
+                "sha": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
+              }
+            ],
+            "truncated": false
           }
         }
       }
@@ -85,6 +115,10 @@
     {
       "lang": "JS",
       "source": "octokit.git.getTree({\n  owner: 'octocat',\n  repo: 'hello-world',\n  tree_sha: 'tree_sha'\n})"
+    },
+    {
+      "lang": "Ruby",
+      "source": "octokit.tree(\n  'hello-world',\n  'tree_sha'\n)"
     }
   ],
   "x-github": {

--- a/openapi/ghe-2.16/operations/git/get-tree.json
+++ b/openapi/ghe-2.16/operations/git/get-tree.json
@@ -1,6 +1,6 @@
 {
   "summary": "Get a tree",
-  "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+  "description": "Returns a single tree using the SHA1 value for that tree.\n\nIf `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
   "operationId": "git/get-tree",
   "tags": ["git"],
   "externalDocs": {
@@ -47,7 +47,7 @@
   ],
   "responses": {
     "200": {
-      "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+      "description": "If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
       "content": {
         "application/json": {
           "schema": {
@@ -72,6 +72,36 @@
               },
               "truncated": { "type": "boolean" }
             }
+          },
+          "example": {
+            "sha": "9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "url": "https://api.github.com/repos/octocat/Hello-World/trees/9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "tree": [
+              {
+                "path": "file.rb",
+                "mode": "100644",
+                "type": "blob",
+                "size": 30,
+                "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132"
+              },
+              {
+                "path": "subdir",
+                "mode": "040000",
+                "type": "tree",
+                "sha": "f484d249c660418515fb01c2b9662073663c242e",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/f484d249c660418515fb01c2b9662073663c242e"
+              },
+              {
+                "path": "exec_file",
+                "mode": "100755",
+                "type": "blob",
+                "size": 75,
+                "sha": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
+              }
+            ],
+            "truncated": false
           }
         }
       }
@@ -85,6 +115,10 @@
     {
       "lang": "JS",
       "source": "octokit.git.getTree({\n  owner: 'octocat',\n  repo: 'hello-world',\n  tree_sha: 'tree_sha'\n})"
+    },
+    {
+      "lang": "Ruby",
+      "source": "octokit.tree(\n  'hello-world',\n  'tree_sha'\n)"
     }
   ],
   "x-github": {

--- a/openapi/ghe-2.17/operations/git/get-tree.json
+++ b/openapi/ghe-2.17/operations/git/get-tree.json
@@ -1,6 +1,6 @@
 {
   "summary": "Get a tree",
-  "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+  "description": "Returns a single tree using the SHA1 value for that tree.\n\nIf `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
   "operationId": "git/get-tree",
   "tags": ["git"],
   "externalDocs": {
@@ -47,7 +47,7 @@
   ],
   "responses": {
     "200": {
-      "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+      "description": "If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
       "content": {
         "application/json": {
           "schema": {
@@ -72,6 +72,36 @@
               },
               "truncated": { "type": "boolean" }
             }
+          },
+          "example": {
+            "sha": "9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "url": "https://api.github.com/repos/octocat/Hello-World/trees/9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "tree": [
+              {
+                "path": "file.rb",
+                "mode": "100644",
+                "type": "blob",
+                "size": 30,
+                "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132"
+              },
+              {
+                "path": "subdir",
+                "mode": "040000",
+                "type": "tree",
+                "sha": "f484d249c660418515fb01c2b9662073663c242e",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/f484d249c660418515fb01c2b9662073663c242e"
+              },
+              {
+                "path": "exec_file",
+                "mode": "100755",
+                "type": "blob",
+                "size": 75,
+                "sha": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
+              }
+            ],
+            "truncated": false
           }
         }
       }
@@ -85,6 +115,10 @@
     {
       "lang": "JS",
       "source": "octokit.git.getTree({\n  owner: 'octocat',\n  repo: 'hello-world',\n  tree_sha: 'tree_sha'\n})"
+    },
+    {
+      "lang": "Ruby",
+      "source": "octokit.tree(\n  'hello-world',\n  'tree_sha'\n)"
     }
   ],
   "x-github": {

--- a/openapi/ghe-2.18/operations/git/get-tree.json
+++ b/openapi/ghe-2.18/operations/git/get-tree.json
@@ -1,6 +1,6 @@
 {
   "summary": "Get a tree",
-  "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+  "description": "Returns a single tree using the SHA1 value for that tree.\n\nIf `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
   "operationId": "git/get-tree",
   "tags": ["git"],
   "externalDocs": {
@@ -47,7 +47,7 @@
   ],
   "responses": {
     "200": {
-      "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+      "description": "If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
       "content": {
         "application/json": {
           "schema": {
@@ -72,6 +72,36 @@
               },
               "truncated": { "type": "boolean" }
             }
+          },
+          "example": {
+            "sha": "9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "url": "https://api.github.com/repos/octocat/Hello-World/trees/9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "tree": [
+              {
+                "path": "file.rb",
+                "mode": "100644",
+                "type": "blob",
+                "size": 30,
+                "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132"
+              },
+              {
+                "path": "subdir",
+                "mode": "040000",
+                "type": "tree",
+                "sha": "f484d249c660418515fb01c2b9662073663c242e",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/f484d249c660418515fb01c2b9662073663c242e"
+              },
+              {
+                "path": "exec_file",
+                "mode": "100755",
+                "type": "blob",
+                "size": 75,
+                "sha": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
+              }
+            ],
+            "truncated": false
           }
         }
       }
@@ -85,6 +115,10 @@
     {
       "lang": "JS",
       "source": "octokit.git.getTree({\n  owner: 'octocat',\n  repo: 'hello-world',\n  tree_sha: 'tree_sha'\n})"
+    },
+    {
+      "lang": "Ruby",
+      "source": "octokit.tree(\n  'hello-world',\n  'tree_sha'\n)"
     }
   ],
   "x-github": {

--- a/openapi/ghe-2.19/operations/git/get-tree.json
+++ b/openapi/ghe-2.19/operations/git/get-tree.json
@@ -1,6 +1,6 @@
 {
   "summary": "Get a tree",
-  "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+  "description": "Returns a single tree using the SHA1 value for that tree.\n\nIf `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
   "operationId": "git/get-tree",
   "tags": ["git"],
   "externalDocs": {
@@ -47,7 +47,7 @@
   ],
   "responses": {
     "200": {
-      "description": "If `truncated` is `true`, the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
+      "description": "If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, you can clone the repository and iterate over the Git data locally.",
       "content": {
         "application/json": {
           "schema": {
@@ -72,6 +72,36 @@
               },
               "truncated": { "type": "boolean" }
             }
+          },
+          "example": {
+            "sha": "9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "url": "https://api.github.com/repos/octocat/Hello-World/trees/9fb037999f264ba9a7fc6274d15fa3ae2ab98312",
+            "tree": [
+              {
+                "path": "file.rb",
+                "mode": "100644",
+                "type": "blob",
+                "size": 30,
+                "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132"
+              },
+              {
+                "path": "subdir",
+                "mode": "040000",
+                "type": "tree",
+                "sha": "f484d249c660418515fb01c2b9662073663c242e",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/f484d249c660418515fb01c2b9662073663c242e"
+              },
+              {
+                "path": "exec_file",
+                "mode": "100755",
+                "type": "blob",
+                "size": 75,
+                "sha": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
+              }
+            ],
+            "truncated": false
           }
         }
       }
@@ -85,6 +115,10 @@
     {
       "lang": "JS",
       "source": "octokit.git.getTree({\n  owner: 'octocat',\n  repo: 'hello-world',\n  tree_sha: 'tree_sha'\n})"
+    },
+    {
+      "lang": "Ruby",
+      "source": "octokit.tree(\n  'hello-world',\n  'tree_sha'\n)"
     }
   ],
   "x-github": {


### PR DESCRIPTION
fixes a related issue with type generation in the `@octokit/rest.js`
