### PR TITLE
feat: `migrations/get-import-status`, `issues/list-milestones`. Deprecations for previous operation IDs

### DIFF
--- a/lib/endpoint/overrides/deprecations.js
+++ b/lib/endpoint/overrides/deprecations.js
@@ -1641,6 +1641,25 @@ function deprecations({ routes, gheVersion }) {
         },
       });
     }
+
+    const getImportStatus = findByRoute(
+      routes,
+      "GET /repos/:owner/:repo/import"
+    );
+    if (getImportStatus) {
+      getImportStatus.operation["x-changes"].push({
+        type: "operation",
+        date: "2020-06-01",
+        note:
+          '"migrations/get-import-progress" operation ID is now "migrations/get-import-status"',
+        before: {
+          operationId: "migrations/get-import-progress",
+        },
+        after: {
+          operationId: "migrations/get-import-status",
+        },
+      });
+    }
   }
 }
 

--- a/lib/endpoint/overrides/deprecations.js
+++ b/lib/endpoint/overrides/deprecations.js
@@ -1622,6 +1622,25 @@ function deprecations({ routes, gheVersion }) {
         },
       });
     }
+
+    const listMilestones = findByRoute(
+      routes,
+      "GET /repos/:owner/:repo/milestones"
+    );
+    if (listMilestones) {
+      listMilestones.operation["x-changes"].push({
+        type: "operation",
+        date: "2020-06-01",
+        note:
+          '"issues/list-milestones-for-repo" operation ID is now "issues/list-milestones"',
+        before: {
+          operationId: "issues/list-milestones-for-repo",
+        },
+        after: {
+          operationId: "issues/list-milestones",
+        },
+      });
+    }
   }
 }
 

--- a/openapi/api.github.com/operations/issues/list-milestones.json
+++ b/openapi/api.github.com/operations/issues/list-milestones.json
@@ -188,5 +188,13 @@
     "githubCloudOnly": false,
     "previews": []
   },
-  "x-changes": []
+  "x-changes": [
+    {
+      "type": "operation",
+      "date": "2020-06-01",
+      "note": "\"issues/list-milestones-for-repo\" operation ID is now \"issues/list-milestones\"",
+      "before": { "operationId": "issues/list-milestones-for-repo" },
+      "after": { "operationId": "issues/list-milestones" }
+    }
+  ]
 }

--- a/openapi/api.github.com/operations/migrations/get-import-status.json
+++ b/openapi/api.github.com/operations/migrations/get-import-status.json
@@ -89,5 +89,13 @@
     "githubCloudOnly": false,
     "previews": []
   },
-  "x-changes": []
+  "x-changes": [
+    {
+      "type": "operation",
+      "date": "2020-06-01",
+      "note": "\"migrations/get-import-progress\" operation ID is now \"migrations/get-import-status\"",
+      "before": { "operationId": "migrations/get-import-progress" },
+      "after": { "operationId": "migrations/get-import-status" }
+    }
+  ]
 }


### PR DESCRIPTION
follow up to https://github.com/octokit/routes/pull/758