### PR TITLE
fix: add missing deprecation for `actions/list-workflow-runs-for-repo`

### DIFF
--- a/lib/endpoint/overrides/deprecations.js
+++ b/lib/endpoint/overrides/deprecations.js
@@ -2066,6 +2066,25 @@ function deprecations({ routes, gheVersion }) {
       },
     });
   }
+
+  const listWorkflowRunsForRepo = findByRoute(
+    routes,
+    "GET /repos/:owner/:repo/actions/runs"
+  );
+  if (listWorkflowRunsForRepo) {
+    listWorkflowRunsForRepo.operation["x-changes"].push({
+      type: "operation",
+      date: "2020-05-04",
+      note:
+        '"actions/list-repo-workflow-runs" operation ID is now "actions/list-workflow-runs-for-repo"',
+      before: {
+        operationId: "actions/list-repo-workflow-runs",
+      },
+      after: {
+        operationId: "actions/list-workflow-runs-for-repo",
+      },
+    });
+  }
 }
 
 function findAllByPath(routes, path) {

--- a/openapi/api.github.com/operations/actions/list-workflow-runs-for-repo.json
+++ b/openapi/api.github.com/operations/actions/list-workflow-runs-for-repo.json
@@ -490,5 +490,13 @@
     "githubCloudOnly": false,
     "previews": []
   },
-  "x-changes": []
+  "x-changes": [
+    {
+      "type": "operation",
+      "date": "2020-05-04",
+      "note": "\"actions/list-repo-workflow-runs\" operation ID is now \"actions/list-workflow-runs-for-repo\"",
+      "before": { "operationId": "actions/list-repo-workflow-runs" },
+      "after": { "operationId": "actions/list-workflow-runs-for-repo" }
+    }
+  ]
 }


### PR DESCRIPTION
addresses https://github.com/octokit/plugin-rest-endpoint-methods.js/pull/125