### PR TITLE
fix(enum): strip quotes from enum values

### DIFF
--- a/lib/endpoint/tags/table.js
+++ b/lib/endpoint/tags/table.js
@@ -163,7 +163,7 @@ function rowToParameter(i, el) {
           .pop()
           .match(/`([^`]+)`/g);
 
-        enumValues = _.uniq((results || []).map((s) => s.replace(/`/g, "")));
+        enumValues = _.uniq((results || []).map((s) => s.replace(/[`"]/g, "")));
       }
 
       // Sometimes enum values contain placeholders in which case we turn it into a

--- a/openapi/api.github.com/operations/repos/update-information-about-pages-site.json
+++ b/openapi/api.github.com/operations/repos/update-information-about-pages-site.json
@@ -65,7 +65,7 @@
             "source": {
               "type": "string",
               "description": "Update the source for the repository. Must include the branch name, and may optionally specify the subdirectory `/docs`. Possible values are `\"gh-pages\"`, `\"master\"`, and `\"master /docs\"`.",
-              "enum": ["\"gh-pages\"", "\"master\"", "\"master /docs\""]
+              "enum": ["gh-pages", "master", "master /docs"]
             }
           }
         },

--- a/openapi/ghe-2.18/operations/repos/update-information-about-pages-site.json
+++ b/openapi/ghe-2.18/operations/repos/update-information-about-pages-site.json
@@ -67,7 +67,7 @@
             "source": {
               "type": "string",
               "description": "Update the source for the repository. Must include the branch name, and may optionally specify the subdirectory `/docs`. Possible values are `\"gh-pages\"`, `\"master\"`, and `\"master /docs\"`.",
-              "enum": ["\"gh-pages\"", "\"master\"", "\"master /docs\""]
+              "enum": ["gh-pages", "master", "master /docs"]
             }
           }
         },

--- a/openapi/ghe-2.19/operations/repos/update-information-about-pages-site.json
+++ b/openapi/ghe-2.19/operations/repos/update-information-about-pages-site.json
@@ -61,7 +61,7 @@
             "source": {
               "type": "string",
               "description": "Update the source for the repository. Must include the branch name, and may optionally specify the subdirectory `/docs`. Possible values are `\"gh-pages\"`, `\"master\"`, and `\"master /docs\"`.",
-              "enum": ["\"gh-pages\"", "\"master\"", "\"master /docs\""]
+              "enum": ["gh-pages", "master", "master /docs"]
             }
           }
         },

--- a/openapi/ghe-2.20/operations/repos/update-information-about-pages-site.json
+++ b/openapi/ghe-2.20/operations/repos/update-information-about-pages-site.json
@@ -61,7 +61,7 @@
             "source": {
               "type": "string",
               "description": "Update the source for the repository. Must include the branch name, and may optionally specify the subdirectory `/docs`. Possible values are `\"gh-pages\"`, `\"master\"`, and `\"master /docs\"`.",
-              "enum": ["\"gh-pages\"", "\"master\"", "\"master /docs\""]
+              "enum": ["gh-pages", "master", "master /docs"]
             }
           }
         },

--- a/openapi/ghe-2.21/operations/repos/update-information-about-pages-site.json
+++ b/openapi/ghe-2.21/operations/repos/update-information-about-pages-site.json
@@ -61,7 +61,7 @@
             "source": {
               "type": "string",
               "description": "Update the source for the repository. Must include the branch name, and may optionally specify the subdirectory `/docs`. Possible values are `\"gh-pages\"`, `\"master\"`, and `\"master /docs\"`.",
-              "enum": ["\"gh-pages\"", "\"master\"", "\"master /docs\""]
+              "enum": ["gh-pages", "master", "master /docs"]
             }
           }
         },


### PR DESCRIPTION
The documentation here https://developer.github.com/v3/repos/pages/#parameters-1 quotes the enum values, which leads to the generated specification incorrectly quoting the values.

Strip quotes from enum values to avoid this.