### PR TITLE
test: add content details to markdown render response

### DIFF
--- a/openapi/api.github.com/operations/markdown/render-raw.json
+++ b/openapi/api.github.com/operations/markdown/render-raw.json
@@ -24,7 +24,18 @@
       "schema": { "type": "string", "enum": ["text/plain; charset=utf-8"] }
     }
   ],
-  "responses": { "200": { "description": "response" } },
+  "responses": {
+    "200": {
+      "description": "response",
+      "content": {
+        "text/html": {
+          "schema": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "x-code-samples": [
     {
       "lang": "Shell",

--- a/openapi/api.github.com/operations/markdown/render.json
+++ b/openapi/api.github.com/operations/markdown/render.json
@@ -18,7 +18,18 @@
       }
     }
   ],
-  "responses": { "200": { "description": "response" } },
+  "responses": {
+    "200": {
+      "description": "response",
+      "content": {
+        "text/html": {
+          "schema": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "x-code-samples": [
     {
       "lang": "Shell",


### PR DESCRIPTION
Fixes #660 

Any pointers or advice you have about getting the tests to pass would be great. For example, I ran this locally but didn't see any change to the test outcome:

```
$ TEST_URL=https://developer.github.com/v3/markdown/#render-an-arbitrary-markdown-document ./node_modules/.bin/tap test/integration/endpoints-test.js
```