### PR TITLE
fix: do not add `?{page,per_page}` parameters for endpoints using `?since` exclusively

### DIFF
--- a/lib/endpoint/find-parameters.js
+++ b/lib/endpoint/find-parameters.js
@@ -369,12 +369,23 @@ function addPaginationParameters(state) {
   const hasResponseWithPaginationHeader = !!state.blocks.find(
     (block) => block.hasPaginationHeader
   );
+  const hasSinceParameterOnlyNote = !!state.blocks.find(
+    (block) =>
+      block.text &&
+      /Pagination is powered exclusively by the `since` parameter/i.test(
+        block.text
+      )
+  );
 
   if (hasResponseBlock && !hasResponseWithPaginationHeader) {
     return;
   }
 
   if (!hasResponseBlock && !hasListHeader) {
+    return;
+  }
+
+  if (hasSinceParameterOnlyNote) {
     return;
   }
 

--- a/openapi/api.github.com/operations/orgs/list.json
+++ b/openapi/api.github.com/operations/orgs/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "integer" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/api.github.com/operations/repos/list-public.json
+++ b/openapi/api.github.com/operations/repos/list-public.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "integer" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/api.github.com/operations/users/list.json
+++ b/openapi/api.github.com/operations/users/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "string" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.17/operations/orgs/list.json
+++ b/openapi/ghe-2.17/operations/orgs/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "integer" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.17/operations/repos/list-public.json
+++ b/openapi/ghe-2.17/operations/repos/list-public.json
@@ -30,18 +30,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "string", "default": "public" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.17/operations/users/list.json
+++ b/openapi/ghe-2.17/operations/users/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "string" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.18/operations/orgs/list.json
+++ b/openapi/ghe-2.18/operations/orgs/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "integer" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.18/operations/repos/list-public.json
+++ b/openapi/ghe-2.18/operations/repos/list-public.json
@@ -30,18 +30,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "string", "default": "public" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.18/operations/users/list.json
+++ b/openapi/ghe-2.18/operations/users/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "string" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.19/operations/orgs/list.json
+++ b/openapi/ghe-2.19/operations/orgs/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "integer" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.19/operations/repos/list-public.json
+++ b/openapi/ghe-2.19/operations/repos/list-public.json
@@ -30,18 +30,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "string", "default": "public" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.19/operations/users/list.json
+++ b/openapi/ghe-2.19/operations/users/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "string" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.20/operations/orgs/list.json
+++ b/openapi/ghe-2.20/operations/orgs/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "integer" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.20/operations/repos/list-public.json
+++ b/openapi/ghe-2.20/operations/repos/list-public.json
@@ -30,18 +30,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "string", "default": "public" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {

--- a/openapi/ghe-2.20/operations/users/list.json
+++ b/openapi/ghe-2.20/operations/users/list.json
@@ -23,18 +23,6 @@
       "in": "query",
       "required": false,
       "schema": { "type": "string" }
-    },
-    {
-      "name": "per_page",
-      "description": "Results per page (max 100)",
-      "in": "query",
-      "schema": { "type": "integer", "default": 30 }
-    },
-    {
-      "name": "page",
-      "description": "Page number of the results to fetch.",
-      "in": "query",
-      "schema": { "type": "integer", "default": 1 }
     }
   ],
   "responses": {


### PR DESCRIPTION
Addresses https://github.com/octokit/rest.js/issues/1684